### PR TITLE
improve: neon-slot-rush — add per-payline win breakdown with click-to-highlight

### DIFF
--- a/apps/2026/03/25/neon-slot-rush/index.html
+++ b/apps/2026/03/25/neon-slot-rush/index.html
@@ -59,6 +59,12 @@
       .paytable { display: grid; gap: 0.4rem; margin: 0.5rem 0; }
       .paytable div { display: flex; justify-content: space-between; background: rgba(0, 0, 0, 0.2); border-radius: 8px; padding: 0.4rem 0.55rem; }
       .muted { opacity: 0.74; }
+      .win-lines { display: flex; flex-direction: column; gap: 0.3rem; margin-top: 0.5rem; }
+      .win-line-item { display: flex; align-items: center; gap: 0.5rem; padding: 0.38rem 0.6rem; background: rgba(0,0,0,0.2); border: 1px solid color-mix(in oklab, var(--warn) 35%, transparent); border-radius: 8px; cursor: pointer; text-align: left; font-size: 0.82rem; transition: background 0.15s ease, border-color 0.15s ease; width: 100%; }
+      .win-line-item:hover, .win-line-item.active { background: color-mix(in oklab, var(--warn) 14%, transparent); border-color: var(--warn); }
+      .wl-sym { font-size: 1rem; flex-shrink: 0; }
+      .wl-label { flex: 1; opacity: 0.85; }
+      .wl-amt { font-weight: 700; color: var(--warn); flex-shrink: 0; }
       @media (min-width: 740px) { main { grid-template-columns: 2fr 1fr; align-items: start; } .hud { grid-column: 1 / -1; } }
     </style>
   </head>
@@ -79,6 +85,7 @@
       </section>
       <section class="panel" aria-label="Info panel">
         <p class="status" id="status">Ready. Press SPIN!</p>
+        <div id="winLines" class="win-lines" aria-label="Winning paylines breakdown" aria-live="polite"></div>
         <p class="muted">10 paylines, 5x3 reels, RNG-driven each spin.</p>
         <p class="muted" id="volatility">Volatility: Medium</p>
         <p class="muted">Keyboard: Space spin, ↑/↓ adjust bet, A toggle auto, T turbo, M mute.</p>
@@ -92,7 +99,7 @@
       const WEIGHTS = [26, 24, 20, 14, 10, 6];
       const PAYOUT = { '🍒': 2, '🍋': 3, '🔔': 5, '💎': 8, '7️⃣': 12, '⭐': 18 };
       const PAYLINES = [[0,0,0,0,0],[1,1,1,1,1],[2,2,2,2,2],[0,1,2,1,0],[2,1,0,1,2],[0,0,1,0,0],[2,2,1,2,2],[1,0,1,2,1],[1,2,1,0,1],[0,1,1,1,2]];
-      const state = { balance: 1000, betLevels: [5, 10, 20, 40, 80], betIndex: 1, autoSpins: 0, turbo: false, muted: true, spinning: false, lastWin: 0, grid: Array.from({ length: 3 }, () => Array(5).fill('🍒')) };
+      const state = { balance: 1000, betLevels: [5, 10, 20, 40, 80], betIndex: 1, autoSpins: 0, turbo: false, muted: true, spinning: false, lastWin: 0, winLines: [], grid: Array.from({ length: 3 }, () => Array(5).fill('🍒')) };
       const reelsEl = document.getElementById('reels');
       const spinBtn = document.getElementById('spin');
       const autoBtn = document.getElementById('auto');
@@ -106,13 +113,14 @@
       function renderGrid(winCells = []) { reelsEl.innerHTML = ''; for (let r = 0; r < 3; r++) { const row = document.createElement('div'); row.className = 'row'; for (let c = 0; c < 5; c++) { const cell = document.createElement('div'); cell.className = 'cell'; if (winCells.includes(`${r}-${c}`)) cell.classList.add('win'); cell.textContent = state.grid[r][c]; row.append(cell); } reelsEl.append(row); } }
       function renderHud() { const bet = state.betLevels[state.betIndex]; document.getElementById('balance').textContent = `$${state.balance}`; document.getElementById('bet').textContent = `$${bet}`; document.getElementById('lastWin').textContent = `$${state.lastWin}`; betSelect.value = String(state.betIndex); autoBtn.textContent = state.autoSpins > 0 ? `Auto ${state.autoSpins}` : 'Auto x10'; }
       function updateStatus(msg, good = true) { statusEl.textContent = msg; statusEl.style.color = good ? 'var(--good)' : 'var(--warn)'; }
