### PR TITLE
chore(shell): env-drive site branding and standardize shared app shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ VITE_TURNSTILE_SITE_KEY=your-site-key
 
 # Google Analytics
 VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Main site URL used by standalone app footer links
+VITE_MAIN_SITE_URL=https://www.valleyofai.com
+
+# Main site name used by standalone app footer links
+VITE_MAIN_SITE_NAME=Valley of AI

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ In addition to Node/npm, this project expects external service configuration.
 | EmailJS | Service ID, template ID, public key (`VITE_EMAILJS_*`) | Send suggestion form submissions |
 | Cloudflare Turnstile | Site key (`VITE_TURNSTILE_SITE_KEY`) | Block bots/robots on forms |
 | Google Analytics | Measurement ID (`VITE_GA_MEASUREMENT_ID`) | Site analytics tracking |
+| Main Site URL | URL value (`VITE_MAIN_SITE_URL`) | Footer link destination for standalone app pages |
+| Main Site Name | Display name (`VITE_MAIN_SITE_NAME`) | Footer link label for standalone app pages |
 
 Set these in your local `.env` (copied from `.env.example`).
 
@@ -142,6 +144,8 @@ Variables currently used:
 | `VITE_EMAILJS_PUBLIC_KEY` | EmailJS browser public key | Yes |
 | `VITE_TURNSTILE_SITE_KEY` | Cloudflare Turnstile site key for spam protection | Yes |
 | `VITE_GA_MEASUREMENT_ID` | Google Analytics measurement ID (injected into HTML during dev/build/deploy) | Yes |
+| `VITE_MAIN_SITE_URL` | Main site URL used by standalone app footer links | Yes |
+| `VITE_MAIN_SITE_NAME` | Main site name used by standalone app footer link text | Yes |
 
 If these values are missing, parts of the app may fail at runtime, and deploy/build analytics injection will not complete.
 

