### PR TITLE
fix(analytics): restore gtag coverage and preserve app referrer

### DIFF
--- a/apps/2026/03/09/gravity-dodge/index.html
+++ b/apps/2026/03/09/gravity-dodge/index.html
@@ -1,4 +1,12 @@
-<!doctype html><html lang='en'><head><meta charset='UTF-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Gravity Dodge - __MAIN_SITE_NAME__</title><style>
+<!doctype html><html lang='en'><head><meta charset='UTF-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Gravity Dodge - __MAIN_SITE_NAME__</title>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', '__GA_MEASUREMENT_ID__');
+	</script><style>
 :root{--bg:#0b1220;--bg2:#1b2a4a;--surface:#101a31;--text:#edf3ff;--muted:#9eb1da;--player:#22d3ee;--haz:#ef4444;--orb:#a78bfa}
 [data-theme='light']{--bg:#eef4ff;--bg2:#dbeafe;--surface:#fff;--text:#1f2f52;--muted:#60739a;--player:#0891b2;--haz:#b91c1c;--orb:#7c3aed}
 *{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:16px;font-family:Inter,system-ui;background:radial-gradient(1000px 700px at 20% 20%,var(--bg2),var(--bg));color:var(--text)}

--- a/src/pages/AppDetailPage.jsx
+++ b/src/pages/AppDetailPage.jsx
@@ -103,7 +103,7 @@ export default function AppDetailPage() {
           <a
             href={app.appPath}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="btn-primary"
           >
             Open App


### PR DESCRIPTION
## Summary
- add the standard GA4 gtag snippet back to `apps/2026/03/09/gravity-dodge/index.html`
- update app launch link in `src/pages/AppDetailPage.jsx` from `rel="noopener noreferrer"` to `rel="noopener"`

## Why
- `gravity-dodge` was missing the GA loader/config block, so visits to that app would not be counted
- `noreferrer` suppressed referrer data when opening standalone apps from the main site, reducing attribution quality in GA

## Validation
- audited all standalone app pages (`36/36`) for exactly one GA loader, one `dataLayer` init, and one `gtag('config')`
- confirmed no remaining app page is missing the GA snippet
- confirmed the app detail launch link preserves `noopener` while allowing referrer