### PR TITLE
improve: galaxian-blitz — fix mobile touch controls, gameplay parity, easier wave 1, colorful enemies

### DIFF
--- a/apps/2026/03/26/galaxian-blitz/index.html
+++ b/apps/2026/03/26/galaxian-blitz/index.html
@@ -448,7 +448,7 @@
           player.y = H - 50;
         }
         player.y = H - 50;
-        formationBaseY = Math.min(80, H * 0.12);
+        formationBaseY = H * 0.13;
         initStars();
       }
 
@@ -484,11 +484,9 @@
           if (e.key === ' ' || e.key === 'Enter') keys.fire = false;
         });
 
-        function ctrlPress(btn, flag, value) {
+        function ctrlPress(btn) {
           btn.addEventListener('pointerdown', (e) => {
             e.preventDefault();
-            flag[flag === touchLeft ? 'val' : ''] = value;
-            // Use direct assignment via closure
             btn._active = true;
             btn.classList.add('pressed');
             if (btn.id.startsWith('left')) {
@@ -583,7 +581,7 @@
               diveSpeed: 0,
               diveReturnX: 0,
               diveReturnY: 0,
-              shootCooldown: Math.random() * 3000 + 1000,
+              shootCooldown: Math.random() * 4000 + 2500,
             });
           }
         }
@@ -691,8 +689,8 @@
       // =====================================================================
       function tryLaunchDiver() {
         if (enemies.length === 0) return;
-        if (diveBombers.length >= Math.min(2 + Math.floor(wave / 2), 5)) return;
-        if (Math.random() > 0.004 * (1 + wave * 0.3)) return;
+        if (diveBombers.length >= Math.min(1 + Math.floor(wave / 2), 5)) return;
+        if (Math.random() > 0.003 * (1 + wave * 0.35)) return;
 
         // Pick a non-diving enemy from front rows preferred
         const candidates = enemies.filter((e) => !e.diving);
@@ -876,8 +874,17 @@
           ctx.lineTo(x - s * 0.7, y);
           ctx.closePath();
           ctx.fill();
-          // Antenna
-          ctx.strokeStyle = c;
+          // Cyan inner diamond accent
+          ctx.fillStyle = '#67e8f9';
+          ctx.beginPath();
+          ctx.moveTo(x, y - s * 0.45);
+          ctx.lineTo(x + s * 0.3, y);
+          ctx.lineTo(x, y + s * 0.25);
+          ctx.lineTo(x - s * 0.3, y);
+          ctx.closePath();
+          ctx.fill();
+          // Yellow antenna tips
+          ctx.strokeStyle = '#fbbf24';
           ctx.lineWidth = 2;
           ctx.beginPath();
           ctx.moveTo(x - 5, y - s);
@@ -897,6 +904,20 @@
           }
           ctx.closePath();
           ctx.fill();
+          // Green inner hexagon accent
+          ctx.shadowBlur = 10;
+          ctx.shadowColor = '#4ade80';
+          ctx.strokeStyle = '#4ade80';
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          for (let i = 0; i < 6; i++) {
+            const a = (Math.PI / 3) * i - Math.PI / 6;
+            const px2 = x + Math.cos(a) * s * 0.62;
+            const py2 = y + Math.sin(a) * s * 0.62;
+            i === 0 ? ctx.moveTo(px2, py2) : ctx.lineTo(px2, py2);
+          }
+          ctx.closePath();
+          ctx.stroke();
           // Core glow
           ctx.shadowBlur = 14;
           ctx.shadowColor = '#fff';
@@ -916,6 +937,21 @@
             i === 0 ? ctx.moveTo(px2, py2) : ctx.lineTo(px2, py2);
           }
           ctx.closePath();
+          ctx.fill();
+          // Purple inner ring accent
+          ctx.shadowBlur = 12;
+          ctx.shadowColor = '#c084fc';
+          ctx.strokeStyle = '#c084fc';
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.arc(x, y, s * 0.48, 0, Math.PI * 2);
+          ctx.stroke();
+          // Bright yellow center dot
+          ctx.shadowBlur = 8;
+          ctx.shadowColor = '#fbbf24';
+          ctx.fillStyle = '#fbbf24';
+          ctx.beginPath();
+          ctx.arc(x, y, s * 0.22, 0, Math.PI * 2);
           ctx.fill();
         }
 

