### PR TITLE
improve: neon-slot-rush payline overlay + enhanced paytable (#205)

### DIFF
--- a/apps/2026/03/25/neon-slot-rush/index.html
+++ b/apps/2026/03/25/neon-slot-rush/index.html
@@ -66,6 +66,12 @@
       .wl-label { flex: 1; opacity: 0.85; }
       .wl-amt { font-weight: 700; color: var(--warn); flex-shrink: 0; }
       @media (min-width: 740px) { main { grid-template-columns: 2fr 1fr; align-items: start; } .hud { grid-column: 1 / -1; } }
+      .reels-wrap { position: relative; }
+      .paylines-overlay { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; overflow: visible; }
+      .paytable-formula { text-align: center; padding: 0.4rem 0.55rem; background: rgba(0,0,0,0.25); border-radius: 8px; margin-bottom: 0.3rem; font-size: 0.82rem; }
+      .pt-hdr { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 0.3rem; padding: 0.3rem 0.55rem; opacity: 0.7; font-size: 0.78rem; }
+      .pt-row { display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 0.3rem; background: rgba(0,0,0,0.2); border-radius: 8px; padding: 0.4rem 0.55rem; align-items: center; }
+      .pt-amt { color: var(--warn); font-weight: 700; }
     </style>
   </head>
   <body>
@@ -76,8 +82,11 @@
         <div class="metric"><small>Last Win</small><strong id="lastWin">$0</strong></div>
       </section>
       <section class="machine panel" aria-label="Slot machine">
-        <div class="title-row"><h1>Neon Slot Rush</h1><button id="helpBtn" type="button" aria-haspopup="dialog">Paytable</button></div>
-        <div class="reels" id="reels" tabindex="0" aria-label="Slot reels. Swipe down or press space to spin."></div>
+        <div class="title-row"><h1>Neon Slot Rush</h1><button id="linesBtn" type="button" aria-pressed="false">Lines Off</button><button id="helpBtn" type="button" aria-haspopup="dialog">Paytable</button></div>
+        <div class="reels-wrap">
+          <div class="reels" id="reels" tabindex="0" aria-label="Slot reels. Swipe down or press space to spin."></div>
+          <svg id="paylinesOverlay" class="paylines-overlay" aria-hidden="true"></svg>
+        </div>
         <div class="controls">
           <div class="control-row"><button id="betDown" type="button">Bet -</button><select id="betSelect" aria-label="Select bet size"></select><button id="betUp" type="button">Bet +</button><button id="turbo" type="button" aria-pressed="false">Turbo Off</button></div>
           <div class="control-row"><button id="auto" type="button" aria-pressed="false">Auto x10</button><button id="mute" type="button" aria-pressed="true">Muted</button><button id="reset" type="button">Reset</button><button id="spin" class="spin" type="button">SPIN</button></div>
@@ -99,7 +108,8 @@
       const WEIGHTS = [26, 24, 20, 14, 10, 6];
       const PAYOUT = { '🍒': 2, '🍋': 3, '🔔': 5, '💎': 8, '7️⃣': 12, '⭐': 18 };
       const PAYLINES = [[0,0,0,0,0],[1,1,1,1,1],[2,2,2,2,2],[0,1,2,1,0],[2,1,0,1,2],[0,0,1,0,0],[2,2,1,2,2],[1,0,1,2,1],[1,2,1,0,1],[0,1,1,1,2]];
-      const state = { balance: 1000, betLevels: [5, 10, 20, 40, 80], betIndex: 1, autoSpins: 0, turbo: false, muted: true, spinning: false, lastWin: 0, winLines: [], grid: Array.from({ length: 3 }, () => Array(5).fill('🍒')) };
+      const PAYLINE_COLORS = ['#ff2bd6','#11f5ff','#ffd63b','#3cff78','#ff6b35','#a78bfa','#f87171','#34d399','#60a5fa','#fb923c'];
+      const state = { balance: 1000, betLevels: [5, 10, 20, 40, 80], betIndex: 1, autoSpins: 0, turbo: false, muted: true, spinning: false, lastWin: 0, winLines: [], showLines: false, grid: Array.from({ length: 3 }, () => Array(5).fill('🍒')) };
       const reelsEl = document.getElementById('reels');
       const spinBtn = document.getElementById('spin');
       const autoBtn = document.getElementById('auto');
@@ -110,7 +120,8 @@
       const paytable = document.getElementById('paytable');
       let touchStartY = 0;
       function weightedPick() { const total = WEIGHTS.reduce((a, b) => a + b, 0); let roll = Math.random() * total; for (let i = 0; i < SYMBOLS.length; i++) { roll -= WEIGHTS[i]; if (roll <= 0) return SYMBOLS[i]; } return SYMBOLS[0]; }
-      function renderGrid(winCells = []) { reelsEl.innerHTML = ''; for (let r = 0; r < 3; r++) { const row = document.createElement('div'); row.className = 'row'; for (let c = 0; c < 5; c++) { const cell = document.createElement('div'); cell.className = 'cell'; if (winCells.includes(`${r}-${c}`)) cell.classList.add('win'); cell.textContent = state.grid[r][c]; row.append(cell); } reelsEl.append(row); } }
+      function renderGrid(winCells = []) { reelsEl.innerHTML = ''; for (let r = 0; r < 3; r++) { const row = document.createElement('div'); row.className = 'row'; for (let c = 0; c < 5; c++) { const cell = document.createElement('div'); cell.className = 'cell'; if (winCells.includes(`${r}-${c}`)) cell.classList.add('win'); cell.textContent = state.grid[r][c]; row.append(cell); } reelsEl.append(row); } renderPaylineOverlay(); }
+      function renderPaylineOverlay() { const svg = document.getElementById('paylinesOverlay'); svg.innerHTML = ''; if (!state.showLines) return; const wrapEl = reelsEl.parentElement; const wrapRect = wrapEl.getBoundingClientRect(); const cells = reelsEl.querySelectorAll('.cell'); if (!cells.length) return; const pos = []; for (let r = 0; r < 3; r++) { pos[r] = []; for (let c = 0; c < 5; c++) { const rect = cells[r * 5 + c].getBoundingClientRect(); pos[r][c] = { x: rect.left - wrapRect.left + rect.width / 2, y: rect.top - wrapRect.top + rect.height / 2 }; } } PAYLINES.forEach((line, li) => { const pts = line.map((row, col) => `${pos[row][col].x},${pos[row][col].y}`).join(' '); const pl = document.createElementNS('http://www.w3.org/2000/svg', 'polyline'); pl.setAttribute('points', pts); pl.setAttribute('stroke', PAYLINE_COLORS[li]); pl.setAttribute('stroke-width', '3'); pl.setAttribute('fill', 'none'); pl.setAttribute('opacity', '0.85'); pl.setAttribute('stroke-linecap', 'round'); pl.setAttribute('stroke-linejoin', 'round'); svg.appendChild(pl); const lbl = document.createElementNS('http://www.w3.org/2000/svg', 'text'); lbl.setAttribute('x', pos[line[0]][0].x - 16); lbl.setAttribute('y', pos[line[0]][0].y + 4); lbl.setAttribute('fill', PAYLINE_COLORS[li]); lbl.setAttribute('font-size', '11'); lbl.setAttribute('font-weight', '700'); lbl.setAttribute('font-family', 'Inter,sans-serif'); lbl.textContent = String(li + 1); svg.appendChild(lbl); }); }
       function renderHud() { const bet = state.betLevels[state.betIndex]; document.getElementById('balance').textContent = `$${state.balance}`; document.getElementById('bet').textContent = `$${bet}`; document.getElementById('lastWin').textContent = `$${state.lastWin}`; betSelect.value = String(state.betIndex); autoBtn.textContent = state.autoSpins > 0 ? `Auto ${state.autoSpins}` : 'Auto x10'; }
       function updateStatus(msg, good = true) { statusEl.textContent = msg; statusEl.style.color = good ? 'var(--good)' : 'var(--warn)'; }
       function evaluateWin(bet) { let total = 0; const winCells = new Set(); const lines = []; for (let li = 0; li < PAYLINES.length; li++) { const line = PAYLINES[li]; let base = state.grid[line[0]][0]; if (base === '⭐') base = state.grid[line[1]][1] || '🍒'; let count = 1; for (let c = 1; c < 5; c++) { const s = state.grid[line[c]][c]; if (s === base || s === '⭐' || base === '⭐') count += 1; else break; } if (count >= 3) { const mult = PAYOUT[base] || 2; const amt = Math.floor(mult * count * (bet / 5)); total += amt; const cells = []; for (let c = 0; c < count; c++) { const key = `${line[c]}-${c}`; winCells.add(key); cells.push(key); } lines.push({ lineIndex: li, symbol: base, count, amount: amt, cells }); } } return { total, winCells: [...winCells], lines }; }
@@ -126,7 +137,8 @@
       }
       function initUi() {
         state.betLevels.forEach((b, i) => { const o = document.createElement('option'); o.value = String(i); o.textContent = `$${b}`; betSelect.append(o); });
-        for (const [sym, val] of Object.entries(PAYOUT)) { const row = document.createElement('div'); row.innerHTML = `<span>${sym} x3+</span><strong>${val}x base</strong>`; paytable.append(row); }
+        const fml = document.createElement('div'); fml.className = 'paytable-formula'; fml.innerHTML = 'Win = Multiplier &times; Matches &times; (Bet &divide; $5)'; paytable.append(fml); const hdr = document.createElement('div'); hdr.className = 'pt-hdr'; hdr.innerHTML = '<span>Symbol</span><span>&times;3</span><span>&times;4</span><span>&times;5</span>'; paytable.append(hdr); for (const [sym, mult] of Object.entries(PAYOUT)) { const row = document.createElement('div'); row.className = 'pt-row'; row.innerHTML = `<span>${sym}</span><span class="pt-amt">$${mult * 3}</span><span class="pt-amt">$${mult * 4}</span><span class="pt-amt">$${mult * 5}</span>`; paytable.append(row); }
+        const linesBtn = document.getElementById('linesBtn'); linesBtn.addEventListener('click', () => { state.showLines = !state.showLines; linesBtn.textContent = state.showLines ? 'Lines On' : 'Lines Off'; linesBtn.setAttribute('aria-pressed', String(state.showLines)); renderPaylineOverlay(); });
         document.getElementById('betDown').addEventListener('click', () => { state.betIndex = Math.max(0, state.betIndex - 1); renderHud(); });
         document.getElementById('betUp').addEventListener('click', () => { state.betIndex = Math.min(state.betLevels.length - 1, state.betIndex + 1); renderHud(); });
         betSelect.addEventListener('change', (e) => { state.betIndex = Number(e.target.value); renderHud(); });

--- a/apps/2026/03/25/neon-slot-rush/meta.json
+++ b/apps/2026/03/25/neon-slot-rush/meta.json
@@ -24,6 +24,15 @@
       "implementedAt": "2026-03-25T19:21:37Z",
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
+    },
+    {
+      "issueNumber": 205,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/205",
+      "description": "Added toggleable visual payline overlay: a Lines On/Off button draws all 10 paylines as colored SVG polylines over the reels using getBoundingClientRect positioning; each payline has a distinct neon color and numbered label. Also enhanced the paytable with a formula header (Win = Multiplier x Matches x (Bet / $5)) and a per-symbol grid showing dollar payouts at x3, x4, and x5 matches.",
+      "requestor": "Jeff Holst",
+      "implementedAt": "2026-03-25T20:49:00Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
     }
   ],
   "generation": {

--- a/apps/2026/03/25/neon-slot-rush/thumbnail.svg
+++ b/apps/2026/03/25/neon-slot-rush/thumbnail.svg
@@ -8,9 +8,9 @@
       <stop offset="0%" stop-color="#1d2350"/>
       <stop offset="100%" stop-color="#151933"/>
     </linearGradient>
-    <linearGradient id="winBtn" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#2a1f00"/>
-      <stop offset="100%" stop-color="#3a2a00"/>
+    <linearGradient id="linesOnBtn" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0a2a2a"/>
+      <stop offset="100%" stop-color="#0d3838"/>
     </linearGradient>
     <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
@@ -35,85 +35,149 @@
   <text x="660" y="40" fill="#94a3c8" font-size="13" font-family="Inter,Segoe UI,sans-serif">Last Win</text>
   <text x="660" y="58" fill="#ffd63b" font-size="17" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glowSm)">$180</text>
 
