### PR TITLE
feat: add cyber-hop cyberpunk Frogger game

### DIFF
--- a/apps/2026/03/18/cyber-hop/index.html
+++ b/apps/2026/03/18/cyber-hop/index.html
@@ -1,0 +1,1261 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <title>Cyber Hop - __MAIN_SITE_NAME__</title>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '__GA_MEASUREMENT_ID__');
+    </script>
+
+    <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+    <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+    <meta name="voa-social-x-url" content="__SOCIAL_X_URL__">
+    <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__">
+    <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__">
+    <script src="/apps/shared/app-shell.js" defer></script>
+
+    <style>
+      :root {
+        --bg: #0f172a;
+        --text: #f9fafb;
+        --surface: #1e293b;
+        --neon-cyan: #00f5ff;
+        --neon-pink: #ff00aa;
+        --neon-yellow: #ffe600;
+        --neon-green: #00ff88;
+        --neon-purple: #bb00ff;
+        --neon-orange: #ff6600;
+        --grid-size: 52px;
+      }
+      [data-theme='light'] {
+        --bg: #ffffff;
+        --text: #1f2937;
+        --surface: #f3f4f6;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: 'Courier New', monospace;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        min-height: 100vh;
+        overflow: hidden;
+        touch-action: none;
+      }
+
+      #game-wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+        max-width: 520px;
+        padding: 8px 8px 0;
+        gap: 8px;
+        user-select: none;
+      }
+
+      #hud {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        padding: 4px 8px;
+        background: var(--surface);
+        border: 1px solid var(--neon-cyan);
+        border-radius: 6px;
+        font-size: 13px;
+        box-shadow: 0 0 10px rgba(0, 245, 255, 0.3);
+      }
+
+      .hud-stat {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1px;
+      }
+
+      .hud-label {
+        font-size: 9px;
+        color: var(--neon-cyan);
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+
+      .hud-value {
+        font-size: 15px;
+        font-weight: bold;
+        color: var(--neon-yellow);
+        text-shadow: 0 0 8px var(--neon-yellow);
+      }
+
+      #lives-display {
+        display: flex;
+        gap: 4px;
+        font-size: 16px;
+      }
+
+      #warp-bar-wrap {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+      }
+
+      #warp-bar {
+        width: 80px;
+        height: 8px;
+        background: rgba(187, 0, 255, 0.2);
+        border: 1px solid var(--neon-purple);
+        border-radius: 4px;
+        overflow: hidden;
+      }
+
+      #warp-fill {
+        height: 100%;
+        background: linear-gradient(90deg, var(--neon-purple), var(--neon-cyan));
+        border-radius: 4px;
+        transition: width 0.3s ease;
+        width: 100%;
+        box-shadow: 0 0 6px var(--neon-purple);
+      }
+
+      #canvas-container {
+        position: relative;
+        width: 100%;
+        line-height: 0;
+      }
+
+      #gameCanvas {
+        width: 100%;
+        height: auto;
+        display: block;
+        border: 1px solid rgba(0, 245, 255, 0.3);
+        border-radius: 8px;
+        box-shadow: 0 0 20px rgba(0, 245, 255, 0.15), inset 0 0 40px rgba(0, 0, 30, 0.5);
+      }
+
+      /* Overlay screens */
+      .overlay {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: rgba(10, 15, 40, 0.92);
+        border-radius: 8px;
+        gap: 14px;
+        backdrop-filter: blur(4px);
+        z-index: 10;
+      }
+
+      .overlay.hidden {
+        display: none;
+      }
+
+      .overlay h1 {
+        font-size: clamp(22px, 6vw, 36px);
+        color: var(--neon-cyan);
+        text-shadow:
+          0 0 10px var(--neon-cyan),
+          0 0 30px var(--neon-cyan);
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        text-align: center;
+      }
+
+      .overlay h2 {
+        font-size: clamp(16px, 4vw, 24px);
+        color: var(--neon-pink);
+        text-shadow: 0 0 10px var(--neon-pink);
+        letter-spacing: 2px;
+        text-transform: uppercase;
+      }
+
+      .overlay p {
+        font-size: clamp(11px, 2.5vw, 14px);
+        color: rgba(200, 220, 255, 0.75);
+        text-align: center;
+        line-height: 1.6;
+        max-width: 280px;
+      }
+
+      .overlay .score-display {
+        font-size: clamp(24px, 7vw, 44px);
+        color: var(--neon-yellow);
+        text-shadow:
+          0 0 12px var(--neon-yellow),
+          0 0 30px var(--neon-yellow);
+        font-weight: bold;
+      }
+
+      .btn {
+        padding: 10px 28px;
+        font-family: 'Courier New', monospace;
+        font-size: 14px;
+        font-weight: bold;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        background: transparent;
+        border: 2px solid var(--neon-cyan);
+        color: var(--neon-cyan);
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+        box-shadow: 0 0 10px rgba(0, 245, 255, 0.3);
+        text-shadow: 0 0 6px var(--neon-cyan);
+      }
+
+      .btn:hover,
+      .btn:active {
+        background: rgba(0, 245, 255, 0.12);
+        box-shadow: 0 0 20px rgba(0, 245, 255, 0.6);
+        transform: scale(1.04);
+      }
+
+      .btn-pink {
+        border-color: var(--neon-pink);
+        color: var(--neon-pink);
+        box-shadow: 0 0 10px rgba(255, 0, 170, 0.3);
+        text-shadow: 0 0 6px var(--neon-pink);
+      }
+
+      .btn-pink:hover,
+      .btn-pink:active {
+        background: rgba(255, 0, 170, 0.12);
+        box-shadow: 0 0 20px rgba(255, 0, 170, 0.6);
+      }
+
+      /* D-Pad controls */
+      #dpad {
+        display: grid;
+        grid-template-areas:
+          '. up .'
+          'left . right'
+          '. down .';
+        gap: 4px;
+        width: 150px;
+        height: 150px;
+      }
+
+      .dpad-btn {
+        width: 46px;
+        height: 46px;
+        background: rgba(0, 245, 255, 0.08);
+        border: 1px solid rgba(0, 245, 255, 0.4);
+        border-radius: 8px;
+        color: var(--neon-cyan);
+        font-size: 22px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.1s;
+        -webkit-tap-highlight-color: transparent;
+        touch-action: manipulation;
+      }
+
+      .dpad-btn:active,
+      .dpad-btn.pressed {
+        background: rgba(0, 245, 255, 0.25);
+        box-shadow: 0 0 14px rgba(0, 245, 255, 0.5);
+        transform: scale(0.92);
+      }
+
+      #btn-up {
+        grid-area: up;
+      }
+      #btn-left {
+        grid-area: left;
+      }
+      #btn-right {
+        grid-area: right;
+      }
+      #btn-down {
+        grid-area: down;
+      }
+
+      #controls-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+        padding: 4px 8px 8px;
+      }
+
+      #warp-btn {
+        width: 80px;
+        height: 80px;
+        border-radius: 50%;
+        background: rgba(187, 0, 255, 0.1);
+        border: 2px solid var(--neon-purple);
+        color: var(--neon-purple);
+        font-size: 10px;
+        font-family: 'Courier New', monospace;
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        -webkit-tap-highlight-color: transparent;
+        touch-action: manipulation;
+        transition: all 0.15s;
+        box-shadow: 0 0 10px rgba(187, 0, 255, 0.3);
+        text-shadow: 0 0 6px var(--neon-purple);
+      }
+
+      #warp-btn .warp-icon {
+        font-size: 24px;
+      }
+
+      #warp-btn:active,
+      #warp-btn.active {
+        background: rgba(187, 0, 255, 0.3);
+        box-shadow: 0 0 24px rgba(187, 0, 255, 0.7);
+        transform: scale(0.94);
+      }
+
+      #warp-btn.disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
+
+      #keyboard-hint {
+        font-size: 10px;
+        color: rgba(150, 180, 220, 0.45);
+        text-align: center;
+        padding-bottom: 4px;
+        letter-spacing: 0.5px;
+      }
+
+      @media (min-width: 480px) {
+        :root {
+          --grid-size: 56px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="game-wrapper">
+      <!-- HUD -->
+      <div id="hud">
+        <div class="hud-stat">
+          <span class="hud-label">Score</span>
+          <span class="hud-value" id="score-val">0</span>
+        </div>
+        <div class="hud-stat">
+          <span class="hud-label">Best</span>
+          <span class="hud-value" id="best-val">0</span>
+        </div>
+        <div class="hud-stat">
+          <span class="hud-label">Level</span>
+          <span class="hud-value" id="level-val">1</span>
+        </div>
+        <div class="hud-stat">
+          <span class="hud-label">Lives</span>
+          <span id="lives-display"></span>
+        </div>
+        <div class="hud-stat" id="warp-bar-wrap">
+          <span class="hud-label">Warp</span>
+          <div id="warp-bar"><div id="warp-fill"></div></div>
+        </div>
+      </div>
+
+      <!-- Canvas -->
+      <div id="canvas-container">
+        <canvas id="gameCanvas"></canvas>
+
+        <!-- Start overlay -->
+        <div class="overlay" id="start-overlay">
+          <h1>Cyber Hop</h1>
+          <p>
+            Navigate your cyber-frog across neon highways and data streams.<br />
+            Reach the safe zones at the top!
+          </p>
+          <p>⬆⬇⬅➡ Arrow keys &nbsp;|&nbsp; WASD &nbsp;|&nbsp; Swipe &nbsp;|&nbsp; D-Pad</p>
+          <p>
+            <span style="color: var(--neon-purple)">⚡ TIME WARP</span> — slow down obstacles (Space
+            / Warp button)
+          </p>
+          <button class="btn" id="start-btn">▶ &nbsp;START</button>
+        </div>
+
+        <!-- Game over overlay -->
+        <div class="overlay hidden" id="gameover-overlay">
+          <h2>Game Over</h2>
+          <div class="score-display" id="final-score">0</div>
+          <p id="gameover-msg">Try again?</p>
+          <div style="display: flex; gap: 12px">
+            <button class="btn" id="restart-btn">↺ &nbsp;Retry</button>
+          </div>
+        </div>
+
+        <!-- Level up overlay -->
+        <div class="overlay hidden" id="levelup-overlay">
+          <h2 style="color: var(--neon-green)">Level Up!</h2>
+          <div
+            class="score-display"
+            id="levelup-num"
+            style="color: var(--neon-green); text-shadow: 0 0 16px var(--neon-green)"
+          >
+            2
+          </div>
+          <p style="color: rgba(0,255,136,0.8)">Speed increased!</p>
+        </div>
+      </div>
+
+      <!-- Mobile controls -->
+      <div id="controls-row">
+        <div id="dpad">
+          <button class="dpad-btn" id="btn-up" aria-label="Up">▲</button>
+          <button class="dpad-btn" id="btn-left" aria-label="Left">◀</button>
+          <button class="dpad-btn" id="btn-right" aria-label="Right">▶</button>
+          <button class="dpad-btn" id="btn-down" aria-label="Down">▼</button>
+        </div>
+        <button id="warp-btn" aria-label="Time Warp">
+          <span class="warp-icon">⚡</span>
+          <span>WARP</span>
+        </button>
+      </div>
+
+      <div id="keyboard-hint">Keyboard: Arrow Keys / WASD &nbsp;·&nbsp; Space = Time Warp</div>
+    </div>
+
+    <script>
+      (() => {
+        'use strict';
+
+        // ─── Constants ───────────────────────────────────────────────
+        const COLS = 9;
+        const ROWS = 13; // 1 safe top, 5 stream, 1 safe mid, 5 road, 1 safe bottom
+        const CELL = 52;
+        const W = COLS * CELL;
+        const H = ROWS * CELL;
+        const FROG_TWEEN_DURATION = 110; // ms for movement tween
+        const DEATH_FLASH_MS = 700;
+        const LEVELUP_SHOW_MS = 1400;
+        const WARP_DURATION_MS = 4000;
+        const WARP_COOLDOWN_MS = 10000;
+        const WARP_SLOW = 0.28;
+
+        // Row layout (row 0 = top)
+        // 0: safe zone (home pads)
+        // 1-5: data streams (platforms move on these)
+        // 6: safe zone (median)
+        // 7-11: cyber roads (vehicles)
+        // 12: safe zone (spawn)
+
+        const ROW_SAFE = new Set([0, 6, 12]);
+        const ROW_STREAM = [1, 2, 3, 4, 5];
+        const ROW_ROAD = [7, 8, 9, 10, 11];
+
+        const HOME_COLS = [1, 3, 5, 7]; // goal positions in row 0
+        const HOMES_TOTAL = HOME_COLS.length;
+
+        // ─── Canvas setup ────────────────────────────────────────────
+        const canvas = document.getElementById('gameCanvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = W;
+        canvas.height = H;
+
+        // ─── State ───────────────────────────────────────────────────
+        let score = 0;
+        let best = parseInt(localStorage.getItem('cyberHopBest') || '0');
+        let lives = 3;
+        let level = 1;
+        let homesReached = new Set();
+        let gameState = 'idle'; // idle | playing | dead | gameover | levelup
+
+        let frog = { col: 4, row: 12, drawX: 4 * CELL, drawY: 12 * CELL };
+        let tweenFrom = null;
+        let tweenStart = 0;
+
+        let lanes = [];
+        let particles = [];
+        let deathFlash = 0;
+        let lastTime = 0;
+
+        let warpActive = false;
+        let warpMs = 0;
+        let warpCooldown = 0;
+        let warpCharge = 1.0;
+
+        // Touch swipe
+        let touchStart = null;
+
+        // ─── DOM refs ────────────────────────────────────────────────
+        const scoreEl = document.getElementById('score-val');
+        const bestEl = document.getElementById('best-val');
+        const levelEl = document.getElementById('level-val');
+        const livesEl = document.getElementById('lives-display');
+        const warpFill = document.getElementById('warp-fill');
+        const startOverlay = document.getElementById('start-overlay');
+        const gameoverOverlay = document.getElementById('gameover-overlay');
+        const levelupOverlay = document.getElementById('levelup-overlay');
+        const finalScore = document.getElementById('final-score');
+        const gameoverMsg = document.getElementById('gameover-msg');
+        const levelupNum = document.getElementById('levelup-num');
+        const warpBtn = document.getElementById('warp-btn');
+
+        bestEl.textContent = best;
+
+        // ─── Lane definitions ─────────────────────────────────────────
+        function buildLanes(lvl) {
+          const spd = 1 + (lvl - 1) * 0.18;
+          lanes = [];
+
+          // Data streams (rows 1-5): moving platforms
+          const streamDefs = [
+            { dir: 1, baseSpeed: 1.1, platformW: 2, count: 3 },
+            { dir: -1, baseSpeed: 1.5, platformW: 2, count: 2 },
+            { dir: 1, baseSpeed: 1.8, platformW: 1, count: 3 },
+            { dir: -1, baseSpeed: 1.3, platformW: 3, count: 2 },
+            { dir: 1, baseSpeed: 2.0, platformW: 1, count: 4 },
+          ];
+          ROW_STREAM.forEach((row, i) => {
+            const def = streamDefs[i];
+            const platforms = [];
+            for (let p = 0; p < def.count; p++) {
+              const offset = (p / def.count) * W;
+              platforms.push({
+                x: offset,
+                w: def.platformW * CELL,
+                h: CELL * 0.62,
+              });
+            }
+            lanes.push({
+              row,
+              type: 'stream',
+              dir: def.dir,
+              speed: def.baseSpeed * spd,
+              platforms,
+            });
+          });
+
+          // Roads (rows 7-11): cyber vehicles
+          const roadDefs = [
+            { dir: -1, baseSpeed: 2.4, vehW: 1.8, count: 3, color: '#ff00aa' },
+            { dir: 1, baseSpeed: 1.8, vehW: 2.4, count: 2, color: '#00f5ff' },
+            { dir: -1, baseSpeed: 3.0, vehW: 1.4, count: 4, color: '#ff6600' },
+            { dir: 1, baseSpeed: 2.2, vehW: 2.0, count: 3, color: '#ffe600' },
+            { dir: -1, baseSpeed: 2.8, vehW: 1.6, count: 2, color: '#00ff88' },
+          ];
+          ROW_ROAD.forEach((row, i) => {
+            const def = roadDefs[i];
+            const vehicles = [];
+            for (let v = 0; v < def.count; v++) {
+              const offset = (v / def.count) * W + (def.dir === -1 ? W - def.vehW * CELL : 0);
+              vehicles.push({ x: offset, w: def.vehW * CELL, h: CELL * 0.7, color: def.color });
+            }
+            lanes.push({
+              row,
+              type: 'road',
+              dir: def.dir,
+              speed: def.baseSpeed * spd,
+              vehicles,
+            });
+          });
+        }
+
+        // ─── Particles ───────────────────────────────────────────────
+        function spawnParticles(cx, cy, color, count) {
+          for (let i = 0; i < count; i++) {
+            const angle = Math.random() * Math.PI * 2;
+            const speed = 1.5 + Math.random() * 3;
+            particles.push({
+              x: cx,
+              y: cy,
+              vx: Math.cos(angle) * speed,
+              vy: Math.sin(angle) * speed,
+              life: 1,
+              decay: 0.025 + Math.random() * 0.03,
+              r: 2 + Math.random() * 4,
+              color,
+            });
+          }
+        }
+
+        // ─── Reset / Init ─────────────────────────────────────────────
+        function resetFrog() {
+          frog.col = 4;
+          frog.row = 12;
+          frog.drawX = 4 * CELL;
+          frog.drawY = 12 * CELL;
+          tweenFrom = null;
+        }
+
+        function startGame() {
+          score = 0;
+          lives = 3;
+          level = 1;
+          homesReached = new Set();
+          warpActive = false;
+          warpMs = 0;
+          warpCooldown = 0;
+          warpCharge = 1.0;
+          particles = [];
+          buildLanes(level);
+          resetFrog();
+          updateHUD();
+          gameState = 'playing';
+          startOverlay.classList.add('hidden');
+          gameoverOverlay.classList.add('hidden');
+          levelupOverlay.classList.add('hidden');
+        }
+
+        function updateHUD() {
+          scoreEl.textContent = score;
+          bestEl.textContent = best;
+          levelEl.textContent = level;
+          livesEl.innerHTML = Array(lives).fill('🐸').join('') + Array(3 - lives).fill('💀').join('');
+          warpFill.style.width = warpCharge * 100 + '%';
+          warpBtn.classList.toggle('disabled', warpCharge < 1 || warpActive);
+          warpBtn.classList.toggle('active', warpActive);
+        }
+
+        // ─── Movement ────────────────────────────────────────────────
+        function tryMove(dc, dr) {
+          if (gameState !== 'playing') return;
+          if (tweenFrom) return; // mid-tween: queue nothing (simple approach)
+
+          const newCol = frog.col + dc;
+          const newRow = frog.row + dr;
+
+          if (newCol < 0 || newCol >= COLS || newRow < 0 || newRow >= ROWS) return;
+
+          // Save tween origin
+          tweenFrom = { x: frog.drawX, y: frog.drawY };
+          tweenStart = performance.now();
+
+          frog.col = newCol;
+          frog.row = newRow;
+
+          // Score for moving forward
+          if (dr < 0) {
+            const rowBonus = Math.max(0, 12 - newRow) * 10;
+            score += rowBonus;
+            if (score > best) {
+              best = score;
+              localStorage.setItem('cyberHopBest', best);
+            }
+            updateHUD();
+          }
+
+          // Check home
+          if (newRow === 0 && HOME_COLS.includes(newCol) && !homesReached.has(newCol)) {
+            homesReached.add(newCol);
+            score += 200;
+            if (score > best) {
+              best = score;
+              localStorage.setItem('cyberHopBest', best);
+            }
+            spawnParticles(newCol * CELL + CELL / 2, CELL / 2, '#00ff88', 25);
+            updateHUD();
+
+            if (homesReached.size >= HOMES_TOTAL) {
+              // Level up!
+              level++;
+              score += 500;
+              if (score > best) {
+                best = score;
+                localStorage.setItem('cyberHopBest', best);
+              }
+              homesReached = new Set();
+              buildLanes(level);
+              resetFrog();
+              tweenFrom = null;
+              levelupNum.textContent = level;
+              levelupOverlay.classList.remove('hidden');
+              gameState = 'levelup';
+              updateHUD();
+              setTimeout(() => {
+                levelupOverlay.classList.add('hidden');
+                gameState = 'playing';
+              }, LEVELUP_SHOW_MS);
+            } else {
+              resetFrog();
+              tweenFrom = null;
+            }
+          }
+        }
+
+        // ─── Collision ───────────────────────────────────────────────
+        function checkCollision() {
+          const fx = frog.drawX;
+          const fy = frog.drawY;
+          const fw = CELL * 0.72;
+          const fh = CELL * 0.72;
+          const fLeft = fx + (CELL - fw) / 2;
+          const fRight = fLeft + fw;
+          const fTop = fy + (CELL - fh) / 2;
+          const fBottom = fTop + fh;
+
+          const row = frog.row;
+
+          // Stream rows: must be ON a platform
+          if (ROW_STREAM.includes(row)) {
+            const lane = lanes.find(l => l.row === row);
+            if (!lane) return killFrog();
+            let onPlatform = false;
+            for (const p of lane.platforms) {
+              const pl = p.x;
+              const pr = p.x + p.w;
+              const pt = row * CELL + (CELL - p.h) / 2;
+              const pb = pt + p.h;
+              if (fRight > pl + 4 && fLeft < pr - 4 && fBottom > pt + 4 && fTop < pb - 4) {
+                onPlatform = true;
+                break;
+              }
+            }
+            if (!onPlatform) killFrog();
+            return;
+          }
+
+          // Road rows: must NOT be hit by a vehicle
+          if (ROW_ROAD.includes(row)) {
+            const lane = lanes.find(l => l.row === row);
+            if (!lane) return;
+            for (const v of lane.vehicles) {
+              const vl = v.x;
+              const vr = v.x + v.w;
+              const vt = row * CELL + (CELL - v.h) / 2;
+              const vb = vt + v.h;
+              if (fRight > vl + 2 && fLeft < vr - 2 && fBottom > vt + 2 && fTop < vb - 2) {
+                killFrog();
+                return;
+              }
+            }
+          }
+        }
+
+        function killFrog() {
+          if (gameState !== 'playing') return;
+          gameState = 'dead';
+          deathFlash = DEATH_FLASH_MS;
+          spawnParticles(frog.drawX + CELL / 2, frog.drawY + CELL / 2, '#ff00aa', 30);
+          lives--;
+          updateHUD();
+          setTimeout(() => {
+            if (lives <= 0) {
+              gameState = 'gameover';
+              finalScore.textContent = score;
+              gameoverMsg.textContent =
+                score >= best ? '🏆 New High Score!' : `Best: ${best}`;
+              gameoverOverlay.classList.remove('hidden');
+            } else {
+              resetFrog();
+              tweenFrom = null;
+              gameState = 'playing';
+            }
+          }, DEATH_FLASH_MS);
+        }
+
+        // ─── Update ──────────────────────────────────────────────────
+        function update(dt) {
+          if (gameState !== 'playing' && gameState !== 'dead') return;
+
+          const slowFactor = warpActive ? WARP_SLOW : 1;
+
+          // Move lanes
+          for (const lane of lanes) {
+            const pixelSpeed = lane.speed * 60 * (dt / 1000) * slowFactor;
+            const items = lane.type === 'stream' ? lane.platforms : lane.vehicles;
+            for (const item of items) {
+              item.x += lane.dir * pixelSpeed;
+              // wrap
+              if (lane.dir > 0 && item.x > W) item.x = -item.w;
+              if (lane.dir < 0 && item.x + item.w < 0) item.x = W;
+            }
+          }
+
+          // Frog rides platform
+          if (ROW_STREAM.includes(frog.row) && !tweenFrom) {
+            const lane = lanes.find(l => l.row === frog.row);
+            if (lane) {
+              const rideSpeed = lane.speed * 60 * (dt / 1000) * slowFactor;
+              frog.drawX += lane.dir * rideSpeed;
+              frog.col = Math.round(frog.drawX / CELL);
+              if (frog.drawX < -CELL / 2 || frog.drawX > W) {
+                killFrog();
+              }
+            }
+          }
+
+          // Tween frog movement
+          if (tweenFrom) {
+            const elapsed = performance.now() - tweenStart;
+            const t = Math.min(elapsed / FROG_TWEEN_DURATION, 1);
+            const ease = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+            const targetX = frog.col * CELL;
+            const targetY = frog.row * CELL;
+            frog.drawX = tweenFrom.x + (targetX - tweenFrom.x) * ease;
+            frog.drawY = tweenFrom.y + (targetY - tweenFrom.y) * ease;
+            if (t >= 1) {
+              frog.drawX = targetX;
+              frog.drawY = targetY;
+              tweenFrom = null;
+              checkCollision();
+            }
+          }
+
+          // Collision check on road (continuous)
+          if (gameState === 'playing' && ROW_ROAD.includes(frog.row) && !tweenFrom) {
+            checkCollision();
+          }
+
+          // Death flash countdown
+          if (deathFlash > 0) deathFlash -= dt;
+
+          // Warp
+          if (warpActive) {
+            warpMs -= dt;
+            warpCharge = Math.max(0, warpMs / WARP_DURATION_MS);
+            if (warpMs <= 0) {
+              warpActive = false;
+              warpCharge = 0;
+              warpCooldown = WARP_COOLDOWN_MS;
+            }
+          } else if (warpCooldown > 0) {
+            warpCooldown -= dt;
+            warpCharge = Math.max(0, 1 - warpCooldown / WARP_COOLDOWN_MS);
+            if (warpCooldown <= 0) {
+              warpCooldown = 0;
+              warpCharge = 1;
+            }
+          }
+
+          // Particles
+          for (let i = particles.length - 1; i >= 0; i--) {
+            const p = particles[i];
+            p.x += p.vx;
+            p.y += p.vy;
+            p.vy += 0.08;
+            p.life -= p.decay;
+            if (p.life <= 0) particles.splice(i, 1);
+          }
+
+          updateHUD();
+        }
+
+        // ─── Draw ─────────────────────────────────────────────────────
+        function draw(now) {
+          ctx.clearRect(0, 0, W, H);
+
+          // Background grid
+          ctx.fillStyle = '#060c1a';
+          ctx.fillRect(0, 0, W, H);
+
+          // Draw lane backgrounds
+          for (let row = 0; row < ROWS; row++) {
+            const y = row * CELL;
+            if (ROW_SAFE.has(row)) {
+              ctx.fillStyle = row === 0 ? '#001a0d' : '#0a1020';
+              ctx.fillRect(0, y, W, CELL);
+              // Grid lines
+              ctx.strokeStyle = 'rgba(0,255,136,0.08)';
+              ctx.lineWidth = 1;
+              ctx.strokeRect(0.5, y + 0.5, W - 1, CELL - 1);
+            } else if (ROW_STREAM.includes(row)) {
+              // Data stream lane
+              const grad = ctx.createLinearGradient(0, y, 0, y + CELL);
+              grad.addColorStop(0, '#001a33');
+              grad.addColorStop(1, '#000d1a');
+              ctx.fillStyle = grad;
+              ctx.fillRect(0, y, W, CELL);
+              // stream glow lines
+              ctx.strokeStyle = 'rgba(0,245,255,0.06)';
+              ctx.lineWidth = 1;
+              ctx.beginPath();
+              ctx.moveTo(0, y + CELL / 2);
+              ctx.lineTo(W, y + CELL / 2);
+              ctx.stroke();
+            } else if (ROW_ROAD.includes(row)) {
+              // Road lane
+              ctx.fillStyle = '#0a0a12';
+              ctx.fillRect(0, y, W, CELL);
+              // road markings
+              ctx.strokeStyle = 'rgba(255,230,0,0.06)';
+              ctx.lineWidth = 1;
+              ctx.setLineDash([12, 16]);
+              ctx.beginPath();
+              ctx.moveTo(0, y + CELL / 2);
+              ctx.lineTo(W, y + CELL / 2);
+              ctx.stroke();
+              ctx.setLineDash([]);
+            }
+          }
+
+          // Home pads
+          HOME_COLS.forEach(col => {
+            const reached = homesReached.has(col);
+            const px = col * CELL + 6;
+            const py = 6;
+            const pw = CELL - 12;
+            const ph = CELL - 12;
+            if (reached) {
+              ctx.fillStyle = 'rgba(0,255,136,0.25)';
+              ctx.shadowColor = '#00ff88';
+              ctx.shadowBlur = 12;
+            } else {
+              ctx.fillStyle = 'rgba(0,255,136,0.07)';
+              ctx.shadowBlur = 0;
+            }
+            ctx.strokeStyle = '#00ff88';
+            ctx.lineWidth = 1.5;
+            roundRect(ctx, px, py, pw, ph, 6);
+            ctx.fill();
+            ctx.stroke();
+            ctx.shadowBlur = 0;
+            if (reached) {
+              ctx.fillStyle = '#00ff88';
+              ctx.font = `${CELL * 0.45}px serif`;
+              ctx.textAlign = 'center';
+              ctx.textBaseline = 'middle';
+              ctx.fillText('🐸', col * CELL + CELL / 2, CELL / 2);
+            }
+          });
+
+          // Lane items
+          for (const lane of lanes) {
+            const y = lane.row * CELL;
+            if (lane.type === 'stream') {
+              for (const p of lane.platforms) {
+                const px = p.x;
+                const py = y + (CELL - p.h) / 2;
+                drawPlatform(ctx, px, py, p.w, p.h);
+              }
+            } else {
+              for (const v of lane.vehicles) {
+                const vx = v.x;
+                const vy = y + (CELL - v.h) / 2;
+                drawVehicle(ctx, vx, vy, v.w, v.h, v.color, lane.dir);
+              }
+            }
+          }
+
+          // Warp overlay effect
+          if (warpActive) {
+            const alpha = 0.04 + 0.03 * Math.sin(now * 0.008);
+            ctx.fillStyle = `rgba(187,0,255,${alpha})`;
+            ctx.fillRect(0, 0, W, H);
+            // scan lines
+            ctx.strokeStyle = `rgba(187,0,255,0.06)`;
+            ctx.lineWidth = 1;
+            for (let sy = 0; sy < H; sy += 4) {
+              ctx.beginPath();
+              ctx.moveTo(0, sy);
+              ctx.lineTo(W, sy);
+              ctx.stroke();
+            }
+          }
+
+          // Particles
+          for (const p of particles) {
+            ctx.globalAlpha = p.life;
+            ctx.fillStyle = p.color;
+            ctx.shadowColor = p.color;
+            ctx.shadowBlur = 6;
+            ctx.beginPath();
+            ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+            ctx.fill();
+          }
+          ctx.globalAlpha = 1;
+          ctx.shadowBlur = 0;
+
+          // Frog
+          if (gameState !== 'gameover') {
+            drawFrog(ctx, frog.drawX, frog.drawY, deathFlash > 0, now);
+          }
+        }
+
+        function drawPlatform(ctx, x, y, w, h) {
+          ctx.save();
+          ctx.shadowColor = '#00f5ff';
+          ctx.shadowBlur = 8;
+          const grad = ctx.createLinearGradient(x, y, x, y + h);
+          grad.addColorStop(0, '#003344');
+          grad.addColorStop(1, '#001a22');
+          ctx.fillStyle = grad;
+          roundRect(ctx, x, y, w, h, 6);
+          ctx.fill();
+          ctx.strokeStyle = '#00f5ff';
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+          // inner glow lines
+          ctx.strokeStyle = 'rgba(0,245,255,0.3)';
+          ctx.lineWidth = 0.5;
+          ctx.beginPath();
+          ctx.moveTo(x + 8, y + h * 0.3);
+          ctx.lineTo(x + w - 8, y + h * 0.3);
+          ctx.stroke();
+          ctx.restore();
+        }
+
+        function drawVehicle(ctx, x, y, w, h, color, dir) {
+          ctx.save();
+          ctx.shadowColor = color;
+          ctx.shadowBlur = 10;
+          const grad = ctx.createLinearGradient(x, y, x + w, y);
+          grad.addColorStop(0, color + '22');
+          grad.addColorStop(dir > 0 ? 0.7 : 0.3, color + 'aa');
+          grad.addColorStop(1, color + '22');
+          ctx.fillStyle = grad;
+          roundRect(ctx, x, y, w, h, 5);
+          ctx.fill();
+          ctx.strokeStyle = color;
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+
+          // headlights
+          const lightR = h * 0.18;
+          const lightY = y + h * 0.3;
+          const lightX = dir > 0 ? x + w - lightR * 2 - 3 : x + lightR * 2 + 3;
+          ctx.fillStyle = color;
+          ctx.shadowBlur = 14;
+          ctx.beginPath();
+          ctx.arc(lightX, lightY, lightR, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.beginPath();
+          ctx.arc(lightX, y + h - h * 0.3, lightR, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.restore();
+        }
+
+        function drawFrog(ctx, x, y, dying, now) {
+          if (dying) {
+            const flicker = Math.floor(now / 60) % 2 === 0;
+            if (!flicker) return;
+          }
+
+          ctx.save();
+          const cx = x + CELL / 2;
+          const cy = y + CELL / 2;
+          const r = CELL * 0.34;
+
+          // Glow
+          ctx.shadowColor = '#00ff88';
+          ctx.shadowBlur = dying ? 4 : 16;
+
+          // Body
+          const grad = ctx.createRadialGradient(cx - r * 0.2, cy - r * 0.2, r * 0.1, cx, cy, r);
+          grad.addColorStop(0, '#00ff88');
+          grad.addColorStop(0.6, '#00cc66');
+          grad.addColorStop(1, '#005533');
+          ctx.fillStyle = grad;
+          ctx.beginPath();
+          ctx.ellipse(cx, cy, r, r * 0.85, 0, 0, Math.PI * 2);
+          ctx.fill();
+
+          // Circuit pattern on body
+          ctx.strokeStyle = 'rgba(0,255,136,0.4)';
+          ctx.lineWidth = 1;
+          ctx.shadowBlur = 0;
+          ctx.beginPath();
+          ctx.moveTo(cx - r * 0.4, cy);
+          ctx.lineTo(cx + r * 0.4, cy);
+          ctx.moveTo(cx, cy - r * 0.3);
+          ctx.lineTo(cx, cy + r * 0.3);
+          ctx.stroke();
+
+          // Eyes
+          const eyeY = cy - r * 0.3;
+          const eyeSpread = r * 0.38;
+          const eyeR = r * 0.2;
+          [-1, 1].forEach(side => {
+            const ex = cx + side * eyeSpread;
+            ctx.fillStyle = '#001a0d';
+            ctx.beginPath();
+            ctx.arc(ex, eyeY, eyeR, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = dying ? '#ff0044' : '#00ffaa';
+            ctx.shadowColor = dying ? '#ff0044' : '#00ffaa';
+            ctx.shadowBlur = 8;
+            ctx.beginPath();
+            ctx.arc(ex, eyeY, eyeR * 0.55, 0, Math.PI * 2);
+            ctx.fill();
+          });
+
+          // Legs (back)
+          ctx.shadowBlur = 0;
+          ctx.strokeStyle = '#00cc66';
+          ctx.lineWidth = 3;
+          const legAnimOffset = Math.sin(now * 0.004) * 4;
+          [-1, 1].forEach(side => {
+            // back leg
+            ctx.beginPath();
+            ctx.moveTo(cx + side * r * 0.55, cy + r * 0.4);
+            ctx.quadraticCurveTo(
+              cx + side * (r + 8),
+              cy + r * 0.8 + legAnimOffset * side,
+              cx + side * (r * 0.9 + 4),
+              cy + r + legAnimOffset * side
+            );
+            ctx.stroke();
+            // front leg
+            ctx.beginPath();
+            ctx.moveTo(cx + side * r * 0.4, cy - r * 0.15);
+            ctx.lineTo(cx + side * (r + 5), cy - r * 0.5);
+            ctx.stroke();
+          });
+
+          ctx.restore();
+        }
+
+        function roundRect(ctx, x, y, w, h, r) {
+          ctx.beginPath();
+          ctx.moveTo(x + r, y);
+          ctx.lineTo(x + w - r, y);
+          ctx.arcTo(x + w, y, x + w, y + r, r);
+          ctx.lineTo(x + w, y + h - r);
+          ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+          ctx.lineTo(x + r, y + h);
+          ctx.arcTo(x, y + h, x, y + h - r, r);
+          ctx.lineTo(x, y + r);
+          ctx.arcTo(x, y, x + r, y, r);
+          ctx.closePath();
+        }
+
+        // ─── Game loop ────────────────────────────────────────────────
+        function loop(now) {
+          const dt = Math.min(now - (lastTime || now), 50);
+          lastTime = now;
+          update(dt);
+          draw(now);
+          requestAnimationFrame(loop);
+        }
+
+        requestAnimationFrame(loop);
+
+        // ─── Input handlers ───────────────────────────────────────────
+        function activateWarp() {
+          if (gameState !== 'playing') return;
+          if (warpCharge >= 1 && !warpActive) {
+            warpActive = true;
+            warpMs = WARP_DURATION_MS;
+          }
+        }
+
+        document.addEventListener('keydown', e => {
+          switch (e.key) {
+            case 'ArrowUp':
+            case 'w':
+            case 'W':
+              e.preventDefault();
+              tryMove(0, -1);
+              break;
+            case 'ArrowDown':
+            case 's':
+            case 'S':
+              e.preventDefault();
+              tryMove(0, 1);
+              break;
+            case 'ArrowLeft':
+            case 'a':
+            case 'A':
+              e.preventDefault();
+              tryMove(-1, 0);
+              break;
+            case 'ArrowRight':
+            case 'd':
+            case 'D':
+              e.preventDefault();
+              tryMove(1, 0);
+              break;
+            case ' ':
+              e.preventDefault();
+              activateWarp();
+              break;
+          }
+        });
+
+        // D-Pad
+        function dpadPress(dc, dr) {
+          return e => {
+            e.preventDefault();
+            tryMove(dc, dr);
+          };
+        }
+        document.getElementById('btn-up').addEventListener('touchstart', dpadPress(0, -1), {
+          passive: false,
+        });
+        document.getElementById('btn-down').addEventListener('touchstart', dpadPress(0, 1), {
+          passive: false,
+        });
+        document.getElementById('btn-left').addEventListener('touchstart', dpadPress(-1, 0), {
+          passive: false,
+        });
+        document.getElementById('btn-right').addEventListener('touchstart', dpadPress(1, 0), {
+          passive: false,
+        });
+        document.getElementById('btn-up').addEventListener('click', dpadPress(0, -1));
+        document.getElementById('btn-down').addEventListener('click', dpadPress(0, 1));
+        document.getElementById('btn-left').addEventListener('click', dpadPress(-1, 0));
+        document.getElementById('btn-right').addEventListener('click', dpadPress(1, 0));
+
+        // Warp button
+        warpBtn.addEventListener('click', activateWarp);
+        warpBtn.addEventListener('touchstart', e => {
+          e.preventDefault();
+          activateWarp();
+        }, { passive: false });
+
+        // Touch swipe on canvas
+        canvas.addEventListener(
+          'touchstart',
+          e => {
+            touchStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+          },
+          { passive: true }
+        );
+        canvas.addEventListener(
+          'touchend',
+          e => {
+            if (!touchStart) return;
+            const dx = e.changedTouches[0].clientX - touchStart.x;
+            const dy = e.changedTouches[0].clientY - touchStart.y;
+            touchStart = null;
+            const absX = Math.abs(dx);
+            const absY = Math.abs(dy);
+            if (Math.max(absX, absY) < 14) return;
+            if (absX > absY) {
+              tryMove(dx > 0 ? 1 : -1, 0);
+            } else {
+              tryMove(0, dy > 0 ? 1 : -1);
+            }
+          },
+          { passive: true }
+        );
+
+        // Start / restart buttons
+        document.getElementById('start-btn').addEventListener('click', startGame);
+        document.getElementById('restart-btn').addEventListener('click', () => {
+          gameoverOverlay.classList.add('hidden');
+          startGame();
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/apps/2026/03/18/cyber-hop/meta.json
+++ b/apps/2026/03/18/cyber-hop/meta.json
@@ -1,0 +1,23 @@
+{
+  "id": "cyber-hop",
+  "name": "Cyber Hop",
+  "shortDescription": "A cyberpunk twist on Frogger — guide your neon cyber-frog across glowing data streams and neon highways. Features smooth tween animation, a time-warp power-up, and full mobile touch controls.",
+  "thumbnail": "thumbnail.svg",
+  "createdAt": "2026-03-18T18:27:54Z",
+  "category": "Games",
+  "votes": 0,
+  "status": "active",
+  "tags": ["arcade", "frogger", "cyberpunk", "neon", "mobile", "canvas", "time-warp", "touch-controls"],
+  "homepagePath": "index.html",
+  "inputMode": "responsive",
+  "generation": {
+    "agentName": "claude-code",
+    "llmModel": "claude-sonnet-4-6",
+    "startTime": "2026-03-18T18:27:54Z",
+    "endTime": "2026-03-18T18:34:33Z",
+    "totalTokensIn": 7900,
+    "totalTokensOut": 12800,
+    "runId": "run-20260318T182754Z-1209f1",
+    "notes": "Cyberpunk Frogger with canvas rendering, requestAnimationFrame smooth tween movement (110ms easing), neon hover vehicles, glowing data-stream platforms, time-warp power-up (slows obstacles 72%), particle death effects, mobile D-pad + swipe controls, keyboard WASD/arrow support, level progression with speed scaling, lives system, local high score."
+  }
+}

--- a/apps/2026/03/18/cyber-hop/thumbnail.svg
+++ b/apps/2026/03/18/cyber-hop/thumbnail.svg
@@ -1,0 +1,295 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <!-- Background gradient -->
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#040c1e"/>
+      <stop offset="100%" stop-color="#060c1a"/>
+    </linearGradient>
+
+    <!-- Neon glow filters -->
+    <filter id="glowCyan" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowGreen" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowPink" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowYellow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow" x="-20%" y="-40%" width="140%" height="180%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+
+    <!-- Platform gradient -->
+    <linearGradient id="platformGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#003344"/>
+      <stop offset="100%" stop-color="#001a22"/>
+    </linearGradient>
+
+    <!-- Road gradient -->
+    <linearGradient id="roadGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c0c18"/>
+      <stop offset="100%" stop-color="#060610"/>
+    </linearGradient>
+
+    <!-- Stream gradient -->
+    <linearGradient id="streamGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#001a33"/>
+      <stop offset="100%" stop-color="#000d1a"/>
+    </linearGradient>
+
+    <!-- Pink vehicle gradient -->
+    <linearGradient id="vehPinkGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff00aa22"/>
+      <stop offset="70%" stop-color="#ff00aaaa"/>
+      <stop offset="100%" stop-color="#ff00aa22"/>
+    </linearGradient>
+
+    <!-- Cyan vehicle gradient -->
+    <linearGradient id="vehCyanGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00f5ff22"/>
+      <stop offset="30%" stop-color="#00f5ffaa"/>
+      <stop offset="100%" stop-color="#00f5ff22"/>
+    </linearGradient>
+
+    <!-- Orange vehicle gradient -->
+    <linearGradient id="vehOrangeGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff660022"/>
+      <stop offset="70%" stop-color="#ff6600aa"/>
+      <stop offset="100%" stop-color="#ff660022"/>
+    </linearGradient>
+
+    <!-- Frog body gradient -->
+    <radialGradient id="frogBodyGrad" cx="40%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#00ff88"/>
+      <stop offset="60%" stop-color="#00cc66"/>
+      <stop offset="100%" stop-color="#005533"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="450" fill="url(#bgGrad)"/>
+
+  <!-- Grid overlay (subtle) -->
+  <g opacity="0.04" stroke="#00f5ff" stroke-width="0.5">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="130" x2="800" y2="130"/>
+    <line x1="0" y1="170" x2="800" y2="170"/>
+    <line x1="0" y1="210" x2="800" y2="210"/>
+    <line x1="0" y1="250" x2="800" y2="250"/>
+    <line x1="0" y1="290" x2="800" y2="290"/>
+    <line x1="0" y1="330" x2="800" y2="330"/>
+    <line x1="0" y1="370" x2="800" y2="370"/>
+    <line x1="0" y1="410" x2="800" y2="410"/>
+  </g>
+
+  <!-- ── TITLE BANNER (top area) ── -->
+  <!-- Safe zone / home area (top) -->
+  <rect x="0" y="0" width="800" height="70" fill="#001a0d"/>
+  <rect x="0" y="0" width="800" height="70" fill="url(#bgGrad)" opacity="0.3"/>
+
+  <!-- Home pads -->
+  <g filter="url(#glowGreen)">
+    <!-- Pad 1 - reached (with frog) -->
+    <rect x="60" y="8" width="100" height="54" rx="8" fill="rgba(0,255,136,0.2)" stroke="#00ff88" stroke-width="2"/>
+    <!-- Pad 2 - reached -->
+    <rect x="220" y="8" width="100" height="54" rx="8" fill="rgba(0,255,136,0.2)" stroke="#00ff88" stroke-width="2"/>
+    <!-- Pad 3 - empty -->
+    <rect x="380" y="8" width="100" height="54" rx="8" fill="rgba(0,255,136,0.05)" stroke="#00ff88" stroke-width="1.5" opacity="0.5"/>
+    <!-- Pad 4 - empty -->
+    <rect x="540" y="8" width="100" height="54" rx="8" fill="rgba(0,255,136,0.05)" stroke="#00ff88" stroke-width="1.5" opacity="0.5"/>
+  </g>
+
+  <!-- Frogs in home pads -->
+  <text x="110" y="47" font-size="32" text-anchor="middle" font-family="serif">🐸</text>
+  <text x="270" y="47" font-size="32" text-anchor="middle" font-family="serif">🐸</text>
+
+  <!-- ── DATA STREAMS ── -->
+  <!-- Stream row 1 -->
+  <rect x="0" y="70" width="800" height="45" fill="url(#streamGrad)"/>
+  <line x1="0" y1="92" x2="800" y2="92" stroke="#00f5ff" stroke-width="0.5" opacity="0.15"/>
+  <!-- Platforms -->
+  <g filter="url(#glowCyan)">
+    <rect x="20" y="79" width="130" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <rect x="300" y="79" width="130" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <rect x="580" y="79" width="130" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+  </g>
+  <!-- Platform glow lines -->
+  <line x1="30" y1="87" x2="140" y2="87" stroke="#00f5ff" stroke-width="0.8" opacity="0.4"/>
+  <line x1="310" y1="87" x2="420" y2="87" stroke="#00f5ff" stroke-width="0.8" opacity="0.4"/>
+  <line x1="590" y1="87" x2="700" y2="87" stroke="#00f5ff" stroke-width="0.8" opacity="0.4"/>
+
+  <!-- Stream row 2 -->
+  <rect x="0" y="115" width="800" height="45" fill="url(#streamGrad)"/>
+  <line x1="0" y1="137" x2="800" y2="137" stroke="#00f5ff" stroke-width="0.5" opacity="0.12"/>
+  <g filter="url(#glowCyan)">
+    <rect x="100" y="124" width="190" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <rect x="480" y="124" width="190" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+  </g>
+
+  <!-- Stream row 3 -->
+  <rect x="0" y="160" width="800" height="45" fill="url(#streamGrad)"/>
+  <g filter="url(#glowCyan)">
+    <rect x="50" y="169" width="90" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <rect x="230" y="169" width="90" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <rect x="500" y="169" width="90" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <rect x="680" y="169" width="90" height="28" rx="6" fill="url(#platformGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+  </g>
+
+  <!-- ── SAFE MEDIAN ── -->
+  <rect x="0" y="205" width="800" height="45" fill="#0a1020"/>
+  <rect x="0" y="205" width="800" height="45" fill="rgba(0,245,255,0.02)"/>
+  <!-- Median grid lines -->
+  <g stroke="rgba(0,245,255,0.06)" stroke-width="0.5">
+    <line x1="0" y1="210" x2="800" y2="210"/>
+    <line x1="0" y1="245" x2="800" y2="245"/>
+  </g>
+
+  <!-- ── ROADS ── -->
+  <!-- Road 1 -->
+  <rect x="0" y="250" width="800" height="45" fill="url(#roadGrad)"/>
+  <line x1="0" y1="272" x2="800" y2="272" stroke="#ffe600" stroke-width="0.6" stroke-dasharray="20,24" opacity="0.2"/>
+  <g filter="url(#glowPink)">
+    <!-- Pink hovercars moving left -->
+    <rect x="80" y="259" width="120" height="28" rx="5" fill="url(#vehPinkGrad)" stroke="#ff00aa" stroke-width="1.5"/>
+    <circle cx="84" cy="267" r="4" fill="#ff00aa"/>
+    <circle cx="84" cy="279" r="4" fill="#ff00aa"/>
+    <rect x="370" y="259" width="120" height="28" rx="5" fill="url(#vehPinkGrad)" stroke="#ff00aa" stroke-width="1.5"/>
+    <circle cx="374" cy="267" r="4" fill="#ff00aa"/>
+    <circle cx="374" cy="279" r="4" fill="#ff00aa"/>
+    <rect x="620" y="259" width="120" height="28" rx="5" fill="url(#vehPinkGrad)" stroke="#ff00aa" stroke-width="1.5"/>
+    <circle cx="624" cy="267" r="4" fill="#ff00aa"/>
+    <circle cx="624" cy="279" r="4" fill="#ff00aa"/>
+  </g>
+
+  <!-- Road 2 -->
+  <rect x="0" y="295" width="800" height="45" fill="url(#roadGrad)"/>
+  <line x1="0" y1="317" x2="800" y2="317" stroke="#ffe600" stroke-width="0.6" stroke-dasharray="20,24" opacity="0.2"/>
+  <g filter="url(#glowCyan)">
+    <!-- Cyan hovercars moving right -->
+    <rect x="150" y="304" width="160" height="28" rx="5" fill="url(#vehCyanGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <circle cx="305" cy="312" r="4" fill="#00f5ff"/>
+    <circle cx="305" cy="324" r="4" fill="#00f5ff"/>
+    <rect x="530" y="304" width="160" height="28" rx="5" fill="url(#vehCyanGrad)" stroke="#00f5ff" stroke-width="1.5"/>
+    <circle cx="685" cy="312" r="4" fill="#00f5ff"/>
+    <circle cx="685" cy="324" r="4" fill="#00f5ff"/>
+  </g>
+
+  <!-- Road 3 (frog is crossing this one) -->
+  <rect x="0" y="340" width="800" height="45" fill="url(#roadGrad)"/>
+  <line x1="0" y1="362" x2="800" y2="362" stroke="#ffe600" stroke-width="0.6" stroke-dasharray="20,24" opacity="0.2"/>
+  <g filter="url(#glowPink)">
+    <rect x="30" y="349" width="95" height="28" rx="5" fill="url(#vehOrangeGrad)" stroke="#ff6600" stroke-width="1.5"/>
+    <circle cx="120" cy="357" r="4" fill="#ff6600"/>
+    <circle cx="120" cy="369" r="4" fill="#ff6600"/>
+    <rect x="290" y="349" width="95" height="28" rx="5" fill="url(#vehOrangeGrad)" stroke="#ff6600" stroke-width="1.5"/>
+    <circle cx="380" cy="357" r="4" fill="#ff6600"/>
+    <circle cx="380" cy="369" r="4" fill="#ff6600"/>
+    <rect x="560" y="349" width="95" height="28" rx="5" fill="url(#vehOrangeGrad)" stroke="#ff6600" stroke-width="1.5"/>
+    <circle cx="650" cy="357" r="4" fill="#ff6600"/>
+    <circle cx="650" cy="369" r="4" fill="#ff6600"/>
+  </g>
+
+  <!-- ── SPAWN SAFE ZONE ── -->
+  <rect x="0" y="385" width="800" height="65" fill="#0a1020"/>
+  <rect x="0" y="385" width="800" height="65" fill="rgba(0,0,0,0.2)"/>
+
+  <!-- ── FROG (center, mid-crossing) ── -->
+  <g filter="url(#glowGreen)" transform="translate(390, 340)">
+    <!-- Frog body -->
+    <ellipse cx="0" cy="0" rx="22" ry="19" fill="url(#frogBodyGrad)"/>
+    <!-- Circuit lines -->
+    <line x1="-10" y1="0" x2="10" y2="0" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <line x1="0" y1="-8" x2="0" y2="8" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <!-- Eyes -->
+    <circle cx="-9" cy="-7" r="5" fill="#001a0d"/>
+    <circle cx="9" cy="-7" r="5" fill="#001a0d"/>
+    <circle cx="-9" cy="-7" r="3" fill="#00ffaa"/>
+    <circle cx="9" cy="-7" r="3" fill="#00ffaa"/>
+    <!-- Back legs -->
+    <path d="M-12 8 Q-22 16 -18 24" stroke="#00cc66" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <path d="M12 8 Q22 16 18 24" stroke="#00cc66" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <!-- Front legs -->
+    <line x1="-10" y1="-4" x2="-22" y2="-12" stroke="#00cc66" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="10" y1="-4" x2="22" y2="-12" stroke="#00cc66" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+
+  <!-- Warp effect particles around frog -->
+  <g opacity="0.7">
+    <circle cx="360" cy="328" r="4" fill="#bb00ff" opacity="0.8"/>
+    <circle cx="420" cy="320" r="3" fill="#bb00ff" opacity="0.6"/>
+    <circle cx="375" cy="358" r="5" fill="#bb00ff" opacity="0.5"/>
+    <circle cx="408" cy="352" r="3" fill="#bb00ff" opacity="0.7"/>
+    <circle cx="350" cy="348" r="2" fill="#00f5ff" opacity="0.8"/>
+    <circle cx="430" cy="340" r="4" fill="#00f5ff" opacity="0.6"/>
+  </g>
+
+  <!-- ── TITLE TEXT ── -->
+  <!-- Shadow/glow layer -->
+  <text x="640" y="430" font-family="'Courier New', monospace" font-size="68" font-weight="bold"
+    fill="#00f5ff" opacity="0.08" text-anchor="middle" letter-spacing="4">CYBER HOP</text>
+
+  <text x="640" y="430" font-family="'Courier New', monospace" font-size="46" font-weight="bold"
+    fill="#00f5ff" text-anchor="middle" letter-spacing="3" filter="url(#textGlow)">CYBER HOP</text>
+
+  <text x="640" y="430" font-family="'Courier New', monospace" font-size="46" font-weight="bold"
+    fill="#00f5ff" text-anchor="middle" letter-spacing="3">CYBER HOP</text>
+
+  <!-- Subtitle -->
+  <text x="640" y="448" font-family="'Courier New', monospace" font-size="13"
+    fill="#bb00ff" text-anchor="middle" letter-spacing="2" opacity="0.9">CYBERPUNK FROGGER</text>
+
+  <!-- ── HUD ELEMENTS (score, level preview) ── -->
+  <!-- Score badge -->
+  <rect x="10" y="390" width="120" height="50" rx="6" fill="rgba(0,245,255,0.06)" stroke="#00f5ff" stroke-width="1" opacity="0.8"/>
+  <text x="70" y="408" font-family="'Courier New', monospace" font-size="9" fill="#00f5ff"
+    text-anchor="middle" letter-spacing="1.5" opacity="0.7">SCORE</text>
+  <text x="70" y="430" font-family="'Courier New', monospace" font-size="22" font-weight="bold"
+    fill="#ffe600" text-anchor="middle" filter="url(#glowYellow)">1840</text>
+
+  <!-- Level badge -->
+  <rect x="145" y="390" width="90" height="50" rx="6" fill="rgba(0,245,255,0.06)" stroke="#00f5ff" stroke-width="1" opacity="0.8"/>
+  <text x="190" y="408" font-family="'Courier New', monospace" font-size="9" fill="#00f5ff"
+    text-anchor="middle" letter-spacing="1.5" opacity="0.7">LEVEL</text>
+  <text x="190" y="430" font-family="'Courier New', monospace" font-size="22" font-weight="bold"
+    fill="#ffe600" text-anchor="middle" filter="url(#glowYellow)">3</text>
+
+  <!-- Lives -->
+  <rect x="248" y="390" width="120" height="50" rx="6" fill="rgba(0,245,255,0.06)" stroke="#00f5ff" stroke-width="1" opacity="0.8"/>
+  <text x="308" y="408" font-family="'Courier New', monospace" font-size="9" fill="#00f5ff"
+    text-anchor="middle" letter-spacing="1.5" opacity="0.7">LIVES</text>
+  <text x="308" y="432" font-size="22" text-anchor="middle" font-family="serif">🐸🐸🐸</text>
+
+  <!-- Warp bar -->
+  <rect x="382" y="390" width="120" height="50" rx="6" fill="rgba(187,0,255,0.06)" stroke="#bb00ff" stroke-width="1" opacity="0.8"/>
+  <text x="442" y="408" font-family="'Courier New', monospace" font-size="9" fill="#bb00ff"
+    text-anchor="middle" letter-spacing="1.5" opacity="0.7">⚡ WARP</text>
+  <rect x="392" y="418" width="100" height="10" rx="4" fill="rgba(187,0,255,0.15)" stroke="#bb00ff" stroke-width="0.5"/>
+  <rect x="392" y="418" width="76" height="10" rx="4" fill="url(#warpBarGrad)"/>
+
+  <defs>
+    <linearGradient id="warpBarGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#bb00ff"/>
+      <stop offset="100%" stop-color="#00f5ff"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Neon border glow at edges -->
+  <rect x="0" y="0" width="800" height="450" fill="none" stroke="#00f5ff" stroke-width="2" opacity="0.15"/>
+
+  <!-- Corner accents -->
+  <g stroke="#00f5ff" stroke-width="1.5" fill="none" opacity="0.5">
+    <polyline points="0,0 24,0 24,16"/>
+    <polyline points="800,0 776,0 776,16"/>
+    <polyline points="0,450 24,450 24,434"/>
+    <polyline points="800,450 776,450 776,434"/>
+  </g>
+</svg>

--- a/components/AppLog.jsx
+++ b/components/AppLog.jsx
@@ -10,7 +10,7 @@ export default function AppLog({ appId }) {
   const [expandedMessages, setExpandedMessages] = useState(new Set());
 
   const toggleMessageExpansion = (messageIndex) => {
-    setExpandedMessages(prev => {
+    setExpandedMessages((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(messageIndex)) {
         newSet.delete(messageIndex);
@@ -20,8 +20,6 @@ export default function AppLog({ appId }) {
       return newSet;
     });
   };
-
-
 
   useEffect(() => {
     const fetchLog = async () => {
@@ -40,7 +38,7 @@ export default function AppLog({ appId }) {
         const data = await response.json();
         setLogs(Array.isArray(data) ? data : []);
         setError(null);
-      } catch (err) {
+      } catch {
         setError('Error loading log file');
         setLogs([]);
       } finally {
@@ -69,7 +67,11 @@ export default function AppLog({ appId }) {
       <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
         <div className="flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
           <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+            <path
+              fillRule="evenodd"
+              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+              clipRule="evenodd"
+            />
           </svg>
           {error || 'No pipeline log available'}
         </div>
@@ -98,27 +100,43 @@ export default function AppLog({ appId }) {
     if (status === 'completed' || status === 'success') {
       return (
         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+            clipRule="evenodd"
+          />
         </svg>
       );
     }
     if (status === 'failed') {
       return (
         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+            clipRule="evenodd"
+          />
         </svg>
       );
     }
     return (
       <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+        <path
+          fillRule="evenodd"
+          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+          clipRule="evenodd"
+        />
       </svg>
     );
   };
 
   const formatDuration = (ms) => {
-    if (!ms) {return '-';}
-    if (ms < 1000) {return `${ms}ms`;}
+    if (!ms) {
+      return '-';
+    }
+    if (ms < 1000) {
+      return `${ms}ms`;
+    }
     return `${(ms / 1000).toFixed(1)}s`;
   };
 
@@ -139,7 +157,11 @@ export default function AppLog({ appId }) {
           fill="currentColor"
           viewBox="0 0 20 20"
         >
-          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+          <path
+            fillRule="evenodd"
+            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
         </svg>
       </button>
 
@@ -148,8 +170,12 @@ export default function AppLog({ appId }) {
           {/* Summary */}
           {transactionStart && (
             <div className="text-xs text-gray-600 dark:text-gray-400 mb-3 pb-3 border-b border-gray-200 dark:border-gray-700">
-              <div className="font-semibold text-gray-900 dark:text-white mb-1">Pipeline Details</div>
-              <div>Run ID: <span className="font-mono text-xs">{transactionStart.runId}</span></div>
+              <div className="font-semibold text-gray-900 dark:text-white mb-1">
+                Pipeline Details
+              </div>
+              <div>
+                Run ID: <span className="font-mono text-xs">{transactionStart.runId}</span>
+              </div>
               {transactionEnd && (
                 <div>Duration: {formatDuration(transactionEnd.pipeline?.durationMs)}</div>
               )}
@@ -177,16 +203,16 @@ export default function AppLog({ appId }) {
                       <div className="text-xs opacity-75">seq: {log.pipeline.seq}</div>
                     )}
                     {log.message && (
-                      <div 
+                      <div
                         className={`text-xs opacity-75 transition-all duration-200 ${
-                          hasLongMessage 
-                            ? 'cursor-pointer select-none hover:opacity-100' 
-                            : ''
-                        } ${
-                          hasLongMessage && !isMessageExpanded ? 'truncate' : ''
-                        }`}
+                          hasLongMessage ? 'cursor-pointer select-none hover:opacity-100' : ''
+                        } ${hasLongMessage && !isMessageExpanded ? 'truncate' : ''}`}
                         onClick={() => hasLongMessage && toggleMessageExpansion(idx)}
-                        style={hasLongMessage ? { WebkitTapHighlightColor: 'rgba(59, 130, 246, 0.1)' } : {}}
+                        style={
+                          hasLongMessage
+                            ? { WebkitTapHighlightColor: 'rgba(59, 130, 246, 0.1)' }
+                            : {}
+                        }
                       >
                         <div className="flex items-start gap-1">
                           <span className={hasLongMessage ? 'flex-grow' : 'w-full'}>
@@ -195,12 +221,32 @@ export default function AppLog({ appId }) {
                           {hasLongMessage && (
                             <button className="flex-shrink-0 text-blue-500 hover:text-blue-700 ml-1 transition-colors">
                               {isMessageExpanded ? (
-                                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                                <svg
+                                  className="w-3 h-3"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M5 15l7-7 7 7"
+                                  />
                                 </svg>
                               ) : (
-                                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                <svg
+                                  className="w-3 h-3"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M19 9l-7 7-7-7"
+                                  />
                                 </svg>
                               )}
                             </button>
@@ -209,26 +255,39 @@ export default function AppLog({ appId }) {
                       </div>
                     )}
                     {/* Token counts for LLM steps */}
-                    {(log.tokensIn || log.pipeline?.tokensIn || log.tokensOut || log.pipeline?.tokensOut) && (
+                    {(log.tokensIn ||
+                      log.pipeline?.tokensIn ||
+                      log.tokensOut ||
+                      log.pipeline?.tokensOut) && (
                       <div className="text-xs opacity-60 mt-1 flex items-center gap-2">
                         {(log.tokensIn || log.pipeline?.tokensIn) && (
                           <span className="inline-flex items-center gap-1">
                             <span>🔽</span>
-                            <span>{(log.tokensIn || log.pipeline?.tokensIn)?.toLocaleString()}</span>
+                            <span>
+                              {(log.tokensIn || log.pipeline?.tokensIn)?.toLocaleString()}
+                            </span>
                           </span>
                         )}
                         {(log.tokensOut || log.pipeline?.tokensOut) && (
                           <span className="inline-flex items-center gap-1">
                             <span>🔼</span>
-                            <span>{(log.tokensOut || log.pipeline?.tokensOut)?.toLocaleString()}</span>
+                            <span>
+                              {(log.tokensOut || log.pipeline?.tokensOut)?.toLocaleString()}
+                            </span>
                           </span>
                         )}
-                        {(log.tokensIn || log.pipeline?.tokensIn) && (log.tokensOut || log.pipeline?.tokensOut) && (
-                          <span className="inline-flex items-center gap-1 opacity-50">
-                            <span>💰</span>
-                            <span>{((log.tokensIn || log.pipeline?.tokensIn) + (log.tokensOut || log.pipeline?.tokensOut))?.toLocaleString()}</span>
-                          </span>
-                        )}
+                        {(log.tokensIn || log.pipeline?.tokensIn) &&
+                          (log.tokensOut || log.pipeline?.tokensOut) && (
+                            <span className="inline-flex items-center gap-1 opacity-50">
+                              <span>💰</span>
+                              <span>
+                                {(
+                                  (log.tokensIn || log.pipeline?.tokensIn) +
+                                  (log.tokensOut || log.pipeline?.tokensOut)
+                                )?.toLocaleString()}
+                              </span>
+                            </span>
+                          )}
                       </div>
                     )}
                   </div>
@@ -249,21 +308,23 @@ export default function AppLog({ appId }) {
                 Validation Checks ({logs.filter((log) => log.category === 'validation').length})
               </div>
               <div className="space-y-1">
-                {logs.filter((log) => log.category === 'validation').map((log, idx) => (
-                  <div
-                    key={idx}
-                    className={`p-1.5 rounded flex items-center gap-2 ${
-                      log.validation?.result === 'PASS'
-                        ? 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20'
-                        : 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20'
-                    }`}
-                  >
-                    {getStatusIcon(log.validation?.result === 'PASS' ? 'completed' : 'failed')}
-                    <span className="flex-grow truncate">
-                      {log.validation?.name || log.validation?.checkType}
-                    </span>
-                  </div>
-                ))}
+                {logs
+                  .filter((log) => log.category === 'validation')
+                  .map((log, idx) => (
+                    <div
+                      key={idx}
+                      className={`p-1.5 rounded flex items-center gap-2 ${
+                        log.validation?.result === 'PASS'
+                          ? 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20'
+                          : 'text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20'
+                      }`}
+                    >
+                      {getStatusIcon(log.validation?.result === 'PASS' ? 'completed' : 'failed')}
+                      <span className="flex-grow truncate">
+                        {log.validation?.name || log.validation?.checkType}
+                      </span>
+                    </div>
+                  ))}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Adds **Cyber Hop** — a cyberpunk twist on classic Frogger arcade game
- Canvas-based rendering with smooth 110ms tween movement easing
- Neon hover vehicles on 5 road lanes, glowing data-stream platforms on 5 stream lanes
- **Time Warp** power-up slows all obstacles by 72% for 4 seconds (10s cooldown)
- Particle death effects, level progression with speed scaling, 3-life system, local high score
- Full mobile support: on-screen D-pad, swipe gestures on canvas, keyboard WASD/arrows

## Fixes
- Fixed pre-existing unused `err` variable lint warning in `components/AppLog.jsx`

## Test plan
- [x] `npm run validate:apps` — all 57 apps pass HTML + meta.json checks
- [x] `npm run generate:apps` — registry generated with cyber-hop included
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 17 tests passing
- [x] `npm run build` — production build successful
- [ ] Open index.html locally: frog renders, vehicles move, platforms flow
- [ ] Mobile: D-pad moves frog, swipe works, time warp button activates
- [ ] Reach all 4 home pads → level-up screen → speed increases on level 2+
- [ ] Lose all 3 lives → game over screen shows final score + best

🤖 Generated with [Claude Code](https://claude.com/claude-code)