### PR TITLE
improve: dungeon-puzzle-run — fix puzzle re-renders appending instead of replacing

### DIFF
--- a/apps/2026/03/23/dungeon-puzzle-run/index.html
+++ b/apps/2026/03/23/dungeon-puzzle-run/index.html
@@ -772,6 +772,7 @@ function renderPuzzle(type, data) {
 }
 
 function renderLogic(area, d) {
+  area.innerHTML = '';
   const hint = document.createElement('div');
   hint.className = 'logic-hint';
   hint.textContent = 'Toggle cells so each row and column matches the target count.';
@@ -825,6 +826,7 @@ function checkLogic(d) {
 }
 
 function renderMemory(area, d) {
+  area.innerHTML = '';
   const cols = 4;
   const grid = document.createElement('div');
   grid.className = 'memory-grid';
@@ -868,6 +870,7 @@ function flipMemCard(card, d) {
 }
 
 function renderTiming(area, d) {
+  area.innerHTML = '';
   const track = document.createElement('div'); track.id = 'timing-track';
   const zone = document.createElement('div'); zone.id = 'timing-zone';
   zone.style.left = d.zoneStart + '%';
@@ -917,6 +920,7 @@ function tapTiming(d) {
 }
 
 function renderTile(area, d) {
+  area.innerHTML = '';
   const hint = document.createElement('div');
   hint.style.cssText = 'font-size:.75rem;color:var(--text2);text-align:center;';
   hint.textContent = 'Toggle tiles to match the goal pattern (gold border).';
@@ -1056,6 +1060,7 @@ function isValidPath(d) {
 }
 
 function renderResource(area, d) {
+  area.innerHTML = '';
   const items = [
     {key:'food',icon:'🍖',label:'Food'},
     {key:'wood',icon:'🪵',label:'Wood'},

--- a/apps/2026/03/23/dungeon-puzzle-run/meta.json
+++ b/apps/2026/03/23/dungeon-puzzle-run/meta.json
@@ -16,6 +16,17 @@
     "prompt": "Create a mobile-first puzzle roguelike. The player explores a dungeon made of short, one-thumb puzzle rooms. Each run should be fast, addictive, and replayable, with AI generating the dungeon layout, room order, enemies, rewards, and flavor text. Requirements: Touch-only controls: tap, swipe, drag, long-press. Runs last 3-10 minutes. Every room has one clear puzzle goal. Puzzle types include logic, memory, timing, tile, pathing, and resource puzzles. Use seeded randomness for replayable runs. Include branching paths, risk/reward choices, a boss room, health, loot, and meta-progression. Use clean visuals: strong lighting, smooth transitions, particles, glowing effects, and mobile-friendly UI. Keep the game fair, readable, and easy to restart after failure.",
     "requestor": "Perplexity"
   },
+  "improvements": [
+    {
+      "issueNumber": 186,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/186",
+      "description": "Fixed puzzle re-renders appending instead of replacing: added area.innerHTML='' to renderLogic, renderMemory, renderTiming, renderTile, and renderResource so each interaction clears before rebuilding.",
+      "requestor": "Claude",
+      "implementedAt": "2026-03-24T02:02:38Z",
+      "agentName": "claude-code",
+      "llmModel": "claude-sonnet-4-6"
+    }
+  ],
   "generation": {
     "agentName": "claude-code",
     "llmModel": "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Closes #186

Each puzzle's sub-render function (`renderLogic`, `renderMemory`, `renderTiming`, `renderTile`, `renderResource`) was appending new DOM nodes to the puzzle area on every interaction without clearing the existing content first. This caused stacking duplicates on each update.

The memory game was most severely broken: every card flip produced a new full grid below the previous one, leaving face-up cards visible across renders — giving away card positions and making the puzzle unsolvable as intended.

## Change

Added `area.innerHTML = '';` as the first line of each affected sub-render function. `renderPuzzle` (room entry point) already cleared correctly — this fix extends that same pattern to in-room re-renders.

Functions changed: `renderLogic`, `renderMemory`, `renderTiming`, `renderTile`, `renderResource`  
Functions unchanged (already correct): `renderPuzzle`, `renderBoss`, `renderPathing`

## Preserved

- All puzzle logic and game mechanics unchanged
- All 6 puzzle types still function
- Seeded RNG, relics, HP, scoring all intact
- Required head tags, theme support, shell config all present

🤖 Generated with [Claude Code](https://claude.com/claude-code)