+  <!-- Machine title row (above reels) -->
+  <rect x="20" y="82" width="490" height="32" rx="8" fill="url(#panel)" stroke="#2a3d8d"/>
+  <text x="38" y="102" fill="#f4f8ff" font-size="14" font-family="Inter,Segoe UI,sans-serif" font-weight="700">Neon Slot Rush</text>
+  <!-- Lines On button (active/highlighted) -->
+  <rect x="340" y="87" width="78" height="22" rx="6" fill="url(#linesOnBtn)" stroke="#11f5ff" stroke-width="1.5"/>
+  <text x="379" y="101" fill="#11f5ff" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle" filter="url(#glowSm)">Lines On</text>
+  <!-- Paytable button -->
+  <rect x="426" y="87" width="72" height="22" rx="6" fill="rgba(0,0,0,0.25)" stroke="#2a3d8d"/>
+  <text x="462" y="101" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif" text-anchor="middle">Paytable</text>
+
   <!-- Reels panel -->
-  <rect x="20" y="88" width="490" height="270" rx="16" fill="#0f1534" stroke="#31439f"/>
+  <rect x="20" y="118" width="490" height="242" rx="16" fill="#0f1534" stroke="#31439f"/>
 
-  <!-- Row 1: 7s win (highlighted) -->
-  <rect x="38" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="136" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="234" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="234" y="104" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
-  <rect x="332" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="332" y="104" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
-  <rect x="430" y="104" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="430" y="104" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <!-- Row 1 cells -->
+  <rect x="38" y="130" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="136" y="130" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="234" y="130" width="86" height="72" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="234" y="130" width="86" height="72" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="332" y="130" width="86" height="72" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="332" y="130" width="86" height="72" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="430" y="130" width="86" height="72" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="430" y="130" width="86" height="72" rx="10" fill="rgba(255,214,59,0.08)"/>
 
-  <!-- Row 2: middle -->
-  <rect x="38" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="38" y="192" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
-  <rect x="136" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="136" y="192" width="86" height="76" rx="10" fill="rgba(255,214,59,0.08)"/>
-  <rect x="234" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="332" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="430" y="192" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <!-- Row 2 cells -->
+  <rect x="38" y="210" width="86" height="72" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="38" y="210" width="86" height="72" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="136" y="210" width="86" height="72" rx="10" fill="#151f53" stroke="#ffd63b"/><rect x="136" y="210" width="86" height="72" rx="10" fill="rgba(255,214,59,0.08)"/>
+  <rect x="234" y="210" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="332" y="210" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="430" y="210" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
 
-  <!-- Row 3 -->
-  <rect x="38" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="136" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="234" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="332" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
-  <rect x="430" y="280" width="86" height="76" rx="10" fill="#151f53" stroke="#31439f"/>
+  <!-- Row 3 cells -->
+  <rect x="38" y="290" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="136" y="290" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="234" y="290" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="332" y="290" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
+  <rect x="430" y="290" width="86" height="72" rx="10" fill="#151f53" stroke="#31439f"/>
 
-  <!-- Symbols -->
+  <!-- Symbols (row centers: 166, 246, 326; col centers: 81,179,277,375,473) -->
   <g font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" text-anchor="middle" dominant-baseline="middle">
-    <text x="81" y="142" font-size="38">🍒</text>
-    <text x="179" y="142" font-size="38">⭐</text>
-    <text x="277" y="142" font-size="38">7️⃣</text>
-    <text x="375" y="142" font-size="38">7️⃣</text>
-    <text x="473" y="142" font-size="38">7️⃣</text>
-    <text x="81" y="230" font-size="38">🍒</text>
-    <text x="179" y="230" font-size="38">🍒</text>
-    <text x="277" y="230" font-size="38">🍋</text>
-    <text x="375" y="230" font-size="38">⭐</text>
-    <text x="473" y="230" font-size="38">🔔</text>
-    <text x="81" y="318" font-size="38">🍋</text>
-    <text x="179" y="318" font-size="38">💎</text>
-    <text x="277" y="318" font-size="38">⭐</text>
-    <text x="375" y="318" font-size="38">🍒</text>
-    <text x="473" y="318" font-size="38">💎</text>
+    <text x="81"  y="166" font-size="36">🍒</text>
+    <text x="179" y="166" font-size="36">⭐</text>
+    <text x="277" y="166" font-size="36">7️⃣</text>
+    <text x="375" y="166" font-size="36">7️⃣</text>
+    <text x="473" y="166" font-size="36">7️⃣</text>
+    <text x="81"  y="246" font-size="36">🍒</text>
+    <text x="179" y="246" font-size="36">🍒</text>
+    <text x="277" y="246" font-size="36">🍋</text>
+    <text x="375" y="246" font-size="36">⭐</text>
+    <text x="473" y="246" font-size="36">🔔</text>
+    <text x="81"  y="326" font-size="36">🍋</text>
+    <text x="179" y="326" font-size="36">💎</text>
+    <text x="277" y="326" font-size="36">⭐</text>
+    <text x="375" y="326" font-size="36">🍒</text>
+    <text x="473" y="326" font-size="36">💎</text>
   </g>
 
-  <!-- Win status -->
-  <rect x="20" y="370" width="490" height="66" rx="13" fill="url(#panel)" stroke="#2a3d8d"/>
-  <text x="44" y="410" fill="#3cff78" font-size="22" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glowSm)">WIN +$180!</text>
-  <text x="260" y="398" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">Click a payline below to highlight it</text>
-  <text x="260" y="416" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">on the reels</text>
+  <!-- Payline overlay (Lines On) - all 10 paylines -->
+  <!-- row y: top=166, mid=246, bot=326  col x: 81,179,277,375,473 -->
+  <!-- PL1 [0,0,0,0,0] top row straight -->
+  <polyline points="81,166 179,166 277,166 375,166 473,166" stroke="#ff2bd6" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="65" y="170" fill="#ff2bd6" font-size="10" font-weight="700" font-family="Inter,sans-serif">1</text>
+  <!-- PL2 [1,1,1,1,1] mid row straight -->
+  <polyline points="81,246 179,246 277,246 375,246 473,246" stroke="#11f5ff" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="65" y="250" fill="#11f5ff" font-size="10" font-weight="700" font-family="Inter,sans-serif">2</text>
+  <!-- PL3 [2,2,2,2,2] bot row straight -->
+  <polyline points="81,326 179,326 277,326 375,326 473,326" stroke="#ffd63b" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="65" y="330" fill="#ffd63b" font-size="10" font-weight="700" font-family="Inter,sans-serif">3</text>
+  <!-- PL4 [0,1,2,1,0] V shape -->
+  <polyline points="81,166 179,246 277,326 375,246 473,166" stroke="#3cff78" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="65" y="170" fill="#3cff78" font-size="10" font-weight="700" font-family="Inter,sans-serif" dy="10">4</text>
+  <!-- PL5 [2,1,0,1,2] inverted V -->
+  <polyline points="81,326 179,246 277,166 375,246 473,326" stroke="#ff6b35" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="65" y="330" fill="#ff6b35" font-size="10" font-weight="700" font-family="Inter,sans-serif" dy="10">5</text>
+  <!-- PL6 [0,0,1,0,0] dip middle -->
+  <polyline points="81,166 179,166 277,246 375,166 473,166" stroke="#a78bfa" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- PL7 [2,2,1,2,2] bump middle -->
+  <polyline points="81,326 179,326 277,246 375,326 473,326" stroke="#f87171" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- PL8 [1,0,1,2,1] zigzag down -->
+  <polyline points="81,246 179,166 277,246 375,326 473,246" stroke="#34d399" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- PL9 [1,2,1,0,1] zigzag up -->
+  <polyline points="81,246 179,326 277,246 375,166 473,246" stroke="#60a5fa" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- PL10 [0,1,1,1,2] diagonal -->
+  <polyline points="81,166 179,246 277,246 375,246 473,326" stroke="#fb923c" stroke-width="2.5" fill="none" opacity="0.85" stroke-linecap="round" stroke-linejoin="round"/>
 