-      function evaluateWin(bet) { let total = 0; const winCells = new Set(); for (const line of PAYLINES) { let base = state.grid[line[0]][0]; if (base === '⭐') base = state.grid[line[1]][1] || '🍒'; let count = 1; for (let c = 1; c < 5; c++) { const s = state.grid[line[c]][c]; if (s === base || s === '⭐' || base === '⭐') count += 1; else break; } if (count >= 3) { const mult = PAYOUT[base] || 2; total += mult * count * (bet / 5); for (let c = 0; c < count; c++) winCells.add(`${line[c]}-${c}`); } } return { total: Math.floor(total), winCells: [...winCells] }; }
+      function evaluateWin(bet) { let total = 0; const winCells = new Set(); const lines = []; for (let li = 0; li < PAYLINES.length; li++) { const line = PAYLINES[li]; let base = state.grid[line[0]][0]; if (base === '⭐') base = state.grid[line[1]][1] || '🍒'; let count = 1; for (let c = 1; c < 5; c++) { const s = state.grid[line[c]][c]; if (s === base || s === '⭐' || base === '⭐') count += 1; else break; } if (count >= 3) { const mult = PAYOUT[base] || 2; const amt = Math.floor(mult * count * (bet / 5)); total += amt; const cells = []; for (let c = 0; c < count; c++) { const key = `${line[c]}-${c}`; winCells.add(key); cells.push(key); } lines.push({ lineIndex: li, symbol: base, count, amount: amt, cells }); } } return { total, winCells: [...winCells], lines }; }
+      function renderWinLines(allWinCells) { const el = document.getElementById('winLines'); el.innerHTML = ''; state.winLines.forEach((line) => { const btn = document.createElement('button'); btn.className = 'win-line-item'; btn.type = 'button'; btn.title = `Click to highlight payline ${line.lineIndex + 1}`; btn.innerHTML = `<span class="wl-sym">${line.symbol}</span><span class="wl-label">Payline ${line.lineIndex + 1} &times;${line.count}</span><span class="wl-amt">+$${line.amount}</span>`; btn.addEventListener('click', () => { el.querySelectorAll('.win-line-item').forEach((b) => b.classList.remove('active')); btn.classList.add('active'); renderGrid(line.cells); }); el.append(btn); }); if (state.winLines.length > 1) { const allBtn = document.createElement('button'); allBtn.className = 'win-line-item active'; allBtn.type = 'button'; allBtn.innerHTML = `<span class="wl-sym">🏆</span><span class="wl-label">All winning lines</span><span class="wl-amt">+$${state.lastWin}</span>`; allBtn.addEventListener('click', () => { el.querySelectorAll('.win-line-item').forEach((b) => b.classList.remove('active')); allBtn.classList.add('active'); renderGrid(allWinCells); }); el.prepend(allBtn); } }
       async function spin() { if (state.spinning) return; const bet = state.betLevels[state.betIndex]; if (state.balance < bet) { updateStatus('Insufficient balance. Reset to continue.', false); return; }
-        state.spinning = true; spinBtn.disabled = true; state.balance -= bet; state.lastWin = 0; renderHud();
+        state.spinning = true; spinBtn.disabled = true; state.balance -= bet; state.lastWin = 0; state.winLines = []; document.getElementById('winLines').innerHTML = ''; renderHud();
         document.querySelectorAll('.cell').forEach((cell) => cell.classList.add('spinning'));
         const loops = state.turbo ? 8 : 16; const pace = state.turbo ? 30 : 55;
         for (let i = 0; i < loops; i++) { state.grid = Array.from({ length: 3 }, () => Array.from({ length: 5 }, weightedPick)); renderGrid(); await new Promise((r) => setTimeout(r, pace)); }
-        const outcome = evaluateWin(bet); state.lastWin = outcome.total; state.balance += outcome.total; renderGrid(outcome.winCells); renderHud(); updateStatus(outcome.total > 0 ? `WIN +$${outcome.total}!` : 'No win this spin.');
+        const outcome = evaluateWin(bet); state.lastWin = outcome.total; state.winLines = outcome.lines; state.balance += outcome.total; renderGrid(outcome.winCells); renderHud(); renderWinLines(outcome.winCells); updateStatus(outcome.total > 0 ? `WIN +$${outcome.total}!` : 'No win this spin.');
         state.spinning = false; spinBtn.disabled = false;
         if (state.autoSpins > 0) { state.autoSpins -= 1; setTimeout(spin, state.turbo ? 120 : 280); }
       }

