### PR TITLE
fix: flappy-bird desktop header/footer full-width

### DIFF
--- a/apps/2026/03/07/flappy-bird/index.html
+++ b/apps/2026/03/07/flappy-bird/index.html
@@ -55,7 +55,7 @@
 
     header {
       width: 100%;
-      max-width: 480px;
+      max-width: none;
       padding: 1rem;
       display: flex;
       justify-content: space-between;
@@ -197,7 +197,7 @@
       border-top: 1px solid var(--text-secondary);
       opacity: 0.7;
       width: 100%;
-      max-width: 480px;
+      max-width: none;
     }
 
     footer a {


### PR DESCRIPTION
## Summary\nAdjust Flappy Bird desktop layout so top/bottom chrome spans full width while preserving the game canvas/container sizing.\n\n### Changes\n- header  -> \n- footer  -> \n-  remains  (unchanged)\n\n## Validation\n- 
> valley-of-ai@0.1.83 validate:apps
> node scripts/validate-apps.js --only flappy-bird

Validated 41 app index.html file(s): all passed.
Validated 41 app meta.json file(s): all passed. ✅\n  - Validated app index/meta checks passed