### PR TITLE
chore: move GA measurement id to env-driven placeholder injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ VITE_EMAILJS_PUBLIC_KEY=your-public-key
 
 # Cloudflare Turnstile
 VITE_TURNSTILE_SITE_KEY=your-site-key
+
+# Google Analytics
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/apps/2026/03/05/breathing-orb/index.html
+++ b/apps/2026/03/05/breathing-orb/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/05/color-palette-generator/index.html
+++ b/apps/2026/03/05/color-palette-generator/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/05/example-app/index.html
+++ b/apps/2026/03/05/example-app/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/05/pomodoro-timer/index.html
+++ b/apps/2026/03/05/pomodoro-timer/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/05/snake-game/index.html
+++ b/apps/2026/03/05/snake-game/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">

--- a/apps/2026/03/06/focus-fountain/index.html
+++ b/apps/2026/03/06/focus-fountain/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/apps/2026/03/06/habit-heatmap/index.html
+++ b/apps/2026/03/06/habit-heatmap/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/06/memory-match/index.html
+++ b/apps/2026/03/06/memory-match/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/06/reaction-ripple/index.html
+++ b/apps/2026/03/06/reaction-ripple/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/apps/2026/03/06/sorting-visualizer/index.html
+++ b/apps/2026/03/06/sorting-visualizer/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/06/word-scramble/index.html
+++ b/apps/2026/03/06/word-scramble/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/06/word-weaver/index.html
+++ b/apps/2026/03/06/word-weaver/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Word Weaver - Valley of AI</title>

--- a/apps/2026/03/07/archery-physics/index.html
+++ b/apps/2026/03/07/archery-physics/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/07/blackjack/index.html
+++ b/apps/2026/03/07/blackjack/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/07/contrast-lab/index.html
+++ b/apps/2026/03/07/contrast-lab/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/07/debug-rush/index.html
+++ b/apps/2026/03/07/debug-rush/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/07/design-dash/index.html
+++ b/apps/2026/03/07/design-dash/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/07/disco-runner/index.html
+++ b/apps/2026/03/07/disco-runner/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">

--- a/apps/2026/03/07/fishing-frenzy/index.html
+++ b/apps/2026/03/07/fishing-frenzy/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">

--- a/apps/2026/03/07/flappy-bird/index.html
+++ b/apps/2026/03/07/flappy-bird/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />

--- a/apps/2026/03/07/halftime-hustle/index.html
+++ b/apps/2026/03/07/halftime-hustle/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/07/neon-velocity/index.html
+++ b/apps/2026/03/07/neon-velocity/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">

--- a/apps/2026/03/07/pacman-classic/index.html
+++ b/apps/2026/03/07/pacman-classic/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/07/realtor-tycoon/index.html
+++ b/apps/2026/03/07/realtor-tycoon/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/07/road-rage/index.html
+++ b/apps/2026/03/07/road-rage/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">

--- a/apps/2026/03/07/workout-timer-pulse/index.html
+++ b/apps/2026/03/07/workout-timer-pulse/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/07/zorkish-text-adventure/index.html
+++ b/apps/2026/03/07/zorkish-text-adventure/index.html
@@ -2,12 +2,12 @@
 <html lang="en" data-theme="auto">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/apps/2026/03/08/daredevil-moto-jump/index.html
+++ b/apps/2026/03/08/daredevil-moto-jump/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/08/eagle-eye-teacher/index.html
+++ b/apps/2026/03/08/eagle-eye-teacher/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/2026/03/08/logic-lights-out/index.html
+++ b/apps/2026/03/08/logic-lights-out/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/08/mini-putt-gauntlet/index.html
+++ b/apps/2026/03/08/mini-putt-gauntlet/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/08/orbit-harmonics/index.html
+++ b/apps/2026/03/08/orbit-harmonics/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/2026/03/08/space-invaders-clone/index.html
+++ b/apps/2026/03/08/space-invaders-clone/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
 <meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Space Invaders Clone - Valley of AI</title>

--- a/apps/2026/03/08/typing-speed-sprint/index.html
+++ b/apps/2026/03/08/typing-speed-sprint/index.html
@@ -6,12 +6,12 @@
 	<title>Typing Speed Sprint</title>
 
 	<!-- Google tag (gtag.js) -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+	<script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
 	<script>
 		window.dataLayer = window.dataLayer || [];
 		function gtag(){dataLayer.push(arguments);}
 		gtag('js', new Date());
-		gtag('config', 'G-WRFSFDYD80');
+		gtag('config', '__GA_MEASUREMENT_ID__');
 	</script>
 
 	<style>

--- a/apps/2026/03/09/pixel-planet-clicker/index.html
+++ b/apps/2026/03/09/pixel-planet-clicker/index.html
@@ -7,12 +7,12 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='88'%3E%F0%9F%8C%8D%3C/text%3E%3C/svg%3E">
 
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-WRFSFDYD80');
+    gtag('config', '__GA_MEASUREMENT_ID__');
   </script>
 
   <style>

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Valley of AI</title>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-WRFSFDYD80');
+      gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "node ./node_modules/vite/bin/vite.js preview",
     "generate:apps": "node scripts/generate-apps.js",
     "deploy:version": "node scripts/deploy-version.js",