--- a/apps/2026/03/25/neon-slot-rush/meta.json
+++ b/apps/2026/03/25/neon-slot-rush/meta.json
@@ -15,6 +15,17 @@
     "prompt": "Design a modern, highly addictive, mobile-first slot machine with 5x3 reels, paylines, configurable symbols, RNG outcomes, balance/bet/win display, turbo and auto-spin, dark neon theme, and concise paytable/help.",
     "requestor": "Perplexity"
   },
+  "improvements": [
+    {
+      "issueNumber": 202,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/202",
+      "description": "Added per-payline win breakdown list with click-to-highlight: after each spin, each winning payline appears as a clickable row showing symbol, payline number, match count, and payout amount; clicking a row highlights only that payline's cells on the reels.",
+      "requestor": "Jeff Holst",
+      "implementedAt": "2026-03-25T19:21:37Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
+    }
+  ],
   "generation": {
     "agentName": "dev",
     "llmModel": "openai-codex/gpt-5.3-codex",

--- a/apps/2026/03/25/neon-slot-rush/thumbnail.svg
+++ b/apps/2026/03/25/neon-slot-rush/thumbnail.svg
@@ -8,48 +8,112 @@
       <stop offset="0%" stop-color="#1d2350"/>
       <stop offset="100%" stop-color="#151933"/>
     </linearGradient>
+    <linearGradient id="winBtn" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#2a1f00"/>
+      <stop offset="100%" stop-color="#3a2a00"/>
+    </linearGradient>
     <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
       <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
+    <filter id="glowSm" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="2.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
-  <rect x="0" y="0" width="800" height="450" fill="url(#bg)"/>
-  <rect x="30" y="24" width="740" height="76" rx="14" fill="url(#panel)" stroke="#2a3d8d"/>
-  <text x="56" y="70" fill="#f4f8ff" font-size="34" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glow)">Neon Slot Rush</text>
-  <text x="610" y="57" fill="#11f5ff" font-size="18" font-family="Inter,Segoe UI,sans-serif">Balance $1240</text>
-  <text x="610" y="80" fill="#ff2bd6" font-size="18" font-family="Inter,Segoe UI,sans-serif">Bet $20  Win $180</text>
 
