### PR TITLE
chore(apps): standardize standalone app title format

### DIFF
--- a/apps/2026/03/05/breathing-orb/index.html
+++ b/apps/2026/03/05/breathing-orb/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Breathing Orb - Valley of AI</title>
+  <title>Breathing Orb - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🫧%3C/text%3E%3C/svg%3E">
   <meta name="description" content="A calming guided breathing app with animated orb and configurable inhale/exhale rhythm." />
   <style>

--- a/apps/2026/03/05/color-palette-generator/index.html
+++ b/apps/2026/03/05/color-palette-generator/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Color Palette Generator - Valley of AI</title>
+  <title>Color Palette Generator - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🎨%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/05/example-app/index.html
+++ b/apps/2026/03/05/example-app/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Example App - Valley of AI</title>
+  <title>Example App - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🎉%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/05/pomodoro-timer/index.html
+++ b/apps/2026/03/05/pomodoro-timer/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Pomodoro Timer - Valley of AI</title>
+  <title>Pomodoro Timer - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🍅%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/05/snake-game/index.html
+++ b/apps/2026/03/05/snake-game/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <title>Snake Game - Valley of AI</title>
+  <title>Snake Game - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🐍%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/06/focus-fountain/index.html
+++ b/apps/2026/03/06/focus-fountain/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Focus Fountain - Valley of AI</title>
+  <title>Focus Fountain - __MAIN_SITE_NAME__</title>
   <meta name="description" content="A playful focus timer where steady work grows a glowing fountain." />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E⛲%3C/text%3E%3C/svg%3E">
   <style>

--- a/apps/2026/03/06/habit-heatmap/index.html
+++ b/apps/2026/03/06/habit-heatmap/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Habit Heatmap - Valley of AI</title>
+  <title>Habit Heatmap - __MAIN_SITE_NAME__</title>
   <meta name="description" content="Track your weekly habits with a tactile heatmap board and streak stats." />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect x='8' y='8' width='48' height='48' rx='10' fill='%2322c55e'/%3E%3Cpath d='M20 38h24M20 30h24M20 22h24' stroke='white' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
   <style>

