### PR TITLE
improve: galaxian-blitz — fix layout height for shell header and footer (#218)

### DIFF
--- a/apps/2026/03/26/galaxian-blitz/index.html
+++ b/apps/2026/03/26/galaxian-blitz/index.html
@@ -59,7 +59,8 @@
         justify-content: flex-start;
         width: 100%;
         height: 100dvh;
-        padding-top: 56px; /* shell header */
+        padding-top: 64px; /* shell header */
+        padding-bottom: 56px; /* shell footer */
       }
 
       #hud {

--- a/apps/2026/03/26/galaxian-blitz/meta.json
+++ b/apps/2026/03/26/galaxian-blitz/meta.json
@@ -15,6 +15,16 @@
     "prompt": "Create a mobile-first HTML/CSS/JavaScript \"Galaxian\" style shooter. Be sure the have smooth game play, detailed looking graphics, and animated explosions. Requirements: Fullscreen canvas, optimized for phones first, then scale up for desktop. Player ship at bottom; move horizontally and shoot upward. Controls: arrow keys + space on desktop, touch buttons or left/right swipe + tap to shoot on mobile. Waves of alien ships appear in formations at the top, then break formation and dive-bomb the player. Enemies should have different types (speed, health, behavior). Implement player lives, score, and increasing difficulty per wave. Add simple power-ups (faster fire, spread shot, shield). Include basic sound effects and retro pixel/\"space\" visuals with starfield background. Keep code organized (separate game loop, input handling, rendering, collision).",
     "requestor": "anonymous"
   },
+  "improvements": [
+    {
+      "issueNumber": 218,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/218",
+      "description": "Fixed game layout to account for the shared shell header and footer: corrected padding-top from 56px to 64px (actual shell header height) and added padding-bottom: 56px so the player ship is no longer hidden behind the footer.",
+      "implementedAt": "2026-03-26T11:37:33Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
+    }
+  ],
   "generation": {
     "agentName": "Claude Code",
     "llmModel": "claude-sonnet-4-6",

--- a/data/apps.json
+++ b/data/apps.json
@@ -30,7 +30,16 @@
       "prompt": "Create a mobile-first HTML/CSS/JavaScript \"Galaxian\" style shooter. Be sure the have smooth game play, detailed looking graphics, and animated explosions. Requirements: Fullscreen canvas, optimized for phones first, then scale up for desktop. Player ship at bottom; move horizontally and shoot upward. Controls: arrow keys + space on desktop, touch buttons or left/right swipe + tap to shoot on mobile. Waves of alien ships appear in formations at the top, then break formation and dive-bomb the player. Enemies should have different types (speed, health, behavior). Implement player lives, score, and increasing difficulty per wave. Add simple power-ups (faster fire, spread shot, shield). Include basic sound effects and retro pixel/\"space\" visuals with starfield background. Keep code organized (separate game loop, input handling, rendering, collision).",
       "requestor": "anonymous"
     },
-    "improvements": null
+    "improvements": [
+      {
+        "issueNumber": 218,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/218",
+        "description": "Fixed game layout to account for the shared shell header and footer: corrected padding-top from 56px to 64px (actual shell header height) and added padding-bottom: 56px so the player ship is no longer hidden behind the footer.",
+        "implementedAt": "2026-03-26T11:37:33Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
+      }
+    ]
   },
   {
     "id": "2026/03/26/raffle-night-caller",


### PR DESCRIPTION
Closes #218

## Problem

The game wrapper used `height: 100dvh` but only reserved `padding-top: 56px` for the shell header (actual header height is **64px**) and had no `padding-bottom` for the shell footer (56px). This caused the canvas to extend behind the fixed footer, hiding the player ship.

## Fix

Two targeted CSS changes to `#gameWrapper`:

- `padding-top`: `56px` → `64px` (matches actual shell header height)
- `padding-bottom`: added `56px` (accounts for shell footer)

The existing `* { box-sizing: border-box }` rule ensures both paddings count inside the `100dvh` height, so the flex content area shrinks correctly and the canvas no longer overlaps the footer.

## Preserved

- All game logic, controls, scoring, power-ups, enemy AI unchanged
- All required head tags present
- Theme CSS variables intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)