-  <!-- Payline breakdown panel -->
-  <rect x="524" y="88" width="256" height="348" rx="16" fill="url(#panel)" stroke="#2a3d8d"/>
-  <text x="544" y="118" fill="#f4f8ff" font-size="15" font-family="Inter,Segoe UI,sans-serif" font-weight="700">Winning Paylines</text>
+  <!-- Win status bar -->
+  <rect x="20" y="368" width="490" height="62" rx="13" fill="url(#panel)" stroke="#2a3d8d"/>
+  <text x="44" y="406" fill="#3cff78" font-size="22" font-family="Inter,Segoe UI,sans-serif" font-weight="700" filter="url(#glowSm)">WIN +$180!</text>
+  <text x="260" y="396" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">10 colored paylines visible</text>
+  <text x="260" y="414" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">Click any payline row to isolate it</text>
 
-  <!-- All lines button (active/selected) -->
-  <rect x="536" y="128" width="232" height="44" rx="9" fill="url(#winBtn)" stroke="#ffd63b"/>
-  <text x="552" y="148" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="18" dominant-baseline="middle">🏆</text>
-  <text x="578" y="149" fill="#f4f8ff" font-size="13" font-family="Inter,Segoe UI,sans-serif" dominant-baseline="middle">All winning lines</text>
-  <text x="746" y="149" fill="#ffd63b" font-size="14" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="end" dominant-baseline="middle" filter="url(#glowSm)">+$180</text>
+  <!-- Enhanced Paytable panel -->
+  <rect x="524" y="82" width="256" height="282" rx="16" fill="url(#panel)" stroke="#2a3d8d"/>
+  <text x="544" y="108" fill="#f4f8ff" font-size="15" font-family="Inter,Segoe UI,sans-serif" font-weight="700">Paytable</text>
 