-  <rect x="70" y="120" width="500" height="290" rx="18" fill="#0f1534" stroke="#31439f"/>
-  <g font-size="52" text-anchor="middle" dominant-baseline="middle" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif">
-    <g>
-      <rect x="90" y="138" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="134" y="179">🍒</text>
-      <rect x="186" y="138" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="230" y="179">⭐</text>
-      <rect x="282" y="138" width="88" height="82" rx="12" fill="#151f53" stroke="#ffd63b"/><text x="326" y="179">7️⃣</text>
-      <rect x="378" y="138" width="88" height="82" rx="12" fill="#151f53" stroke="#ffd63b"/><text x="422" y="179">7️⃣</text>
-      <rect x="474" y="138" width="88" height="82" rx="12" fill="#151f53" stroke="#ffd63b"/><text x="518" y="179">7️⃣</text>
-    </g>
-    <g>
-      <rect x="90" y="226" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="134" y="267">💎</text>
-      <rect x="186" y="226" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="230" y="267">🔔</text>
-      <rect x="282" y="226" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="326" y="267">🍋</text>
-      <rect x="378" y="226" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="422" y="267">⭐</text>
-      <rect x="474" y="226" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="518" y="267">🔔</text>
-    </g>
-    <g>
-      <rect x="90" y="314" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="134" y="355">🍋</text>
-      <rect x="186" y="314" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="230" y="355">💎</text>
-      <rect x="282" y="314" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="326" y="355">⭐</text>
-      <rect x="378" y="314" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="422" y="355">🍒</text>
-      <rect x="474" y="314" width="88" height="82" rx="12" fill="#151f53" stroke="#31439f"/><text x="518" y="355">💎</text>
-    </g>
+  <!-- Background -->
+  <rect x="0" y="0" width="800" height="450" fill="url(#bg)"/>
+
+  <!-- HUD bar -->
+  <rect x="20" y="14" width="760" height="60" rx="13" fill="url(#panel)" stroke="#2a3d8d"/>
+  <text x="44" y="52" fill="#f4f8ff" font-size="28" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glow)">Neon Slot Rush</text>
+  <text x="430" y="40" fill="#94a3c8" font-size="13" font-family="Inter,Segoe UI,sans-serif">Balance</text>
+  <text x="430" y="58" fill="#f4f8ff" font-size="17" font-family="Inter,Segoe UI,sans-serif" font-weight="700">$1 240</text>
+  <text x="560" y="40" fill="#94a3c8" font-size="13" font-family="Inter,Segoe UI,sans-serif">Bet</text>
+  <text x="560" y="58" fill="#f4f8ff" font-size="17" font-family="Inter,Segoe UI,sans-serif" font-weight="700">$20</text>
+  <text x="660" y="40" fill="#94a3c8" font-size="13" font-family="Inter,Segoe UI,sans-serif">Last Win</text>
+  <text x="660" y="58" fill="#ffd63b" font-size="17" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glowSm)">$180</text>
+
+  <!-- Reels panel -->
+  <rect x="20" y="88" width="490" height="270" rx="16" fill="#0f1534" stroke="#31439f"/>
+
+  <!-- Row 1: 7s win (highlighted) -->
+  <rect x="38" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="136" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="234" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="234" y="104" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="332" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="332" y="104" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="430" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="430" y="104" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
+
+  <!-- Row 2: middle -->
+  <rect x="38" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="38" y="192" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="136" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="136" y="192" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="234" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="332" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="430" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+
+  <!-- Row 3 -->
+  <rect x="38" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="136" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="234" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="332" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="430" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+
+  <!-- Symbols -->
+  <g font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" text-anchor="middle" dominant-baseline="middle">
+    <text x="81" y="142" font-size="38">🍒</text>
+    <text x="179" y="142" font-size="38">⭐</text>
+    <text x="277" y="142" font-size="38">7️⃣</text>
+    <text x="375" y="142" font-size="38">7️⃣</text>
+    <text x="473" y="142" font-size="38">7️⃣</text>
+    <text x="81" y="230" font-size="38">🍒</text>
+    <text x="179" y="230" font-size="38">🍒</text>
+    <text x="277" y="230" font-size="38">🍋</text>
+    <text x="375" y="230" font-size="38">⭐</text>
+    <text x="473" y="230" font-size="38">🔔</text>
+    <text x="81" y="318" font-size="38">🍋</text>
+    <text x="179" y="318" font-size="38">💎</text>
+    <text x="277" y="318" font-size="38">⭐</text>
+    <text x="375" y="318" font-size="38">🍒</text>
+    <text x="473" y="318" font-size="38">💎</text>
   </g>
 