--- a/apps/2026/03/06/memory-match/index.html
+++ b/apps/2026/03/06/memory-match/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Memory Match</title>
+  <title>Memory Match - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🧠%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/06/reaction-ripple/index.html
+++ b/apps/2026/03/06/reaction-ripple/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Reaction Ripple — Valley of AI</title>
+  <title>Reaction Ripple - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E⚡%3C/text%3E%3C/svg%3E">
   <style>
     :root{

--- a/apps/2026/03/06/sorting-visualizer/index.html
+++ b/apps/2026/03/06/sorting-visualizer/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sorting Algorithm Visualizer</title>
+  <title>Sorting Algorithm Visualizer - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E📊%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/06/word-scramble/index.html
+++ b/apps/2026/03/06/word-scramble/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Word Scramble - Valley of AI</title>
+  <title>Word Scramble - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🔤%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/06/word-weaver/index.html
+++ b/apps/2026/03/06/word-weaver/index.html
@@ -10,7 +10,7 @@
       gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
   <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Word Weaver - Valley of AI</title>
+  <title>Word Weaver - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🧵%3C/text%3E%3C/svg%3E">
   <style>
     :root{--bg:#0f172a;--bg2:#1e293b;--surface:#111827;--text:#f1f5f9;--muted:#94a3b8;--primary:#8b5cf6;--accent:#22d3ee}

--- a/apps/2026/03/07/archery-physics/index.html
+++ b/apps/2026/03/07/archery-physics/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Archery Physics</title>
+  <title>Archery Physics - __MAIN_SITE_NAME__</title>
   <style>
     :root {
       --sky-top: #87CEEB;

--- a/apps/2026/03/07/blackjack/index.html
+++ b/apps/2026/03/07/blackjack/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Blackjack</title>
+  <title>Blackjack - __MAIN_SITE_NAME__</title>
   <style>
     :root {
       --felt-green: #0d5c2e;

--- a/apps/2026/03/07/contrast-lab/index.html
+++ b/apps/2026/03/07/contrast-lab/index.html
@@ -12,7 +12,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Contrast Lab helps you tune foreground/background colors to meet WCAG accessibility targets." />
-  <title>Contrast Lab • Valley of AI</title>
+  <title>Contrast Lab - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230f172a'/%3E%3Ccircle cx='24' cy='32' r='12' fill='%23f8fafc'/%3E%3Ccircle cx='40' cy='32' r='12' fill='%230ea5e9'/%3E%3C/svg%3E" />
   <style>
     :root {

--- a/apps/2026/03/07/debug-rush/index.html
+++ b/apps/2026/03/07/debug-rush/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Debug Rush - Valley of AI</title>
+  <title>Debug Rush - __MAIN_SITE_NAME__</title>
   <style>
     :root {
       --bg: #0f172a;

--- a/apps/2026/03/07/design-dash/index.html
+++ b/apps/2026/03/07/design-dash/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Design Dash - Valley of AI</title>
+  <title>Design Dash - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎨</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/07/disco-runner/index.html
+++ b/apps/2026/03/07/disco-runner/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <title>Disco Runner - Valley of AI</title>
+  <title>Disco Runner - __MAIN_SITE_NAME__</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕺</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/07/fishing-frenzy/index.html
+++ b/apps/2026/03/07/fishing-frenzy/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <title>Fishing Frenzy - Valley of AI</title>
+  <title>Fishing Frenzy - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎣</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/07/flappy-bird/index.html
+++ b/apps/2026/03/07/flappy-bird/index.html
@@ -12,7 +12,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <meta name="description" content="A classic Flappy Bird clone - tap to fly through the pipes!" />
-  <title>Flappy Bird • Valley of AI</title>
+  <title>Flappy Bird - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🐦%3C/text%3E%3C/svg%3E" />
   <style>
     :root {

--- a/apps/2026/03/07/halftime-hustle/index.html
+++ b/apps/2026/03/07/halftime-hustle/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Halftime Hustle - Valley of AI</title>
+  <title>Halftime Hustle - __MAIN_SITE_NAME__</title>
   <style>
     :root {
       --bg: #1a1a2e;

--- a/apps/2026/03/07/neon-velocity/index.html
+++ b/apps/2026/03/07/neon-velocity/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <title>Neon Velocity - Valley of AI</title>
+  <title>Neon Velocity - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/07/pacman-classic/index.html
+++ b/apps/2026/03/07/pacman-classic/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Pacman Classic - Valley of AI</title>
+  <title>Pacman Classic - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🟡%3C/text%3E%3C/svg%3E">
   <style>
     :root {

--- a/apps/2026/03/07/realtor-tycoon/index.html
+++ b/apps/2026/03/07/realtor-tycoon/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Realtor Tycoon - Valley of AI</title>
+  <title>Realtor Tycoon - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/07/road-rage/index.html
+++ b/apps/2026/03/07/road-rage/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-  <title>Road Rage - Valley of AI</title>
+  <title>Road Rage - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏎️</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/07/workout-timer-pulse/index.html
+++ b/apps/2026/03/07/workout-timer-pulse/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Workout Timer Pulse - Valley of AI</title>
+  <title>Workout Timer Pulse - __MAIN_SITE_NAME__</title>
   <style>
     :root{--bg:#0b1220;--bg2:#15243d;--surface:#101a30;--text:#eaf1ff;--muted:#98abd4;--primary:#22d3ee;--accent:#8b5cf6;--work:#22c55e;--rest:#f59e0b;--ready:#60a5fa}
     [data-theme="light"]{--bg:#eef5ff;--bg2:#dbeafe;--surface:#fff;--text:#1f2f52;--muted:#5f7198;--primary:#0891b2;--accent:#6d28d9;--work:#15803d;--rest:#b45309;--ready:#2563eb}

--- a/apps/2026/03/07/zorkish-text-adventure/index.html
+++ b/apps/2026/03/07/zorkish-text-adventure/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Lantern of Hollowmere - Valley of AI</title>
+  <title>Lantern of Hollowmere - __MAIN_SITE_NAME__</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🕯️%3C/text%3E%3C/svg%3E">
   <style>
     :root{--bg:#0b0f1a;--bg2:#161d2f;--surface:#121827;--text:#e8eefc;--muted:#97a6ca;--accent:#7c3aed;--accent2:#22d3ee;--ok:#34d399}

--- a/apps/2026/03/08/daredevil-moto-jump/index.html
+++ b/apps/2026/03/08/daredevil-moto-jump/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Daredevil Moto Jump - Valley of AI</title>
+  <title>Daredevil Moto Jump - __MAIN_SITE_NAME__</title>
   <style>
     :root {
       --bg: #0a0a1a;

--- a/apps/2026/03/08/eagle-eye-teacher/index.html
+++ b/apps/2026/03/08/eagle-eye-teacher/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Eagle Eye Teacher - Valley of AI</title>
+  <title>Eagle Eye Teacher - __MAIN_SITE_NAME__</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦅</text></svg>">
   <style>
     :root {

--- a/apps/2026/03/08/logic-lights-out/index.html
+++ b/apps/2026/03/08/logic-lights-out/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Logic Lights Out · Valley of AI</title>
+  <title>Logic Lights Out - __MAIN_SITE_NAME__</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%92%A1%3C/text%3E%3C/svg%3E" />
   <style>
     :root {

--- a/apps/2026/03/08/mini-putt-gauntlet/index.html
+++ b/apps/2026/03/08/mini-putt-gauntlet/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Mini Putt Gauntlet - Valley of AI</title>
+  <title>Mini Putt Gauntlet - __MAIN_SITE_NAME__</title>
   <meta name="description" content="Play a 3-hole mini putt challenge with a moving windmill, a closing gate, and a trap door. Par is 3 on every hole." />
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='22' fill='%231f7a4c'/%3E%3Ccircle cx='66' cy='34' r='16' fill='%23f5f7ff'/%3E%3Ccircle cx='66' cy='34' r='6' fill='%2314213d'/%3E%3C/svg%3E" />
   <style>

--- a/apps/2026/03/08/orbit-harmonics/index.html
+++ b/apps/2026/03/08/orbit-harmonics/index.html
@@ -11,7 +11,7 @@
     </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Orbit Harmonics · Valley of AI</title>
+  <title>Orbit Harmonics - __MAIN_SITE_NAME__</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='36' fill='%230f172a'/%3E%3Ccircle cx='50' cy='24' r='9' fill='%23f59e0b'/%3E%3C/svg%3E" />
   <style>
     :root {

--- a/apps/2026/03/08/space-invaders-clone/index.html
+++ b/apps/2026/03/08/space-invaders-clone/index.html
@@ -10,7 +10,7 @@
       gtag('config', '__GA_MEASUREMENT_ID__');
     </script>
 <meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Space Invaders Clone - Valley of AI</title>
+<title>Space Invaders Clone - __MAIN_SITE_NAME__</title>
 <style>
 :root{--bg:#0a1020;--bg2:#162448;--surface:#0f1730;--text:#edf3ff;--muted:#9ab0e0;--primary:#22d3ee;--enemy:#f43f5e;--player:#4ade80;--bullet:#fef08a}
 [data-theme="light"]{--bg:#edf4ff;--bg2:#dbeafe;--surface:#fff;--text:#1f2f52;--muted:#60739a;--primary:#0891b2;--enemy:#be123c;--player:#15803d;--bullet:#b45309}

--- a/apps/2026/03/08/typing-speed-sprint/index.html
+++ b/apps/2026/03/08/typing-speed-sprint/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Typing Speed Sprint</title>
+	<title>Typing Speed Sprint - __MAIN_SITE_NAME__</title>
 
 	<!-- Google tag (gtag.js) -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>

--- a/apps/2026/03/09/gravity-dodge/index.html
+++ b/apps/2026/03/09/gravity-dodge/index.html
@@ -1,4 +1,4 @@
-<!doctype html><html lang='en'><head><meta charset='UTF-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Gravity Dodge</title><style>
+<!doctype html><html lang='en'><head><meta charset='UTF-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Gravity Dodge - __MAIN_SITE_NAME__</title><style>
 :root{--bg:#0b1220;--bg2:#1b2a4a;--surface:#101a31;--text:#edf3ff;--muted:#9eb1da;--player:#22d3ee;--haz:#ef4444;--orb:#a78bfa}
 [data-theme='light']{--bg:#eef4ff;--bg2:#dbeafe;--surface:#fff;--text:#1f2f52;--muted:#60739a;--player:#0891b2;--haz:#b91c1c;--orb:#7c3aed}
 *{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:16px;font-family:Inter,system-ui;background:radial-gradient(1000px 700px at 20% 20%,var(--bg2),var(--bg));color:var(--text)}

--- a/apps/2026/03/09/pixel-planet-clicker/index.html
+++ b/apps/2026/03/09/pixel-planet-clicker/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Pixel Planet Clicker - Valley of AI</title>
+  <title>Pixel Planet Clicker - __MAIN_SITE_NAME__</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='88'%3E%F0%9F%8C%8D%3C/text%3E%3C/svg%3E">
 
   <!-- Google tag (gtag.js) -->


### PR DESCRIPTION
## Summary
- standardize all standalone app `<title>` tags to use the shared format: `App Name - __MAIN_SITE_NAME__`
- align titles with AGENT_PROMPT protocol and env-driven branding strategy
- apply changes across all current standalone apps (36 files)

## Why
- keeps generated app titles consistent with project conventions
- ensures site branding remains centrally configurable via env placeholder injection
- prevents drift between prompt requirements and actual app HTML

## Validation
- audited all `apps/**/index.html` before update: 36 mismatches
- updated titles from each app `meta.json` name
- re-audited after update: 0 mismatches
- diff scope: title-line replacement only in app HTML files