-  <!-- Payline 3 item -->
-  <rect x="536" y="180" width="232" height="44" rx="9" fill="rgba(0,0,0,0.2)" stroke="rgba(255,214,59,0.3)"/>
-  <text x="552" y="200" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="18" dominant-baseline="middle">7️⃣</text>
-  <text x="578" y="201" fill="#d4d8f0" font-size="13" font-family="Inter,Segoe UI,sans-serif" dominant-baseline="middle">Payline 3 ×3</text>
-  <text x="746" y="201" fill="#ffd63b" font-size="13" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="end" dominant-baseline="middle">+$120</text>
+  <!-- Formula row -->
+  <rect x="536" y="114" width="232" height="24" rx="6" fill="rgba(0,0,0,0.3)"/>
+  <text x="652" y="130" fill="#94a3c8" font-size="11" font-family="Inter,Segoe UI,sans-serif" text-anchor="middle">Win = Mult × Matches × (Bet ÷ $5)</text>
 
-  <!-- Payline 2 item -->
-  <rect x="536" y="232" width="232" height="44" rx="9" fill="rgba(0,0,0,0.2)" stroke="rgba(255,214,59,0.3)"/>
-  <text x="552" y="252" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="18" dominant-baseline="middle">🍒</text>
-  <text x="578" y="253" fill="#d4d8f0" font-size="13" font-family="Inter,Segoe UI,sans-serif" dominant-baseline="middle">Payline 2 ×3</text>
-  <text x="746" y="253" fill="#ffd63b" font-size="13" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="end" dominant-baseline="middle">+$60</text>
+  <!-- Column headers -->
+  <text x="548" y="152" fill="#94a3c8" font-size="11" font-family="Inter,Segoe UI,sans-serif">Symbol</text>
+  <text x="658" y="152" fill="#94a3c8" font-size="11" font-family="Inter,Segoe UI,sans-serif" text-anchor="middle">×3</text>
+  <text x="700" y="152" fill="#94a3c8" font-size="11" font-family="Inter,Segoe UI,sans-serif" text-anchor="middle">×4</text>
+  <text x="745" y="152" fill="#94a3c8" font-size="11" font-family="Inter,Segoe UI,sans-serif" text-anchor="middle">×5</text>
 
