### PR TITLE
chore(dev): show startup reminder via dev launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node ./node_modules/vite/bin/vite.js",
+    "dev": "node scripts/dev.js",
     "validate:apps": "node scripts/validate-apps.js",
     "build": "npm run validate:apps && npm run generate:apps && node ./node_modules/vite/bin/vite.js build",
     "preview": "node ./node_modules/vite/bin/vite.js preview",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+
+process.stdout.write('\x1Bc');
+
+console.log("\n📌 Don't forget to run 'npm run generate:apps' if an app has been added\n");
+
+const vite = spawn('node', ['./node_modules/vite/bin/vite.js', '--clearScreen', 'false'], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+vite.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
Summary: replaces inline dev command with scripts/dev.js so npm output is cleaner, prints the reminder message, and clears the screen at startup before launching Vite with clearScreen disabled. Scope: package.json + scripts/dev.js only.