--- a/apps/2026/03/05/breathing-orb/index.html
+++ b/apps/2026/03/05/breathing-orb/index.html
@@ -171,6 +171,9 @@
       * { animation: none !important; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/05/color-palette-generator/index.html
+++ b/apps/2026/03/05/color-palette-generator/index.html
@@ -384,6 +384,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/05/example-app/index.html
+++ b/apps/2026/03/05/example-app/index.html
@@ -124,6 +124,9 @@
       margin-top: 20px;
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/05/pomodoro-timer/index.html
+++ b/apps/2026/03/05/pomodoro-timer/index.html
@@ -277,6 +277,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/05/snake-game/index.html
+++ b/apps/2026/03/05/snake-game/index.html
@@ -223,6 +223,9 @@
       .instructions { display: none; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/06/focus-fountain/index.html
+++ b/apps/2026/03/06/focus-fountain/index.html
@@ -151,6 +151,9 @@
     @media (max-width: 560px){ .stats{grid-template-columns:1fr;} }
     @media (prefers-reduced-motion: reduce){ *{animation:none!important; transition:none!important;} }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/06/habit-heatmap/index.html
+++ b/apps/2026/03/06/habit-heatmap/index.html
@@ -193,6 +193,9 @@
       *, *::before, *::after { transition: none !important; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <main class="app" aria-label="Habit heatmap tracker">

--- a/apps/2026/03/06/memory-match/index.html
+++ b/apps/2026/03/06/memory-match/index.html
@@ -352,6 +352,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <div class="header">

--- a/apps/2026/03/06/reaction-ripple/index.html
+++ b/apps/2026/03/06/reaction-ripple/index.html
@@ -77,6 +77,9 @@
     @media (max-width:600px){.stats{grid-template-columns:1fr}}
     @media (prefers-reduced-motion: reduce){*{animation:none!important;transition:none!important}}
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/06/sorting-visualizer/index.html
+++ b/apps/2026/03/06/sorting-visualizer/index.html
@@ -323,6 +323,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">🌙</button>

--- a/apps/2026/03/06/word-scramble/index.html
+++ b/apps/2026/03/06/word-scramble/index.html
@@ -352,6 +352,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/06/word-weaver/index.html
+++ b/apps/2026/03/06/word-weaver/index.html
@@ -28,6 +28,9 @@
     .stats{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}.pill{font-size:.85rem;color:var(--muted);padding:6px 10px;border:1px solid color-mix(in srgb,var(--muted) 25%,transparent);border-radius:999px}
     @media (max-width:760px){.grid{grid-template-columns:1fr}}
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/07/archery-physics/index.html
+++ b/apps/2026/03/07/archery-physics/index.html
@@ -327,6 +327,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/07/blackjack/index.html
+++ b/apps/2026/03/07/blackjack/index.html
@@ -775,6 +775,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <div id="game-container">

--- a/apps/2026/03/07/contrast-lab/index.html
+++ b/apps/2026/03/07/contrast-lab/index.html
@@ -225,6 +225,9 @@
       * { transition: none !important; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <main class="wrap">

--- a/apps/2026/03/07/debug-rush/index.html
+++ b/apps/2026/03/07/debug-rush/index.html
@@ -472,6 +472,9 @@
       .line-code { font-size: 0.8rem; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/07/design-dash/index.html
+++ b/apps/2026/03/07/design-dash/index.html
@@ -516,6 +516,9 @@
       .options-grid { grid-template-columns: repeat(2, 1fr); }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <!-- Top Bar -->

--- a/apps/2026/03/07/disco-runner/index.html
+++ b/apps/2026/03/07/disco-runner/index.html
@@ -286,6 +286,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/07/fishing-frenzy/index.html
+++ b/apps/2026/03/07/fishing-frenzy/index.html
@@ -231,7 +231,7 @@
     /* Instructions */
     .instructions {
       position: fixed;
-      bottom: 20px;
+      bottom: 72px;
       left: 50%;
       transform: translateX(-50%);
       background: var(--surface);
@@ -355,6 +355,9 @@
       .overlay h1 { font-size: 2rem; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <!-- Top Bar -->

--- a/apps/2026/03/07/flappy-bird/index.html
+++ b/apps/2026/03/07/flappy-bird/index.html
@@ -217,6 +217,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <header>

--- a/apps/2026/03/07/halftime-hustle/index.html
+++ b/apps/2026/03/07/halftime-hustle/index.html
@@ -245,6 +245,9 @@
     
     .back-link:hover { transform: translateX(-2px); background: var(--secondary); }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <a href="https://valleyofai.com" class="back-link">← Valley of AI</a>

--- a/apps/2026/03/07/neon-velocity/index.html
+++ b/apps/2026/03/07/neon-velocity/index.html
@@ -453,6 +453,9 @@
       z-index: 10;
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <!-- Top Bar -->

--- a/apps/2026/03/07/pacman-classic/index.html
+++ b/apps/2026/03/07/pacman-classic/index.html
@@ -119,6 +119,9 @@
     .kbd { color: var(--muted); text-align: center; margin-top: 10px; font-size: .9rem; }
     @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/07/realtor-tycoon/index.html
+++ b/apps/2026/03/07/realtor-tycoon/index.html
@@ -475,6 +475,9 @@
     .toast.warning { border-left: 4px solid var(--warning); }
     .toast.error { border-left: 4px solid var(--danger); }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <!-- Top Bar -->

--- a/apps/2026/03/07/road-rage/index.html
+++ b/apps/2026/03/07/road-rage/index.html
@@ -384,6 +384,9 @@
       90% { transform: translate(8px, -8px) rotate(0deg); }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <!-- Top Bar -->

--- a/apps/2026/03/07/workout-timer-pulse/index.html
+++ b/apps/2026/03/07/workout-timer-pulse/index.html
@@ -38,6 +38,9 @@
     .chip{font-size:.75rem;padding:5px 8px;border-radius:999px;border:1px solid color-mix(in srgb,var(--muted) 24%,transparent);color:var(--muted)}
     @media(max-width:800px){.layout{grid-template-columns:1fr}.ring-wrap{height:320px}}
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/07/zorkish-text-adventure/index.html
+++ b/apps/2026/03/07/zorkish-text-adventure/index.html
@@ -28,6 +28,9 @@
     button{border:none;border-radius:999px;padding:10px 14px;font:inherit;font-weight:700;cursor:pointer;color:#fff;background:linear-gradient(90deg,var(--accent),var(--accent2))}
     .help{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}.chip{font-size:.78rem;color:var(--muted);border:1px solid color-mix(in srgb,var(--muted) 22%,transparent);padding:4px 8px;border-radius:999px}
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/08/daredevil-moto-jump/index.html
+++ b/apps/2026/03/08/daredevil-moto-jump/index.html
@@ -210,6 +210,9 @@
       .btn { padding: 12px 28px; font-size: 14px; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <a class="home-link" href="https://valleyofai.com" aria-label="Back to Valley of AI">← Valley of AI</a>

--- a/apps/2026/03/08/eagle-eye-teacher/index.html
+++ b/apps/2026/03/08/eagle-eye-teacher/index.html
@@ -409,6 +409,9 @@
       .legend { font-size: 0.75rem; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/08/logic-lights-out/index.html
+++ b/apps/2026/03/08/logic-lights-out/index.html
@@ -174,6 +174,9 @@
       *, *::before, *::after { animation: none !important; transition: none !important; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <main class="app">

--- a/apps/2026/03/08/mini-putt-gauntlet/index.html
+++ b/apps/2026/03/08/mini-putt-gauntlet/index.html
@@ -234,6 +234,9 @@
       .stat .value { font-size: 1.05rem; }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <main class="app">

--- a/apps/2026/03/08/orbit-harmonics/index.html
+++ b/apps/2026/03/08/orbit-harmonics/index.html
@@ -351,6 +351,9 @@
       }
     }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <div class="shell">

--- a/apps/2026/03/08/space-invaders-clone/index.html
+++ b/apps/2026/03/08/space-invaders-clone/index.html
@@ -27,7 +27,10 @@ h1{margin:0 0 4px}.sub{margin:0 0 10px;color:var(--muted)}
 canvas{width:100%;max-width:760px;aspect-ratio:4/3;display:block;margin:auto;background:#050a14;border-radius:12px;border:1px solid color-mix(in srgb,var(--muted) 26%,transparent)}
 .controls{display:flex;gap:8px;justify-content:center;flex-wrap:wrap;margin-top:10px}button{border:none;border-radius:999px;padding:9px 13px;font:inherit;font-weight:700;cursor:pointer;color:#fff;background:linear-gradient(90deg,#7c3aed,var(--primary))}
 .kbd{text-align:center;color:var(--muted);margin-top:8px;font-size:.9rem}
-</style></head>
+</style>  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
+</head>
 <body>
 <div class="top-bar">
   <a href="https://www.valleyofai.com" class="home-link">

--- a/apps/2026/03/08/typing-speed-sprint/index.html
+++ b/apps/2026/03/08/typing-speed-sprint/index.html
@@ -239,6 +239,9 @@
 			font-weight: 800;
 		}
 	</style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
 	<button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>

--- a/apps/2026/03/09/gravity-dodge/index.html
+++ b/apps/2026/03/09/gravity-dodge/index.html
@@ -12,7 +12,10 @@ canvas{width:100%;max-width:760px;aspect-ratio:4/3;display:block;margin:auto;bac
 .back{margin-top:12px;padding-top:12px;border-top:1px solid color-mix(in srgb,var(--muted) 24%,transparent);text-align:center}
 .back a{color:var(--orb);text-decoration:none}
 .back a:hover{text-decoration:underline}
-</style></head><body><main class='card'><div class='head'><h1>🪐 Gravity Dodge</h1><button class='theme-toggle' onclick='toggleTheme()' aria-label='Toggle theme'>🌙</button></div><p class='sub'>Pull toward the orb. Dodge red hazards. Survive as long as possible.</p>
+</style>  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
+</head><body><main class='card'><div class='head'><h1>🪐 Gravity Dodge</h1><button class='theme-toggle' onclick='toggleTheme()' aria-label='Toggle theme'>🌙</button></div><p class='sub'>Pull toward the orb. Dodge red hazards. Survive as long as possible.</p>
 <div class='top'><span class='pill' id='score'>Score: 0</span><span class='pill' id='best'>Best: 0</span><span class='pill' id='state'>State: Ready</span></div>
 <canvas id='g' width='760' height='570'></canvas><div class='controls'><button id='start'>Start / Restart</button></div><p class='k'>Move: ← → ↑ ↓ or WASD</p><div class='back'><a href='https://www.valleyofai.com' target='_blank' rel='noopener noreferrer'>← Back to Valley of AI</a></div></main>
 <script>

--- a/apps/2026/03/09/pixel-planet-clicker/index.html
+++ b/apps/2026/03/09/pixel-planet-clicker/index.html
@@ -132,6 +132,9 @@
     @media (max-width: 760px) { .grid { grid-template-columns: 1fr; } .planet { width: min(78vw, 260px); } }
     @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation: none !important; transition: none !important; } }
   </style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
 </head>
 <body>
   <main class="app">

--- a/apps/shared/app-shell.js
+++ b/apps/shared/app-shell.js
@@ -1,0 +1,209 @@
+(() => {
+  const THEME_KEY = 'theme';
+  const MAIN_SITE_URL_PLACEHOLDER = '__MAIN_SITE_URL__';
+  const MAIN_SITE_NAME_PLACEHOLDER = '__MAIN_SITE_NAME__';
+  const DEFAULT_MAIN_SITE_URL = 'https://www.valleyofai.com';
+  const DEFAULT_MAIN_SITE_NAME = 'Valley of AI';
+
+  function resolveMainSiteUrl() {
+    const metaUrl = document.querySelector('meta[name="voa-main-site-url"]')?.getAttribute('content')?.trim();
+    if (metaUrl && metaUrl !== MAIN_SITE_URL_PLACEHOLDER) return metaUrl;
+    return DEFAULT_MAIN_SITE_URL;
+  }
+
+  function resolveMainSiteName() {
+    const metaName = document.querySelector('meta[name="voa-main-site-name"]')?.getAttribute('content')?.trim();
+    if (metaName && metaName !== MAIN_SITE_NAME_PLACEHOLDER) return metaName;
+    return DEFAULT_MAIN_SITE_NAME;
+  }
+
+  function getAppName() {
+    const explicitName = document.querySelector('meta[name="application-name"]')?.getAttribute('content')?.trim();
+    if (explicitName) return explicitName;
+
+    const firstHeading = document.querySelector('h1, .title, [data-app-title]');
+    const headingText = firstHeading?.textContent?.trim();
+    if (headingText) return headingText.replace(/^\s*[\u2190-\u27A1]+\s*/g, '').trim();
+
+    const titleText = (document.title || 'Valley of AI App').trim();
+    return titleText.replace(/\s*[|-]\s*Valley of AI.*$/i, '').trim();
+  }
+
+  function setToggleIcons(theme) {
+    const icon = theme === 'dark' ? '☀️' : '🌙';
+    const toggles = document.querySelectorAll('.theme-toggle');
+    for (const toggle of toggles) {
+      toggle.textContent = icon;
+    }
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem(THEME_KEY, theme);
+    setToggleIcons(theme);
+  }
+
+  function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme') || localStorage.getItem(THEME_KEY) || 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+  }
+
+  function ensureThemeInitialized() {
+    const preferred = localStorage.getItem(THEME_KEY) || document.documentElement.getAttribute('data-theme') || 'light';
+    applyTheme(preferred);
+  }
+
+  function hideLegacyBackLinks() {
+    const links = document.querySelectorAll('a[href]');
+    for (const link of links) {
+      const href = link.getAttribute('href') || '';
+      const text = (link.textContent || '').toLowerCase();
+      const inShellFooter = !!link.closest('.voa-shell-footer');
+      if (inShellFooter) continue;
+      if (!/valleyofai\.com/.test(href)) continue;
+      if (!/back to valley|valley of ai/.test(text)) continue;
+
+      const wrapper = link.closest('footer, .footer, .back, .home-link, .home-link-wrapper') || link;
+      wrapper.classList.add('voa-hide-legacy-link');
+    }
+  }
+
+  function injectShellStyles() {
+    if (document.getElementById('voa-shell-style')) return;
+    const style = document.createElement('style');
+    style.id = 'voa-shell-style';
+    style.textContent = `
+      body.voa-shell-enabled {
+        padding-top: 64px;
+        padding-bottom: 56px;
+        box-sizing: border-box;
+      }
+
+      .voa-shell-header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 9999;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        min-height: 56px;
+        padding: 10px 16px;
+        background: color-mix(in srgb, var(--surface, #ffffff) 92%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--muted, #94a3b8) 28%, transparent);
+        backdrop-filter: blur(8px);
+      }
+
+      .voa-shell-app-name {
+        font: 700 0.98rem/1.2 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+        color: var(--text, var(--text-primary, #f8fafc));
+        letter-spacing: 0.01em;
+      }
+
+      #voa-theme-toggle.theme-toggle {
+        width: 40px;
+        height: 40px;
+        border-radius: 999px;
+        border: 1px solid color-mix(in srgb, var(--muted, #94a3b8) 28%, transparent);
+        background: var(--surface, #ffffff);
+        color: var(--text, var(--text-primary, #f8fafc));
+        cursor: pointer;
+        font-size: 1.05rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      #voa-theme-toggle.theme-toggle:hover {
+        transform: scale(1.05);
+      }
+
+      .theme-toggle:not(#voa-theme-toggle) {
+        display: none !important;
+      }
+
+      .voa-shell-footer {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 9998;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, var(--surface, #ffffff) 94%, transparent);
+        border-top: 1px solid color-mix(in srgb, var(--muted, #94a3b8) 28%, transparent);
+        backdrop-filter: blur(8px);
+      }
+
+      .voa-shell-footer-link {
+        color: var(--primary, #2563eb);
+        text-decoration: none;
+        font: 600 0.92rem/1 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      .voa-shell-footer-link:hover {
+        text-decoration: underline;
+      }
+
+      .voa-hide-legacy-link {
+        display: none !important;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function injectShell() {
+    if (document.getElementById('voa-shell-header')) return;
+
+    document.body.classList.add('voa-shell-enabled');
+
+    const header = document.createElement('header');
+    header.id = 'voa-shell-header';
+    header.className = 'voa-shell-header';
+
+    const appName = document.createElement('div');
+    appName.className = 'voa-shell-app-name';
+    appName.textContent = getAppName();
+
+    const toggle = document.createElement('button');
+    toggle.id = 'voa-theme-toggle';
+    toggle.className = 'theme-toggle';
+    toggle.type = 'button';
+    toggle.setAttribute('aria-label', 'Toggle theme');
+    toggle.addEventListener('click', toggleTheme);
+
+    header.appendChild(appName);
+    header.appendChild(toggle);
+
+    const footer = document.createElement('footer');
+    footer.className = 'voa-shell-footer';
+
+    const footerLink = document.createElement('a');
+    footerLink.className = 'voa-shell-footer-link';
+    footerLink.href = resolveMainSiteUrl();
+    footerLink.textContent = `Back to ${resolveMainSiteName()}`;
+    footer.appendChild(footerLink);
+
+    document.body.prepend(header);
+    document.body.appendChild(footer);
+
+    hideLegacyBackLinks();
+    ensureThemeInitialized();
+  }
+
+  window.toggleTheme = toggleTheme;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      injectShellStyles();
+      injectShell();
+    });
+  } else {
+    injectShellStyles();
+    injectShell();
+  }
+})();

--- a/prompts/AGENT_PROMPT.md
+++ b/prompts/AGENT_PROMPT.md
@@ -61,7 +61,7 @@ Rotate through these categories to maintain variety:
 
 ### File Structure
 
-Each app must be placed in: `apps/YYYY/MM/DD/<app-id>/`
+Each app MUST be placed in: `apps/YYYY/MM/DD/<app-id>/`
 
 Required files:
 ```
@@ -74,11 +74,12 @@ apps/YYYY/MM/DD/<app-id>/
 
 ### Analytics Requirement (Mandatory)
 
-Every generated app `index.html` must include the same Google Analytics tag used by the main app.
+Every generated app `index.html` MUST include the same Google Analytics tag used by the main app.
 
 - Place the snippet inside `<head>` near the top (before app scripts).
 - Use the GA placeholder `__GA_MEASUREMENT_ID__` in source; deployment injects the real ID from environment.
-- Do not omit this for any app.
+- Never hardcode a real `G-...` value in source.
+- MUST NOT omit this for any app.
 
 Required snippet:
 
@@ -92,6 +93,60 @@ Required snippet:
   gtag('config', '__GA_MEASUREMENT_ID__');
 </script>
 ```
+
+### Shared App Shell Requirement (Mandatory)
+
+All standalone apps MUST use the shared app shell so header/footer/theme behavior stays consistent across the gallery.
+
+- Include both of these tags in `<head>`:
+
+```html
+<meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+<meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+<script src="/apps/shared/app-shell.js" defer></script>
+```
+
+- `__MAIN_SITE_URL__` is injected from environment (`VITE_MAIN_SITE_URL`) during dev/preview/deploy.
+- `__MAIN_SITE_NAME__` is injected from environment (`VITE_MAIN_SITE_NAME`) during dev/preview/deploy.
+- MUST NOT hardcode `https://www.valleyofai.com` in app markup for footer/back links.
+- MUST NOT add per-app custom top bars for app title/theme toggle unless the app explicitly requires additional controls.
+- MUST NOT add manual "Back to Valley of AI" footer markup; shared shell provides the standard footer link.
+- MUST NOT implement a separate app-local theme toggle system when using the shared shell.
+
+This protocol guarantees:
+- Header top-left app name (derived from app title/heading)
+- Header top-right light/dark toggle
+- Footer centered link back to main site
+
+#### Shared Shell Exception Protocol (Rare)
+
+Deviating from the shared shell is allowed only when the shell would materially break core UX/gameplay.
+
+Allowed examples:
+- Fullscreen/canvas apps where fixed shell chrome blocks critical HUD, controls, or play area.
+- Apps with immersive or kiosk-style presentation where persistent header/footer would conflict with core interaction.
+
+If an exception is used, the agent MUST:
+1. Explain the reason in PR notes and generation notes.
+2. Keep GA snippet + `__GA_MEASUREMENT_ID__` placeholder unchanged.
+3. Still include a visible path back to the main site using `__MAIN_SITE_URL__` (do not hardcode URL).
+4. Preserve the shared theme protocol (`theme` key + `data-theme` compatibility).
+5. Verify controls/content are not hidden by custom chrome on mobile and desktop.
+
+If none of the above exception conditions apply, shared shell usage is mandatory.
+
+### Environment Variables (Mandatory)
+
+When building/testing/deploying apps, assume these env vars are required and sourced from `.env` (template: `.env.example`):
+
+- `VITE_GA_MEASUREMENT_ID`: injected into `__GA_MEASUREMENT_ID__` placeholders.
+- `VITE_MAIN_SITE_URL`: injected into `__MAIN_SITE_URL__` placeholders for shared footer links.
+- `VITE_MAIN_SITE_NAME`: injected into `__MAIN_SITE_NAME__` placeholders for shared footer link text.
+
+Rules:
+- MUST keep placeholders in source files (`__GA_MEASUREMENT_ID__`, `__MAIN_SITE_URL__`, `__MAIN_SITE_NAME__`).
+- MUST NOT replace placeholders with hardcoded production values in committed app HTML.
+- If placeholders appear at runtime during local dev, verify `.env` values and restart Vite.
 
 ### Thumbnail Generation
 
@@ -262,7 +317,7 @@ The app has: grid board, snake body segments, food dot, score/level display.
 
 ### meta.json Schema
 
-Every app must include a valid `meta.json`:
+Every app MUST include a valid `meta.json`:
 
 ```json
 {
@@ -292,14 +347,14 @@ Every app must include a valid `meta.json`:
 - `id`: lowercase, hyphenated, unique (e.g., `snake-game`, `pomodoro-timer`)
 - `category`: One of `Games`, `Productivity`, `Utilities`, `Design`, `Education`, `Entertainment`, `Visualization`
 - `tags`: 2-5 relevant tags for discoverability
-- `generation`: Must accurately reflect your actual token usage and timing
+- `generation`: MUST accurately reflect your actual token usage and timing
 
 ### App Quality Standards
 
-**Every app must:**
+**Every app MUST:**
 1. Work immediately without instructions (intuitive UX)
 2. Be fully responsive (mobile-friendly)
-3. Support both light and dark mode using the **shared theme system** (see [Theme Requirements](#1-lightdark-mode-implementation) below)
+3. Support both light and dark mode via the shared app shell + shared `theme` key protocol
 4. Have smooth animations and transitions
 5. Handle edge cases gracefully
 6. Be visually polished with good typography and spacing
@@ -324,7 +379,7 @@ Before finalizing any game app, run this checklist and fix failures:
 - Confirm no browser control conflicts (for example arrow keys should not scroll the page during gameplay).
 - Log that runtime checks passed.
 
-If any check fails, do not proceed to commit, PR, or deploy.
+If any check fails, MUST NOT proceed to commit, PR, or deploy.
 
 ### Canvas Rules (Mandatory for `<canvas>` Apps)
 
@@ -365,6 +420,10 @@ If any check fails, do not proceed to commit, PR, or deploy.
     gtag('config', '__GA_MEASUREMENT_ID__');
   </script>
 
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+  <script src="/apps/shared/app-shell.js" defer></script>
+
   <style>
     :root {
       --primary: #6366f1;
@@ -388,34 +447,12 @@ If any check fails, do not proceed to commit, PR, or deploy.
       justify-content: center;
       padding: 1rem;
     }
-    .theme-toggle {
-      position: fixed; top: 1rem; right: 1rem;
-      background: var(--surface); border: none; border-radius: 50%;
-      width: 40px; height: 40px; cursor: pointer; font-size: 1.2rem;
-      display: flex; align-items: center; justify-content: center;
-    }
-    .theme-toggle:hover { transform: scale(1.1); }
     /* App styles... */
   </style>
 </head>
 <body>
-  <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>
   <!-- App content -->
   <script>
-    // Theme init — MUST use shared key 'theme' in localStorage
-    const theme = localStorage.getItem('theme') ||
-      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    document.documentElement.setAttribute('data-theme', theme);
-    document.querySelector('.theme-toggle').textContent = theme === 'dark' ? '☀️' : '🌙';
-
-    function toggleTheme() {
-      const current = document.documentElement.getAttribute('data-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem('theme', next);
-      document.querySelector('.theme-toggle').textContent = next === 'dark' ? '☀️' : '🌙';
-    }
-
     // App logic
   </script>
 </body>
@@ -759,35 +796,20 @@ Before moving to final review, ensure these polish items are complete:
 
 ### 1. Light/Dark Mode Implementation
 
-Every app MUST support both light and dark mode using the **shared theme system**. This ensures a user who sets dark mode on the main site (or any app) sees that preference honored everywhere.
+Every app MUST support both light and dark mode using the **shared app shell**. This ensures a user who sets dark mode on the main site (or any app) sees that preference honored everywhere.
 
 #### Critical Rules
 
-1. **Use the shared localStorage key `'theme'`** — this is the SAME key the main Valley of AI site uses in `ThemeToggle.jsx`. Do NOT use app-specific keys like `'my-app-theme'`.
-2. **Set `data-theme` attribute on `document.documentElement`** (the `<html>` tag), NOT on `<body>`.
-3. **Values must be `'dark'` or `'light'`** — do not use `'auto'` or other values.
-4. **Fall back to system preference** via `window.matchMedia('(prefers-color-scheme: dark)')` when no stored preference exists.
-5. **Include a visible toggle button** (🌙/☀️) so users can switch themes.
-6. **Do NOT hardcode `data-theme` in the `<html>` tag** — let JS set it on load to avoid flash of wrong theme.
-7. **Do NOT use `@media (prefers-color-scheme)` as the primary mechanism** — use it only as the fallback when no `localStorage` value exists.
-
-#### Required Theme JavaScript (copy exactly)
-
-```javascript
-// Theme init — place at top of your <script> block
-const theme = localStorage.getItem('theme') ||
-  (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-document.documentElement.setAttribute('data-theme', theme);
-document.querySelector('.theme-toggle').textContent = theme === 'dark' ? '☀️' : '🌙';
-
-function toggleTheme() {
-  const current = document.documentElement.getAttribute('data-theme');
-  const next = current === 'dark' ? 'light' : 'dark';
-  document.documentElement.setAttribute('data-theme', next);
-  localStorage.setItem('theme', next);
-  document.querySelector('.theme-toggle').textContent = next === 'dark' ? '☀️' : '🌙';
-}
-```
+1. **Include shared app shell tags in `<head>`**:
+   - `<meta name="voa-main-site-url" content="__MAIN_SITE_URL__">`
+  - `<meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">`
+   - `<script src="/apps/shared/app-shell.js" defer></script>`
+2. **Keep using CSS variables for app colors** and provide both light/dark values via `[data-theme="light"]` or `[data-theme="dark"]`.
+3. **Do not create app-local theme keys** — shared shell uses the global `'theme'` key.
+4. **Do not add a second theme toggle button** — shell injects the standard header toggle.
+5. **Do not hardcode `data-theme` in `<html>`**.
+6. **Test both light and dark modes** after integrating shell.
+7. **Only bypass shared shell with explicit exception justification** (see Shared Shell Exception Protocol above).
 
 #### Required CSS Pattern
 
@@ -815,14 +837,6 @@ body {
   color: var(--text);
 }
 ```
-```
-
-**Toggle button** – Include a visible sun/moon toggle in the header:
-```html
-<button onclick="toggleTheme()" aria-label="Toggle theme" class="theme-toggle">
-  🌙
-</button>
-```
 
 ### 2. Favicon Generation
 
@@ -843,23 +857,17 @@ Every app MUST have a custom favicon that represents the app:
 
 ### 3. Link Back to Valley of AI
 
-Every app MUST include a link back to the main site in the footer:
+Every app MUST provide a link back to the main site via the shared shell footer (do not hand-code this):
 
 ```html
-<!-- Add at the bottom of your app -->
-<footer style="text-align: center; padding: 20px; margin-top: 40px; border-top: 1px solid var(--text-secondary); opacity: 0.7;">
-  <a href="https://www.valleyofai.com" target="_blank" rel="noopener" 
-     style="color: var(--accent); text-decoration: none;">
-    ← Back to Valley of AI
-  </a>
-</footer>
+<meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+<meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+<script src="/apps/shared/app-shell.js" defer></script>
 ```
 
 **Styling requirements:**
-- Should be subtle but visible
-- Use theme-aware colors
-- Include `target="_blank"` and `rel="noopener"`
-- Position at the very bottom of the app
+- Footer link is centered and themed by shared shell.
+- Do not add duplicate manual back links.
 
 ### 4. Additional Polish Items
 
@@ -872,14 +880,15 @@ Every app MUST include a link back to the main site in the footer:
 - [ ] **Animations** – Respect `prefers-reduced-motion` media query
 - [ ] **Performance** – No janky animations, no layout thrashing
 - [ ] **Console Clean** – Zero errors or warnings in browser console
+- [ ] **Shell Compliance** – Use shared shell, or document and validate exception requirements
 
 ### Pre-Code Polish Summary
 
 | Item | Required | Notes |
 |------|----------|-------|
-| Dark/Light Mode | ✅ Yes | Shared `localStorage('theme')` key + toggle + `data-theme` on `<html>` |
+| Dark/Light Mode | ✅ Yes | Shared app shell (`/apps/shared/app-shell.js`) + CSS theme variables |
 | Favicon | ✅ Yes | Emoji or SVG, app-specific |
-| Back to Valley Link | ✅ Yes | Footer link with `target="_blank"` |
+| Back to Valley Link | ✅ Yes | Shared shell footer using `__MAIN_SITE_URL__` + `__MAIN_SITE_NAME__` |
 | Responsive Design | ✅ Yes | Works on mobile |
 | Touch Support | For games | Touch events for interactive apps |
 | Keyboard Nav | ✅ Yes | Tab-navigable UI |

--- a/scripts/inject-ga-id.js
+++ b/scripts/inject-ga-id.js
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const root = path.resolve(__dirname, '..');
+const DEFAULT_MAIN_SITE_URL = 'https://www.valleyofai.com';
+const DEFAULT_MAIN_SITE_NAME = 'Valley of AI';
 
 function loadEnvLikeFile(filePath) {
   const values = {};
@@ -43,10 +45,44 @@ function resolveGaMeasurementId() {
   return '';
 }
 
-function replaceInFile(filePath, gaId) {
+function resolveMainSiteUrl() {
+  if (process.env.VITE_MAIN_SITE_URL) return process.env.VITE_MAIN_SITE_URL;
+
+  const envPaths = [
+    path.join(root, '.env.local'),
+    path.join(root, '.env'),
+  ];
+
+  for (const p of envPaths) {
+    const vals = loadEnvLikeFile(p);
+    if (vals.VITE_MAIN_SITE_URL) return vals.VITE_MAIN_SITE_URL;
+  }
+
+  return DEFAULT_MAIN_SITE_URL;
+}
+
+function resolveMainSiteName() {
+  if (process.env.VITE_MAIN_SITE_NAME) return process.env.VITE_MAIN_SITE_NAME;
+
+  const envPaths = [
+    path.join(root, '.env.local'),
+    path.join(root, '.env'),
+  ];
+
+  for (const p of envPaths) {
+    const vals = loadEnvLikeFile(p);
+    if (vals.VITE_MAIN_SITE_NAME) return vals.VITE_MAIN_SITE_NAME;
+  }
+
+  return DEFAULT_MAIN_SITE_NAME;
+}
+
+function replaceInFile(filePath, gaId, mainSiteUrl, mainSiteName) {
   let content = fs.readFileSync(filePath, 'utf8');
   const next = content
     .replaceAll('__GA_MEASUREMENT_ID__', gaId)
+    .replaceAll('__MAIN_SITE_URL__', mainSiteUrl)
+    .replaceAll('__MAIN_SITE_NAME__', mainSiteName)
     .replace(/googletagmanager\.com\/gtag\/js\?id=G-[A-Z0-9]+/g, `googletagmanager.com/gtag/js?id=${gaId}`)
     .replace(/gtag\('config', 'G-[A-Z0-9]+'\)/g, `gtag('config', '${gaId}')`);
 
@@ -73,6 +109,8 @@ function walk(dirPath, files = []) {
 
 function main() {
   const gaId = resolveGaMeasurementId();
+  const mainSiteUrl = resolveMainSiteUrl();
+  const mainSiteName = resolveMainSiteName();
   if (!gaId) {
     console.error('ERROR: Missing VITE_GA_MEASUREMENT_ID (.env/.env.local or environment variable).');
     process.exit(1);
@@ -86,10 +124,10 @@ function main() {
 
   let changed = 0;
   for (const filePath of targetFiles) {
-    changed += replaceInFile(filePath, gaId);
+    changed += replaceInFile(filePath, gaId, mainSiteUrl, mainSiteName);
   }
 
-  console.log(`Injected GA ID into ${changed} file(s).`);
+  console.log(`Injected GA ID, main site URL, and main site name into ${changed} file(s).`);
 }
 
 main();

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import ThemeToggle from './ThemeToggle'
+import { siteName } from '../lib/siteConfig'
 
 export default function Header() {
   return (
@@ -9,7 +10,7 @@ export default function Header() {
           <Link to="/" className="flex items-center gap-2">
             <span className="text-2xl">🏔️</span>
             <span className="text-xl font-bold text-gray-900 dark:text-white">
-              Valley of AI
+              {siteName}
             </span>
           </Link>
           

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom'
 import Header from './Header'
+import { siteName } from '../lib/siteConfig'
 
 export default function Layout() {
   return (
@@ -12,7 +13,7 @@ export default function Layout() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
           <span>✨ An experiment in AI, powered by curiosity and <span className="heart-pulse">❤️</span> from <span className="sparkle-text">Jeff Holst</span></span>
           <div className="flex items-center gap-4">
-            <span>🏔️ Valley of AI © 2026</span>
+            <span>🏔️ {siteName} © 2026</span>
             <span className="text-gray-300 dark:text-gray-600">•</span>
             <a 
               href="https://github.com/jeffholst/valley-of-ai" 

--- a/src/lib/siteConfig.js
+++ b/src/lib/siteConfig.js
@@ -1,0 +1,1 @@
+export const siteName = import.meta.env.VITE_MAIN_SITE_NAME || 'Valley of AI'

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,10 +6,9 @@ import path from 'path'
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const deployVersion = process.env.DEPLOY_VERSION || `${pkg.version}+local`
 
-function gaPlaceholderRewritePlugin(gaId) {
+function appPlaceholderRewritePlugin(gaId, mainSiteUrl, mainSiteName) {
   const rewriteRequest = (req, res, next) => {
     const url = (req.url || '').split('?')[0]
-    if (!gaId || gaId === '__GA_MEASUREMENT_ID__') return next()
 
     // Rewrite standalone app HTML files served directly from /apps in local dev/preview.
     if (!url.startsWith('/apps/') || !url.endsWith('/index.html')) return next()
@@ -17,15 +16,21 @@ function gaPlaceholderRewritePlugin(gaId) {
     const filePath = path.join(process.cwd(), url.slice(1))
     if (!existsSync(filePath)) return next()
 
-    const html = readFileSync(filePath, 'utf-8').replaceAll('__GA_MEASUREMENT_ID__', gaId)
+    const html = readFileSync(filePath, 'utf-8')
+      .replaceAll('__GA_MEASUREMENT_ID__', gaId || '__GA_MEASUREMENT_ID__')
+      .replaceAll('__MAIN_SITE_URL__', mainSiteUrl || '__MAIN_SITE_URL__')
+      .replaceAll('__MAIN_SITE_NAME__', mainSiteName || '__MAIN_SITE_NAME__')
     res.setHeader('Content-Type', 'text/html; charset=utf-8')
     res.end(html)
   }
 
   return {
-    name: 'ga-placeholder-rewrite',
+    name: 'app-placeholder-rewrite',
     transformIndexHtml(html) {
-      return html.replaceAll('__GA_MEASUREMENT_ID__', gaId || '__GA_MEASUREMENT_ID__')
+      return html
+        .replaceAll('__GA_MEASUREMENT_ID__', gaId || '__GA_MEASUREMENT_ID__')
+        .replaceAll('__MAIN_SITE_URL__', mainSiteUrl || '__MAIN_SITE_URL__')
+        .replaceAll('__MAIN_SITE_NAME__', mainSiteName || '__MAIN_SITE_NAME__')
     },
     configureServer(server) {
       server.middlewares.use(rewriteRequest)
@@ -40,9 +45,11 @@ function gaPlaceholderRewritePlugin(gaId) {
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const gaMeasurementId = env.VITE_GA_MEASUREMENT_ID || process.env.VITE_GA_MEASUREMENT_ID || '__GA_MEASUREMENT_ID__'
+  const mainSiteUrl = env.VITE_MAIN_SITE_URL || process.env.VITE_MAIN_SITE_URL || 'https://www.valleyofai.com'
+  const mainSiteName = env.VITE_MAIN_SITE_NAME || process.env.VITE_MAIN_SITE_NAME || 'Valley of AI'
 
   return {
-    plugins: [react(), gaPlaceholderRewritePlugin(gaMeasurementId)],
+    plugins: [react(), appPlaceholderRewritePlugin(gaMeasurementId, mainSiteUrl, mainSiteName)],
     base: '/',
     define: {
       __APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## Summary
This PR ships env-driven branding and shared app shell standardization across standalone apps.

## Changes
- Added shared shell runtime: apps/shared/app-shell.js (common header/footer/theme toggle behavior).
- Made shell footer fully env-driven:
  - URL: VITE_MAIN_SITE_URL -> __MAIN_SITE_URL__
  - Label: VITE_MAIN_SITE_NAME -> __MAIN_SITE_NAME__
- Added shell meta/script tags across all standalone app index files.
- Extended placeholder rewrite/injection in vite.config.js and scripts/inject-ga-id.js to include URL + name placeholders.
- Added env template keys in .env.example.
- Updated main React app branding to use VITE_MAIN_SITE_NAME in Header and footer copyright.
- Updated README and AGENT_PROMPT protocol docs.
- Included fishing-frenzy shell compatibility fix (instructions offset + dark-mode text fallback in shell).

## Validation
- npm run build passed
- npm run predeploy passed
- predeploy confirmed GA, main site URL, and main site name injection