-  <!-- Divider -->
-  <line x1="536" y1="290" x2="768" y2="290" stroke="#2a3d8d" stroke-width="1"/>
+  <!-- Symbol rows (mult: cherry=2, lemon=3, bell=5, diamond=8, 7=12, star=18) -->
+  <!-- at $5 base bet: win = mult * count * 1 -->
+  <rect x="536" y="156" width="232" height="26" rx="6" fill="rgba(0,0,0,0.2)"/>
+  <text x="548" y="173" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="16">🍒</text>
+  <text x="658" y="173" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$6</text>
+  <text x="700" y="173" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$8</text>
+  <text x="745" y="173" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$10</text>
 
-  <text x="544" y="316" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">10 paylines · 5×3 reels · RNG</text>
-  <text x="544" y="336" fill="#94a3c8" font-size="12" font-family="Inter,Segoe UI,sans-serif">Turbo: ON  ·  Auto: 6</text>
+  <rect x="536" y="184" width="232" height="26" rx="6" fill="rgba(0,0,0,0.2)"/>
+  <text x="548" y="201" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="16">🍋</text>
+  <text x="658" y="201" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$9</text>
+  <text x="700" y="201" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$12</text>
+  <text x="745" y="201" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$15</text>
+
+  <rect x="536" y="212" width="232" height="26" rx="6" fill="rgba(0,0,0,0.2)"/>
+  <text x="548" y="229" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="16">🔔</text>
+  <text x="658" y="229" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$15</text>
+  <text x="700" y="229" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$20</text>
+  <text x="745" y="229" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$25</text>
+
+  <rect x="536" y="240" width="232" height="26" rx="6" fill="rgba(0,0,0,0.2)"/>
+  <text x="548" y="257" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="16">💎</text>
+  <text x="658" y="257" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$24</text>
+  <text x="700" y="257" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$32</text>
+  <text x="745" y="257" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$40</text>
+
+  <rect x="536" y="268" width="232" height="26" rx="6" fill="rgba(0,0,0,0.2)"/>
+  <text x="548" y="285" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="16">7️⃣</text>
+  <text x="658" y="285" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$36</text>
+  <text x="700" y="285" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$48</text>
+  <text x="745" y="285" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$60</text>
+
+  <rect x="536" y="296" width="232" height="26" rx="6" fill="rgba(0,0,0,0.2)"/>
+  <text x="548" y="313" font-family="Segoe UI Emoji,Apple Color Emoji,sans-serif" font-size="16">⭐</text>
+  <text x="658" y="313" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$54</text>
+  <text x="700" y="313" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$72</text>
+  <text x="745" y="313" fill="#ffd63b" font-size="12" font-family="Inter,Segoe UI,sans-serif" font-weight="700" text-anchor="middle">$90</text>
+
+  <line x1="536" y1="330" x2="756" y2="330" stroke="#2a3d8d" stroke-width="1"/>
+  <text x="544" y="348" fill="#94a3c8" font-size="11" font-family="Inter,Segoe UI,sans-serif">at $5 base bet · Wild ⭐ subs all</text>
 
   <!-- Spin button -->