--- a/apps/2026/03/26/galaxian-blitz/meta.json
+++ b/apps/2026/03/26/galaxian-blitz/meta.json
@@ -31,6 +31,14 @@
       "implementedAt": "2026-03-26T14:39:01Z",
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
+    },
+    {
+      "issueNumber": 223,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/223",
+      "description": "Fixed mobile touch controls (removed dead code throwing TypeError on pointerdown), improved mobile/desktop parity (formation Y now proportional to canvas height), reduced wave-1 difficulty (longer initial shoot cooldown, fewer dive bombers), and added multi-color accents to all three enemy types.",
+      "implementedAt": "2026-03-26T15:00:54Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
     }
   ],
   "generation": {

--- a/apps/2026/03/26/galaxian-blitz/thumbnail.svg
+++ b/apps/2026/03/26/galaxian-blitz/thumbnail.svg
@@ -36,6 +36,11 @@
       <stop offset="0%" stop-color="#93c5fd"/>
       <stop offset="100%" stop-color="#3b82f6"/>
     </radialGradient>
+    <!-- Scout inner cyan accent -->
+    <radialGradient id="scoutAccent" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#cffafe"/>
+      <stop offset="100%" stop-color="#67e8f9"/>
+    </radialGradient>
     <!-- Bomber color -->
     <radialGradient id="bomberGrad" cx="50%" cy="40%" r="60%">
       <stop offset="0%" stop-color="#fdba74"/>
@@ -102,7 +107,7 @@
 
   <!-- Lives -->
   <text x="776" y="18" font-family="Courier New, monospace" font-size="10" fill="#64748b" letter-spacing="2" text-anchor="end">LIVES</text>
-  <text x="776" y="42" font-family="Courier New, monospace" font-size="20" font-weight="bold" fill="#f43f5e" filter="url(#textGlow)" text-anchor="end">♥ ♥ ♥</text>
+  <text x="776" y="42" font-family="Courier New, monospace" font-size="20" font-weight="bold" fill="#f43f5e" filter="url(#textGlow)" text-anchor="end">&#9829; &#9829; &#9829;</text>
 
   <!-- Power-up badge (SPREAD active) -->
   <rect x="24" y="48" width="90" height="16" rx="3" fill="#8b5cf622" stroke="#8b5cf666" stroke-width="1"/>
@@ -111,106 +116,141 @@
   <!-- Title text -->
   <text x="400" y="92" font-family="Courier New, monospace" font-size="28" font-weight="bold" fill="#38bdf8" filter="url(#textGlow)" text-anchor="middle" letter-spacing="4" opacity="0.35">GALAXIAN BLITZ</text>
 
-  <!-- ENEMY FORMATION: Row 0 — Scouts (blue) -->
-  <!-- 8 scouts across -->
+  <!-- ENEMY FORMATION: Row 0 — Scouts (blue+cyan accent, yellow antennas) -->
   <g filter="url(#enemyGlow)">
-    <!-- Scout shape: diamond with antennae -->
     <!-- col 0 -->
     <polygon points="76,108 64,118 76,126 88,118" fill="url(#scoutGrad)"/>
-    <line x1="71" y1="108" x2="71" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="81" y1="108" x2="81" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="76,112 69,117 76,122 83,117" fill="url(#scoutAccent)"/>
+    <line x1="71" y1="108" x2="71" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="81" y1="108" x2="81" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 1 -->
     <polygon points="178,108 166,118 178,126 190,118" fill="url(#scoutGrad)"/>
-    <line x1="173" y1="108" x2="173" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="183" y1="108" x2="183" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="178,112 171,117 178,122 185,117" fill="url(#scoutAccent)"/>
+    <line x1="173" y1="108" x2="173" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="183" y1="108" x2="183" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 2 -->
     <polygon points="280,108 268,118 280,126 292,118" fill="url(#scoutGrad)"/>
-    <line x1="275" y1="108" x2="275" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="285" y1="108" x2="285" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="280,112 273,117 280,122 287,117" fill="url(#scoutAccent)"/>
+    <line x1="275" y1="108" x2="275" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="285" y1="108" x2="285" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 3 -->
     <polygon points="382,108 370,118 382,126 394,118" fill="url(#scoutGrad)"/>
-    <line x1="377" y1="108" x2="377" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="387" y1="108" x2="387" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="382,112 375,117 382,122 389,117" fill="url(#scoutAccent)"/>
+    <line x1="377" y1="108" x2="377" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="387" y1="108" x2="387" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 4 -->
     <polygon points="484,108 472,118 484,126 496,118" fill="url(#scoutGrad)"/>
-    <line x1="479" y1="108" x2="479" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="489" y1="108" x2="489" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="484,112 477,117 484,122 491,117" fill="url(#scoutAccent)"/>
+    <line x1="479" y1="108" x2="479" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="489" y1="108" x2="489" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 5 -->
     <polygon points="586,108 574,118 586,126 598,118" fill="url(#scoutGrad)"/>
-    <line x1="581" y1="108" x2="581" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="591" y1="108" x2="591" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="586,112 579,117 586,122 593,117" fill="url(#scoutAccent)"/>
+    <line x1="581" y1="108" x2="581" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="591" y1="108" x2="591" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 6 -->
     <polygon points="664,108 652,118 664,126 676,118" fill="url(#scoutGrad)"/>
-    <line x1="659" y1="108" x2="659" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="669" y1="108" x2="669" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="664,112 657,117 664,122 671,117" fill="url(#scoutAccent)"/>
+    <line x1="659" y1="108" x2="659" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="669" y1="108" x2="669" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
     <!-- col 7 -->
     <polygon points="740,108 728,118 740,126 752,118" fill="url(#scoutGrad)"/>
-    <line x1="735" y1="108" x2="735" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="745" y1="108" x2="745" y2="102" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="740,112 733,117 740,122 747,117" fill="url(#scoutAccent)"/>
+    <line x1="735" y1="108" x2="735" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="745" y1="108" x2="745" y2="102" stroke="#fbbf24" stroke-width="1.5"/>
   </g>
 
-  <!-- Row 1 — Scouts -->
+  <!-- Row 1 — Scouts (blue+cyan accent, yellow antennas) -->
   <g filter="url(#enemyGlow)">
     <polygon points="76,152 64,162 76,170 88,162" fill="url(#scoutGrad)"/>
-    <line x1="71" y1="152" x2="71" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="81" y1="152" x2="81" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="76,156 69,161 76,166 83,161" fill="url(#scoutAccent)"/>
+    <line x1="71" y1="152" x2="71" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="81" y1="152" x2="81" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="178,152 166,162 178,170 190,162" fill="url(#scoutGrad)"/>
-    <line x1="173" y1="152" x2="173" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="183" y1="152" x2="183" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="178,156 171,161 178,166 185,161" fill="url(#scoutAccent)"/>
+    <line x1="173" y1="152" x2="173" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="183" y1="152" x2="183" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="280,152 268,162 280,170 292,162" fill="url(#scoutGrad)"/>
-    <line x1="275" y1="152" x2="275" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="285" y1="152" x2="285" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="280,156 273,161 280,166 287,161" fill="url(#scoutAccent)"/>
+    <line x1="275" y1="152" x2="275" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="285" y1="152" x2="285" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="382,152 370,162 382,170 394,162" fill="url(#scoutGrad)"/>
-    <line x1="377" y1="152" x2="377" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="387" y1="152" x2="387" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="382,156 375,161 382,166 389,161" fill="url(#scoutAccent)"/>
+    <line x1="377" y1="152" x2="377" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="387" y1="152" x2="387" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="484,152 472,162 484,170 496,162" fill="url(#scoutGrad)"/>
-    <line x1="479" y1="152" x2="479" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="489" y1="152" x2="489" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="484,156 477,161 484,166 491,161" fill="url(#scoutAccent)"/>
+    <line x1="479" y1="152" x2="479" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="489" y1="152" x2="489" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="586,152 574,162 586,170 598,162" fill="url(#scoutGrad)"/>
-    <line x1="581" y1="152" x2="581" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="591" y1="152" x2="591" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="586,156 579,161 586,166 593,161" fill="url(#scoutAccent)"/>
+    <line x1="581" y1="152" x2="581" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="591" y1="152" x2="591" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="664,152 652,162 664,170 676,162" fill="url(#scoutGrad)"/>
-    <line x1="659" y1="152" x2="659" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="669" y1="152" x2="669" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="664,156 657,161 664,166 671,161" fill="url(#scoutAccent)"/>
+    <line x1="659" y1="152" x2="659" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="669" y1="152" x2="669" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
     <polygon points="740,152 728,162 740,170 752,162" fill="url(#scoutGrad)"/>
-    <line x1="735" y1="152" x2="735" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
-    <line x1="745" y1="152" x2="745" y2="146" stroke="#60a5fa" stroke-width="1.5"/>
+    <polygon points="740,156 733,161 740,166 747,161" fill="url(#scoutAccent)"/>
+    <line x1="735" y1="152" x2="735" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
+    <line x1="745" y1="152" x2="745" y2="146" stroke="#fbbf24" stroke-width="1.5"/>
   </g>
 
-  <!-- Row 2 — Bombers (hexagons) -->
+  <!-- Row 2 — Bombers (orange + green inner ring + white core) -->
   <g filter="url(#enemyGlow)">
     <polygon points="76,192 64.6,199 64.6,213 76,220 87.4,213 87.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="76" cy="206" r="4" fill="#fff3" />
+    <polygon points="76,196 68.3,200.5 68.3,209.5 76,214 83.7,209.5 83.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="76" cy="206" r="4" fill="#fff3"/>
     <polygon points="178,192 166.6,199 166.6,213 178,220 189.4,213 189.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="178" cy="206" r="4" fill="#fff3" />
+    <polygon points="178,196 170.3,200.5 170.3,209.5 178,214 185.7,209.5 185.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="178" cy="206" r="4" fill="#fff3"/>
     <polygon points="280,192 268.6,199 268.6,213 280,220 291.4,213 291.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="280" cy="206" r="4" fill="#fff3" />
+    <polygon points="280,196 272.3,200.5 272.3,209.5 280,214 287.7,209.5 287.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="280" cy="206" r="4" fill="#fff3"/>
     <polygon points="382,192 370.6,199 370.6,213 382,220 393.4,213 393.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="382" cy="206" r="4" fill="#fff3" />
+    <polygon points="382,196 374.3,200.5 374.3,209.5 382,214 389.7,209.5 389.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="382" cy="206" r="4" fill="#fff3"/>
     <polygon points="484,192 472.6,199 472.6,213 484,220 495.4,213 495.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="484" cy="206" r="4" fill="#fff3" />
+    <polygon points="484,196 476.3,200.5 476.3,209.5 484,214 491.7,209.5 491.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="484" cy="206" r="4" fill="#fff3"/>
     <polygon points="586,192 574.6,199 574.6,213 586,220 597.4,213 597.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="586" cy="206" r="4" fill="#fff3" />
+    <polygon points="586,196 578.3,200.5 578.3,209.5 586,214 593.7,209.5 593.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="586" cy="206" r="4" fill="#fff3"/>
     <polygon points="664,192 652.6,199 652.6,213 664,220 675.4,213 675.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="664" cy="206" r="4" fill="#fff3" />
+    <polygon points="664,196 656.3,200.5 656.3,209.5 664,214 671.7,209.5 671.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="664" cy="206" r="4" fill="#fff3"/>
     <polygon points="740,192 728.6,199 728.6,213 740,220 751.4,213 751.4,199" fill="url(#bomberGrad)"/>
-    <circle cx="740" cy="206" r="4" fill="#fff3" />
+    <polygon points="740,196 732.3,200.5 732.3,209.5 740,214 747.7,209.5 747.7,200.5" fill="none" stroke="#4ade80" stroke-width="1.5"/>
+    <circle cx="740" cy="206" r="4" fill="#fff3"/>
   </g>
 
-  <!-- Row 3 — Elites (stars) — 6 remain, 2 killed -->
+  <!-- Row 3 — Elites (red + purple ring + yellow center) — 6 remain, 2 killed -->
   <g filter="url(#enemyGlow)">
-    <!-- 6 elites visible, 2 spots empty -->
     <polygon points="76,248 79,256 88,256 81,261 84,270 76,265 68,270 71,261 64,256 73,256" fill="url(#eliteGrad)"/>
+    <circle cx="76" cy="259" r="6" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="76" cy="259" r="2.5" fill="#fbbf24"/>
     <polygon points="178,248 181,256 190,256 183,261 186,270 178,265 170,270 173,261 166,256 175,256" fill="url(#eliteGrad)"/>
+    <circle cx="178" cy="259" r="6" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="178" cy="259" r="2.5" fill="#fbbf24"/>
     <polygon points="280,248 283,256 292,256 285,261 288,270 280,265 272,270 275,261 268,256 277,256" fill="url(#eliteGrad)"/>
+    <circle cx="280" cy="259" r="6" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="280" cy="259" r="2.5" fill="#fbbf24"/>
     <polygon points="382,248 385,256 394,256 387,261 390,270 382,265 374,270 377,261 370,256 379,256" fill="url(#eliteGrad)"/>
+    <circle cx="382" cy="259" r="6" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="382" cy="259" r="2.5" fill="#fbbf24"/>
     <polygon points="484,248 487,256 496,256 489,261 492,270 484,265 476,270 479,261 472,256 481,256" fill="url(#eliteGrad)"/>
+    <circle cx="484" cy="259" r="6" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="484" cy="259" r="2.5" fill="#fbbf24"/>
     <polygon points="586,248 589,256 598,256 591,261 594,270 586,265 578,270 581,261 574,256 583,256" fill="url(#eliteGrad)"/>
+    <circle cx="586" cy="259" r="6" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="586" cy="259" r="2.5" fill="#fbbf24"/>
   </g>
 
   <!-- Dive-bombing Elite: diving toward player -->
   <g filter="url(#enemyGlow)">
     <polygon points="520,310 523,318 532,318 525,323 528,332 520,327 512,332 515,323 508,318 517,318" fill="url(#eliteGrad)"/>
+    <circle cx="520" cy="321" r="5.5" fill="none" stroke="#c084fc" stroke-width="1.5"/>
+    <circle cx="520" cy="321" r="2" fill="#fbbf24"/>
   </g>
 
   <!-- Dive bomber trail -->
@@ -252,7 +292,9 @@
     <circle cx="28" cy="8" r="2" fill="#fda4af" opacity="0.5"/>
     <circle cx="-26" cy="6" r="2.5" fill="#f43f5e" opacity="0.7"/>
     <circle cx="5" cy="-26" r="2" fill="#fda4af" opacity="0.6"/>
-    <circle cx="-8" cy="28" r="2.5" fill="#f43f5e" opacity="0.5"/>
+    <!-- Purple + yellow debris from elite -->
+    <circle cx="-8" cy="28" r="2.5" fill="#c084fc" opacity="0.7"/>
+    <circle cx="12" cy="-22" r="2" fill="#fbbf24" opacity="0.8"/>
   </g>
 
   <!-- Power-up (spread) floating down -->

--- a/data/apps.json
+++ b/data/apps.json
@@ -46,6 +46,14 @@
         "implementedAt": "2026-03-26T14:39:01Z",
         "agentName": "Claude Code",
         "llmModel": "claude-sonnet-4-6"
+      },
+      {
+        "issueNumber": 223,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/223",
+        "description": "Fixed mobile touch controls (removed dead code throwing TypeError on pointerdown), improved mobile/desktop parity (formation Y now proportional to canvas height), reduced wave-1 difficulty (longer initial shoot cooldown, fewer dive bombers), and added multi-color accents to all three enemy types.",
+        "implementedAt": "2026-03-26T15:00:54Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Closes #223
- **Fixed mobile touch controls**: Removed dead code `flag[...] = value` in `ctrlPress()` that threw `TypeError: Cannot read properties of undefined` on every `pointerdown` event, preventing `touchLeft`/`touchRight`/`touchFire` from ever being set. Touch buttons now work correctly.
- **Mobile/desktop gameplay parity**: Replaced `formationBaseY = Math.min(80, H * 0.12)` with `formationBaseY = H * 0.13` — formation Y is now always proportional to canvas height, so the enemy-to-player gap scales consistently across screen sizes.
- **Easier wave 1**: Increased initial enemy shoot cooldown from `1–4s` to `2.5–6.5s`, reduced max concurrent dive bombers on wave 1 from 2→1 (using `1 + floor(wave/2)`), and lowered dive probability for early waves.
- **More colorful enemies**: Added multi-color accents to all three enemy types — scouts get a cyan inner diamond + yellow antenna tips, bombers get a green inner hexagon ring, elites get a purple inner ring + yellow center dot. Thumbnail updated to match.

## What was preserved

- All game logic, collision detection, power-ups, particle system, and wave progression unchanged
- All required head tags, theme CSS variables, and shell integration intact
- Dark/light theme support retained

## Test plan

- [x] `npm run validate:apps` — passed
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 174 tests passed
- [x] `npm run validate:responsive:sample` — passed
- [x] `npm run build` — successful
- [x] `xmllint --noout thumbnail.svg` — SVG valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)