-    "predeploy": "DEPLOY_VERSION=$(npm run -s deploy:version) npm run build && cp -r apps dist/ && cp -r logs dist/",
+    "predeploy": "DEPLOY_VERSION=$(npm run -s deploy:version) npm run build && cp -r apps dist/ && cp -r logs dist/ && node scripts/inject-ga-id.js",
     "deploy": "node ./node_modules/gh-pages/bin/gh-pages.js -d dist"
   },
   "dependencies": {

--- a/prompts/AGENT_PROMPT.md
+++ b/prompts/AGENT_PROMPT.md
@@ -77,19 +77,19 @@ apps/YYYY/MM/DD/<app-id>/
 Every generated app `index.html` must include the same Google Analytics tag used by the main app.
 
 - Place the snippet inside `<head>` near the top (before app scripts).
-- Use this exact measurement ID: `G-WRFSFDYD80`.
+- Use the GA placeholder `__GA_MEASUREMENT_ID__` in source; deployment injects the real ID from environment.
 - Do not omit this for any app.
 
 Required snippet:
 
 ```html
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-WRFSFDYD80');
+  gtag('config', '__GA_MEASUREMENT_ID__');
 </script>
 ```
 
@@ -357,12 +357,12 @@ If any check fails, do not proceed to commit, PR, or deploy.
   <title>App Name - Valley of AI</title>
 
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-WRFSFDYD80"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-WRFSFDYD80');
+    gtag('config', '__GA_MEASUREMENT_ID__');
   </script>
 
   <style>

--- a/scripts/inject-ga-id.js
+++ b/scripts/inject-ga-id.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+
+function loadEnvLikeFile(filePath) {
+  const values = {};
+  if (!fs.existsSync(filePath)) return values;
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    values[key] = value;
+  }
+  return values;
+}
+
+function resolveGaMeasurementId() {
+  if (process.env.VITE_GA_MEASUREMENT_ID) return process.env.VITE_GA_MEASUREMENT_ID;
+
+  const envPaths = [
+    path.join(root, '.env.local'),
+    path.join(root, '.env'),
+  ];
+
+  for (const p of envPaths) {
+    const vals = loadEnvLikeFile(p);
+    if (vals.VITE_GA_MEASUREMENT_ID) return vals.VITE_GA_MEASUREMENT_ID;
+  }
+
+  return '';
+}
+
+function replaceInFile(filePath, gaId) {
+  let content = fs.readFileSync(filePath, 'utf8');
+  const next = content
+    .replaceAll('__GA_MEASUREMENT_ID__', gaId)
+    .replace(/googletagmanager\.com\/gtag\/js\?id=G-[A-Z0-9]+/g, `googletagmanager.com/gtag/js?id=${gaId}`)
+    .replace(/gtag\('config', 'G-[A-Z0-9]+'\)/g, `gtag('config', '${gaId}')`);
+
+  if (next !== content) {
+    fs.writeFileSync(filePath, next);
+    return 1;
+  }
+  return 0;
+}
+
+function walk(dirPath, files = []) {
+  if (!fs.existsSync(dirPath)) return files;
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, files);
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function main() {
+  const gaId = resolveGaMeasurementId();
+  if (!gaId) {
+    console.error('ERROR: Missing VITE_GA_MEASUREMENT_ID (.env/.env.local or environment variable).');
+    process.exit(1);
+  }
+
+  const distDir = path.join(root, 'dist');
+  const targetFiles = [
+    path.join(distDir, 'index.html'),
+    ...walk(path.join(distDir, 'apps')).filter((p) => p.endsWith('index.html')),
+  ].filter((p) => fs.existsSync(p));
+
+  let changed = 0;
+  for (const filePath of targetFiles) {
+    changed += replaceInFile(filePath, gaId);
+  }
+
+  console.log(`Injected GA ID into ${changed} file(s).`);
+}
+
+main();

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,52 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
+import path from 'path'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const deployVersion = process.env.DEPLOY_VERSION || `${pkg.version}+local`
 
+function gaPlaceholderRewritePlugin(gaId) {
+  const rewriteRequest = (req, res, next) => {
+    const url = (req.url || '').split('?')[0]
+    if (!gaId || gaId === '__GA_MEASUREMENT_ID__') return next()
+
+    // Rewrite standalone app HTML files served directly from /apps in local dev/preview.
+    if (!url.startsWith('/apps/') || !url.endsWith('/index.html')) return next()
+
+    const filePath = path.join(process.cwd(), url.slice(1))
+    if (!existsSync(filePath)) return next()
+
+    const html = readFileSync(filePath, 'utf-8').replaceAll('__GA_MEASUREMENT_ID__', gaId)
+    res.setHeader('Content-Type', 'text/html; charset=utf-8')
+    res.end(html)
+  }
+
+  return {
+    name: 'ga-placeholder-rewrite',
+    transformIndexHtml(html) {
+      return html.replaceAll('__GA_MEASUREMENT_ID__', gaId || '__GA_MEASUREMENT_ID__')
+    },
+    configureServer(server) {
+      server.middlewares.use(rewriteRequest)
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(rewriteRequest)
+    },
+  }
+}
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  base: '/',
-  define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
-    __DEPLOY_VERSION__: JSON.stringify(deployVersion),
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const gaMeasurementId = env.VITE_GA_MEASUREMENT_ID || process.env.VITE_GA_MEASUREMENT_ID || '__GA_MEASUREMENT_ID__'
+
+  return {
+    plugins: [react(), gaPlaceholderRewritePlugin(gaMeasurementId)],
+    base: '/',
+    define: {
+      __APP_VERSION__: JSON.stringify(pkg.version),
+      __DEPLOY_VERSION__: JSON.stringify(deployVersion),
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- replace hardcoded GA measurement IDs in source HTML with __GA_MEASUREMENT_ID__ placeholder
- add VITE_GA_MEASUREMENT_ID to .env.example
- add scripts/inject-ga-id.js to inject GA ID into dist during predeploy
- update predeploy to run GA injection step
- add Vite plugin/middleware to rewrite placeholders in local dev/preview
- update AGENT_PROMPT analytics guidance to use placeholder pattern

## Validation
- npm run predeploy
- npm run build