-  <rect x="536" y="352" width="232" height="70" rx="12" fill="url(#glow)"/>
-  <rect x="536" y="352" width="232" height="70" rx="12" fill="#11f5ff"/>
-  <text x="652" y="392" fill="#02030f" font-size="28" font-family="Inter,Segoe UI,sans-serif" font-weight="800" text-anchor="middle" dominant-baseline="middle">SPIN</text>
+  <rect x="524" y="372" width="256" height="66" rx="12" fill="#11f5ff" filter="url(#glow)"/>
+  <text x="652" y="411" fill="#02030f" font-size="28" font-family="Inter,Segoe UI,sans-serif" font-weight="800" text-anchor="middle" dominant-baseline="middle">SPIN</text>
 </svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -39,6 +39,15 @@
         "implementedAt": "2026-03-25T19:21:37Z",
         "agentName": "Claude Code",
         "llmModel": "claude-sonnet-4-6"
+      },
+      {
+        "issueNumber": 205,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/205",
+        "description": "Added toggleable visual payline overlay: a Lines On/Off button draws all 10 paylines as colored SVG polylines over the reels using getBoundingClientRect positioning; each payline has a distinct neon color and numbered label. Also enhanced the paytable with a formula header (Win = Multiplier x Matches x (Bet / $5)) and a per-symbol grid showing dollar payouts at x3, x4, and x5 matches.",
+        "requestor": "Jeff Holst",
+        "implementedAt": "2026-03-25T20:49:00Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ]
   },


