### PR TITLE
improve: galaxian-blitz — fix full-viewport layout with position:fixed safe-zone anchoring

### DIFF
--- a/apps/2026/03/26/galaxian-blitz/index.html
+++ b/apps/2026/03/26/galaxian-blitz/index.html
@@ -53,14 +53,15 @@
       }
 
       #gameWrapper {
+        position: fixed;
+        top: 64px; /* shell header height */
+        bottom: 56px; /* shell footer height */
+        left: 0;
+        right: 0;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: flex-start;
-        width: 100%;
-        height: 100dvh;
-        padding-top: 64px; /* shell header */
-        padding-bottom: 56px; /* shell footer */
       }
 
       #hud {

--- a/apps/2026/03/26/galaxian-blitz/meta.json
+++ b/apps/2026/03/26/galaxian-blitz/meta.json
@@ -23,6 +23,14 @@
       "implementedAt": "2026-03-26T11:37:33Z",
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
+    },
+    {
+      "issueNumber": 221,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/221",
+      "description": "Replaced broken height:100dvh+padding layout on #gameWrapper with position:fixed top:64px bottom:56px — ensures mobile controls are never obscured by the shell footer at any viewport size.",
+      "implementedAt": "2026-03-26T14:39:01Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
     }
   ],
   "generation": {

--- a/data/apps.json
+++ b/data/apps.json
@@ -38,6 +38,14 @@
         "implementedAt": "2026-03-26T11:37:33Z",
         "agentName": "Claude Code",
         "llmModel": "claude-sonnet-4-6"
+      },
+      {
+        "issueNumber": 221,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/221",
+        "description": "Replaced broken height:100dvh+padding layout on #gameWrapper with position:fixed top:64px bottom:56px — ensures mobile controls are never obscured by the shell footer at any viewport size.",
+        "implementedAt": "2026-03-26T14:39:01Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Closes #221
- Replaces the broken `height: 100dvh; padding-top: 64px; padding-bottom: 56px` layout on `#gameWrapper` with `position: fixed; top: 64px; bottom: 56px; left: 0; right: 0`
- The previous layout overflowed the viewport by 64px at the bottom (since `#gameWrapper` started at y=64 due to shell body padding, extending to y=64+100dvh); the `padding-bottom: 56px` fell entirely in that off-screen region and provided zero clearance for the shell footer
- The new layout anchors the game wrapper exactly to the safe zone between shell header and footer at any viewport size — mobile controls are now fully visible and tappable

## What was preserved

- All game logic, enemy AI, power-up system, and particle effects unchanged
- HUD, canvas container, and mobile control DOM structure unchanged
- All required head tags, theme CSS variables, and shell integration intact
- Dark/light theme support retained

## Test plan

- [x] `npm run validate:apps` — passed
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 173 tests passed
- [x] `npm run validate:responsive:sample` — passed
- [x] `npm run build` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)