### PR TITLE
fix: add gravity-dodge shared theme toggle and valley backlink

### DIFF
--- a/apps/2026/03/09/gravity-dodge/index.html
+++ b/apps/2026/03/09/gravity-dodge/index.html
@@ -1,16 +1,34 @@
 <!doctype html><html lang='en'><head><meta charset='UTF-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Gravity Dodge</title><style>
 :root{--bg:#0b1220;--bg2:#1b2a4a;--surface:#101a31;--text:#edf3ff;--muted:#9eb1da;--player:#22d3ee;--haz:#ef4444;--orb:#a78bfa}
-@media(prefers-color-scheme:light){:root{--bg:#eef4ff;--bg2:#dbeafe;--surface:#fff;--text:#1f2f52;--muted:#60739a;--player:#0891b2;--haz:#b91c1c;--orb:#7c3aed}}
+[data-theme='light']{--bg:#eef4ff;--bg2:#dbeafe;--surface:#fff;--text:#1f2f52;--muted:#60739a;--player:#0891b2;--haz:#b91c1c;--orb:#7c3aed}
 *{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:16px;font-family:Inter,system-ui;background:radial-gradient(1000px 700px at 20% 20%,var(--bg2),var(--bg));color:var(--text)}
 .card{width:min(860px,100%);background:color-mix(in srgb,var(--surface) 90%,transparent);border:1px solid color-mix(in srgb,var(--muted) 24%,transparent);border-radius:18px;padding:14px;box-shadow:0 18px 45px #0004}
 h1{margin:0 0 4px}.sub{margin:0 0 10px;color:var(--muted)}.top{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px}.pill{font-size:.86rem;padding:6px 10px;border-radius:999px;border:1px solid color-mix(in srgb,var(--muted) 24%,transparent);color:var(--muted)}
 canvas{width:100%;max-width:760px;aspect-ratio:4/3;display:block;margin:auto;background:#050a14;border-radius:12px;border:1px solid color-mix(in srgb,var(--muted) 26%,transparent)}
 .controls{text-align:center;margin-top:10px}button{border:none;border-radius:999px;padding:9px 13px;font:inherit;font-weight:700;cursor:pointer;color:#fff;background:linear-gradient(90deg,#7c3aed,#22d3ee)}
 .k{text-align:center;color:var(--muted);font-size:.9rem;margin-top:8px}
-</style></head><body><main class='card'><h1>🪐 Gravity Dodge</h1><p class='sub'>Pull toward the orb. Dodge red hazards. Survive as long as possible.</p>
+.head{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.theme-toggle{width:40px;height:40px;padding:0;font-size:1.05rem;background:var(--surface);color:var(--text);border:1px solid color-mix(in srgb,var(--muted) 24%,transparent)}
+.back{margin-top:12px;padding-top:12px;border-top:1px solid color-mix(in srgb,var(--muted) 24%,transparent);text-align:center}
+.back a{color:var(--orb);text-decoration:none}
+.back a:hover{text-decoration:underline}
+</style></head><body><main class='card'><div class='head'><h1>🪐 Gravity Dodge</h1><button class='theme-toggle' onclick='toggleTheme()' aria-label='Toggle theme'>🌙</button></div><p class='sub'>Pull toward the orb. Dodge red hazards. Survive as long as possible.</p>
 <div class='top'><span class='pill' id='score'>Score: 0</span><span class='pill' id='best'>Best: 0</span><span class='pill' id='state'>State: Ready</span></div>
-<canvas id='g' width='760' height='570'></canvas><div class='controls'><button id='start'>Start / Restart</button></div><p class='k'>Move: ← → ↑ ↓ or WASD</p></main>
+<canvas id='g' width='760' height='570'></canvas><div class='controls'><button id='start'>Start / Restart</button></div><p class='k'>Move: ← → ↑ ↓ or WASD</p><div class='back'><a href='https://www.valleyofai.com' target='_blank' rel='noopener noreferrer'>← Back to Valley of AI</a></div></main>
 <script>
+const theme = localStorage.getItem('theme') ||
+	(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+document.documentElement.setAttribute('data-theme', theme);
+document.querySelector('.theme-toggle').textContent = theme === 'dark' ? '☀️' : '🌙';
+
+function toggleTheme() {
+	const current = document.documentElement.getAttribute('data-theme');
+	const next = current === 'dark' ? 'light' : 'dark';
+	document.documentElement.setAttribute('data-theme', next);
+	localStorage.setItem('theme', next);
+	document.querySelector('.theme-toggle').textContent = next === 'dark' ? '☀️' : '🌙';
+}
+
 const c = document.getElementById('g');
 const x = c.getContext('2d');
 let best = +localStorage.getItem('gravity-best') || 0;


### PR DESCRIPTION
## Summary
- add required shared light/dark theme pattern using localStorage('theme')
- add visible theme toggle button in app header
- switch light theme vars to data-theme selector
- add footer backlink to https://www.valleyofai.com

## Validation
- npm run build