### PR TITLE
improve: galaxian-blitz — add mobile auto-fire toggle button

### DIFF
--- a/apps/2026/03/26/galaxian-blitz/index.html
+++ b/apps/2026/03/26/galaxian-blitz/index.html
@@ -206,6 +206,24 @@
         background: #7c3aed55;
       }
 
+      #autoFireBtn {
+        width: 56px;
+        height: 56px;
+        background: #1e293b;
+        border-color: #334155;
+        color: #64748b;
+        font-size: 10px;
+        font-weight: bold;
+        letter-spacing: 1px;
+        border-radius: 12px;
+      }
+      #autoFireBtn.auto-active {
+        background: #15803d22;
+        border-color: #4ade80;
+        color: #4ade80;
+        box-shadow: 0 0 10px #4ade8055;
+      }
+
       /* Overlay screens */
       #overlay {
         position: absolute;
@@ -322,6 +340,7 @@
         <button class="ctrl-btn" id="leftBtn" aria-label="Move left">◀</button>
         <button class="ctrl-btn" id="leftBtn2" aria-label="Move left">◀</button>
         <button id="fireBtn" class="ctrl-btn" aria-label="Fire">FIRE</button>
+        <button id="autoFireBtn" class="ctrl-btn" aria-label="Toggle auto-fire">⚡AUTO</button>
         <button class="ctrl-btn" id="rightBtn2" aria-label="Move right">▶</button>
         <button class="ctrl-btn" id="rightBtn" aria-label="Move right">▶</button>
       </div>
@@ -422,6 +441,7 @@
       let touchLeft = false;
       let touchRight = false;
       let touchFire = false;
+      let autoFire = false; // mobile auto-fire toggle
 
       // =====================================================================
       // INIT & RESIZE
@@ -514,6 +534,17 @@
           const el = document.getElementById(id);
           if (el) ctrlPress(el);
         });
+
+        // Auto-fire toggle — single tap to enable/disable
+        const autoBtn = document.getElementById('autoFireBtn');
+        if (autoBtn) {
+          autoBtn.addEventListener('pointerdown', (e) => {
+            e.preventDefault();
+            autoFire = !autoFire;
+            autoBtn.classList.toggle('auto-active', autoFire);
+            if (autoFire && (gameState === 'title' || gameState === 'gameover')) startGame();
+          });
+        }
       }
 
       // =====================================================================
@@ -1052,7 +1083,7 @@
         // Player movement
         const left = keys.left || touchLeft;
         const right = keys.right || touchRight;
-        const fire = keys.fire || touchFire;
+        const fire = keys.fire || touchFire || autoFire;
 
         if (left) player.x = Math.max(player.w / 2 + 4, player.x - player.speed * dt);
         if (right) player.x = Math.min(W - player.w / 2 - 4, player.x + player.speed * dt);

--- a/apps/2026/03/26/galaxian-blitz/meta.json
+++ b/apps/2026/03/26/galaxian-blitz/meta.json
@@ -39,6 +39,14 @@
       "implementedAt": "2026-03-26T15:00:54Z",
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
+    },
+    {
+      "issueNumber": 225,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/225",
+      "description": "Added mobile auto-fire toggle button (⚡AUTO) to the touch controls bar — single tap enables continuous firing at the normal cooldown rate (380ms), glows green when active; persists across rounds as a user preference.",
+      "implementedAt": "2026-03-26T15:38:32Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
     }
   ],
   "generation": {

--- a/data/apps.json
+++ b/data/apps.json
@@ -54,6 +54,14 @@
         "implementedAt": "2026-03-26T15:00:54Z",
         "agentName": "Claude Code",
         "llmModel": "claude-sonnet-4-6"
+      },
+      {
+        "issueNumber": 225,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/225",
+        "description": "Added mobile auto-fire toggle button (⚡AUTO) to the touch controls bar — single tap enables continuous firing at the normal cooldown rate (380ms), glows green when active; persists across rounds as a user preference.",
+        "implementedAt": "2026-03-26T15:38:32Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Closes #225
- Added an **⚡AUTO** toggle button to the mobile touch controls bar (`#mobileControls`, only shown on touch devices via `pointer: coarse` media query)
- Single tap enables/disables continuous auto-fire — no need to hold the FIRE button
- When active, glows green with a subtle box-shadow; when inactive, grey like other unlit controls
- Auto-fire uses the standard `BULLET_COOLDOWN_NORMAL` (380ms ≈ 2.6 shots/sec) — sustainable and not overpowered; respects the rapid-fire power-up when active
- Persists across rounds as a user preference (not reset on game restart)

## What was preserved

- FIRE button still works for manual fire — auto-fire is additive, not a replacement
- All game logic, enemy AI, power-ups, collision, and wave progression unchanged
- All required head tags, theme CSS variables, and shell integration intact

## Test plan

- [x] `npm run validate:apps` — passed
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 174 tests passed
- [x] `npm run validate:responsive:sample` — passed
- [x] `npm run build` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)