-  <rect x="590" y="122" width="180" height="288" rx="16" fill="url(#panel)" stroke="#2a3d8d"/>
-  <text x="610" y="160" fill="#f4f8ff" font-size="20" font-family="Inter,Segoe UI,sans-serif" font-weight="700">SPIN</text>
-  <rect x="610" y="172" width="140" height="58" rx="12" fill="#11f5ff"/>
-  <text x="680" y="210" fill="#02030f" font-size="30" text-anchor="middle" font-family="Inter,Segoe UI,sans-serif" font-weight="800">GO</text>
-  <text x="610" y="256" fill="#3cff78" font-size="18" font-family="Inter,Segoe UI,sans-serif">Turbo: ON</text>
-  <text x="610" y="284" fill="#f4f8ff" font-size="18" font-family="Inter,Segoe UI,sans-serif">Auto: 6</text>
-  <text x="610" y="312" fill="#f4f8ff" font-size="18" font-family="Inter,Segoe UI,sans-serif">10 Paylines</text>
-  <text x="610" y="352" fill="#ffd63b" font-size="26" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glow)">WIN +$180</text>
+  <!-- Win status -->
+  <rect x="20" y="370" width="490" height="66" rx="13" fill="url(#panel)" stroke="#2a3d8d"/>
+  <text x="44" y="410" fill="#3cff78" font-size="22" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glowSm)">WIN +$180!</text>
+  <text x="260" y="398" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">Click a payline below to highlight it</text>
+  <text x="260" y="416" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">on the reels</text>
+
+  <!-- Payline breakdown panel -->
+  <rect x="524" y="88" width="256" height="348" rx="16" fill="url(#panel)" stroke="#2a3d8d"/>
+  <text x="544" y="118" fill="#f4f8ff" font-size="15" font-family="Inter,Segoe UI,sans-serif" font-weight="700">Winning Paylines</text>
+
+  <!-- All lines button (active/selected) -->
+  <rect x="536" y="128" width="232" height="44" rx="9" fill="url(#winBtn)" stroke="#ffd63b"/>
+  <text x="552" y="148" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="18" dominant-baseline="middle">🏆</text>
+  <text x="578" y="149" fill="#f4f8ff" font-size="13" font-family="Inter,Segoe UI,sans-serif" dominant-baseline="middle">All winning lines</text>
+  <text x="746" y="149" fill="#ffd63b" font-size="14" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="end" dominant-baseline="middle" filter="url(#glowSm)">+$180</text>
+
+  <!-- Payline 3 item -->
+  <rect x="536" y="180" width="232" height="44" rx="9" fill="rgba(0,0,0,0.2)" stroke="rgba(255,214,59,0.3)"/>
+  <text x="552" y="200" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="18" dominant-baseline="middle">7️⃣</text>
+  <text x="578" y="201" fill="#d4d8f0" font-size="13" font-family="Inter,Segoe UI,sans-serif" dominant-baseline="middle">Payline 3 ×3</text>
+  <text x="746" y="201" fill="#ffd63b" font-size="13" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="end" dominant-baseline="middle">+$120</text>
+
+  <!-- Payline 2 item -->
+  <rect x="536" y="232" width="232" height="44" rx="9" fill="rgba(0,0,0,0.2)" stroke="rgba(255,214,59,0.3)"/>
+  <text x="552" y="252" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="18" dominant-baseline="middle">🍒</text>
+  <text x="578" y="253" fill="#d4d8f0" font-size="13" font-family="Inter,Segoe UI,sans-serif" dominant-baseline="middle">Payline 2 ×3</text>
+  <text x="746" y="253" fill="#ffd63b" font-size="13" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="end" dominant-baseline="middle">+$60</text>
+
+  <!-- Divider -->
+  <line x1="536" y1="290" x2="768" y2="290" stroke="#2a3d8d" stroke-width="1"/>
+
+  <text x="544" y="316" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">10 paylines · 5×3 reels · RNG</text>
+  <text x="544" y="336" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">Turbo: ON  ·  Auto: 6</text>
+
+  <!-- Spin button -->
+  <rect x="536" y="352" width="232" height="70" rx="12" fill="url(#glow)"/>
+  <rect x="536" y="352" width="232" height="70" rx="12" fill="#11f5ff"/>
+  <text x="652" y="392" fill="#02030f" font-size="28" font-family="Inter,Segoe UI,sans-serif" font-weight="800" text-anchor="middle" dominant-baseline="middle">SPIN</text>
 </svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -30,7 +30,17 @@
       "prompt": "Design a modern, highly addictive, mobile-first slot machine with 5x3 reels, paylines, configurable symbols, RNG outcomes, balance/bet/win display, turbo and auto-spin, dark neon theme, and concise paytable/help.",
       "requestor": "Perplexity"
     },
-    "improvements": null
+    "improvements": [
+      {
+        "issueNumber": 202,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/202",
+        "description": "Added per-payline win breakdown list with click-to-highlight: after each spin, each winning payline appears as a clickable row showing symbol, payline number, match count, and payout amount; clicking a row highlights only that payline's cells on the reels.",
+        "requestor": "Jeff Holst",
+        "implementedAt": "2026-03-25T19:21:37Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
+      }
+    ]
   },
   {
     "id": "2026/03/25/peg-solitaire",


### PR DESCRIPTION
## Summary

Closes #202

Adds a **payline breakdown panel** to the info section that appears after each spin when there are winning combinations. Each winning payline is shown as a clickable row displaying the matched symbol, payline number, match count, and payout amount. Clicking a row highlights only that payline's cells on the reels; an "All winning lines" row at the top restores the full highlight (shown when 2+ paylines win).

## What changed

- `index.html` — `evaluateWin()` now returns per-line data (`lines` array); new `renderWinLines()` function builds the clickable breakdown; `spin()` stores `winLines` in state and calls `renderWinLines()` after each result; panel is cleared at spin start
- `thumbnail.svg` — updated right panel to show the payline breakdown UI with example winning rows
- `meta.json` — appended improvement record to `improvements` array

## What was preserved

- All existing spin, turbo, auto-spin, bet, reset, mute, and keyboard functionality unchanged
- HUD, payable modal, theme support, and shared shell tags intact
- No changes to game math or RNG logic

## Validation

- `npm run validate:apps` — passed
- `npm run lint` — 0 errors, 0 warnings
- `npm test` — 173 tests passed
- `npm run validate:responsive:sample` — passed
- `npm run build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)