### PR DESCRIPTION
## Summary

Implements issue #205 improvements to Neon Slot Rush:

- **Payline overlay toggle**: A new "Lines On/Off" button in the machine title row draws all 10 paylines as colored SVG polylines directly over the reels. Each payline has a distinct neon color and a numbered label on the left. Built with `getBoundingClientRect()` so positions stay accurate at any viewport size. The SVG sits as an absolutely-positioned sibling to `#reels` inside a new `.reels-wrap` wrapper div, sidestepping the `innerHTML = ''` wipe that would destroy an overlay placed inside the reels container.

- **Enhanced paytable**: The help modal's paytable now shows a formula header (`Win = Multiplier × Matches × (Bet ÷ $5)`), column headers (Symbol | ×3 | ×4 | ×5), and dollar payout amounts for each symbol at the $5 base bet — so players can calculate exact returns at any bet size.

- Updated thumbnail to show both features: payline overlay active over the reels, enhanced paytable panel on the right.

## Test plan

- [ ] Click "Lines On" — all 10 colored polylines appear over the reels with numbered labels
- [ ] Click "Lines Off" — overlay disappears, reels look normal
- [ ] Resize window — polylines remain correctly positioned over cells
- [ ] Spin — overlay redraws correctly after spin resolves
- [ ] Open Paytable modal — formula header, column headers (×3/×4/×5), and dollar amounts visible
- [ ] Validate: `npm run validate:apps` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)