### PR TITLE
feat: track app version backups in registry and showcase

### DIFF
--- a/app/showcase/[...id]/page.jsx
+++ b/app/showcase/[...id]/page.jsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useVotes } from '@/hooks/useVotes';
 import VoteButtons from '@/components/VoteButtons';
 import { notFound } from 'next/navigation';
-import { use } from 'react';
+import { use, useState } from 'react';
 import AppLog from '@/components/AppLog';
 import { githubUrl } from '@/lib/siteConfig';
 
@@ -25,6 +25,7 @@ export default function AppDetailPage({ params }) {
 
 function AppDetailContent({ app, id }) {
   const { upvoteCount, downvoteCount, myVote, isLoading, isVoting, vote } = useVotes(id);
+  const [selectedVersionUrl, setSelectedVersionUrl] = useState(app.appPath);
 
   const formattedDate = new Date(app.createdAt).toLocaleDateString('en-US', {
     year: 'numeric',
@@ -140,17 +141,34 @@ function AppDetailContent({ app, id }) {
               </div>
             </div>
 
-            <a
-              href={app.appPath}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="animate-pulse-ring relative inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-semibold text-white text-sm bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-500 hover:from-emerald-600 hover:via-teal-500 hover:to-cyan-600 shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-105"
-            >
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M8 5v14l11-7z" />
-              </svg>
-              Launch App
-            </a>
+            <div className="flex items-center gap-2">
+              <a
+                href={selectedVersionUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="animate-pulse-ring relative inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-semibold text-white text-sm bg-gradient-to-r from-emerald-500 via-teal-400 to-cyan-500 hover:from-emerald-600 hover:via-teal-500 hover:to-cyan-600 shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-105"
+              >
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Launch App
+              </a>
+              {app.backups && app.backups.length > 0 && (
+                <select
+                  value={selectedVersionUrl}
+                  onChange={(e) => setSelectedVersionUrl(e.target.value)}
+                  className="text-xs rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 px-2 py-2 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  aria-label="Select app version"
+                >
+                  <option value={app.appPath}>Current (latest)</option>
+                  {app.backups.map((b) => (
+                    <option key={b.runId} value={b.url}>
+                      {b.runId}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
           </div>
 
           <p className="text-gray-600 dark:text-gray-300 text-lg">{app.shortDescription}</p>

--- a/data/apps.json
+++ b/data/apps.json
@@ -1,47 +1,5 @@
 [
   {
-    "id": "2026/03/26/sokoban-warehouse/backups/run-20260327T145952Z-b90288",
-    "name": "Sokoban Warehouse",
-    "shortDescription": "Classic box-pushing puzzle game with 12 levels of increasing difficulty. Push crates onto targets using swipe, on-screen D-pad, or arrow keys — with unlimited undo and a level select menu.",
-    "thumbnailUrl": "/apps/2026/03/26/sokoban-warehouse/backups/run-20260327T145952Z-b90288/thumbnail.svg",
-    "createdAt": "2026-03-26T18:53:45Z",
-    "year": 2026,
-    "month": 3,
-    "day": 26,
-    "category": "Games",
-    "inputMode": "responsive",
-    "status": "active",
-    "tags": ["puzzle", "sokoban", "mobile", "touch", "classic", "grid", "levels"],
-    "route": "/apps/2026/03/26/sokoban-warehouse/backups/run-20260327T145952Z-b90288",
-    "appPath": "/apps/2026/03/26/sokoban-warehouse/backups/run-20260327T145952Z-b90288/index.html",
-    "generation": {
-      "agentName": "claude-code",
-      "llmModel": "claude-sonnet-4-6",
-      "startTime": "2026-03-26T18:53:45Z",
-      "endTime": "2026-03-26T19:05:00Z",
-      "totalTokensIn": 15000,
-      "totalTokensOut": 20000,
-      "runId": "run-20260326T185345Z-a3f7c2",
-      "notes": "Built from approved community suggestion issue #230. 12 hand-crafted levels of increasing difficulty. Canvas-based rendering with brick walls, wooden crate aesthetic, amber color palette. Token counts are estimates."
-    },
-    "suggestion": {
-      "issueNumber": 230,
-      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/230",
-      "prompt": "Build a mobile-first version of the classic puzzle game Sokoban with multiple levels. The game should run in a single web page, no frameworks. Requirements: Grid-based warehouse layout with walls, floor tiles, movable boxes/crates, storage targets, and a player. Use simple 2D graphics or colored tiles; ensure everything is readable on phones. Touch controls for mobile (swipe or on-screen arrows) and arrow keys for desktop. Rules: the player can move up/down/left/right; pushing exactly one adjacent box into an empty floor tile is allowed, but pulling is not. Level is solved when all boxes are on target tiles. Include at least 10 built-in levels of increasing difficulty, selectable from a simple level menu. Track moves and pushes; show level complete message and option to restart or go to the next level. Provide a clean, responsive layout that works well on small screens first, then scales to desktop."
-    },
-    "improvements": [
-      {
-        "issueNumber": 232,
-        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/232",
-        "description": "Reworked upper-level Sokoban layouts to ensure the reported levels are solvable.",
-        "implementedAt": "2026-03-26T20:21:31Z",
-        "agentName": "GitHub Copilot",
-        "llmModel": "GPT-5.3-Codex"
-      }
-    ],
-    "allowImprovements": true
-  },
-  {
     "id": "2026/03/26/sokoban-warehouse",
     "name": "Sokoban Warehouse",
     "shortDescription": "Classic box-pushing puzzle game with 12 levels of increasing difficulty. Push crates onto targets using swipe, on-screen D-pad, or arrow keys — with unlimited undo and a level select menu.",
@@ -90,7 +48,14 @@
         "llmModel": "claude-sonnet-4-6"
       }
     ],
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": [
+      {
+        "runId": "run-20260327T145952Z-b90288",
+        "path": "backups/run-20260327T145952Z-b90288/index.html",
+        "url": "/apps/2026/03/26/sokoban-warehouse/backups/run-20260327T145952Z-b90288/index.html"
+      }
+    ]
   },
   {
     "id": "2026/03/26/galaxian-blitz",
@@ -157,7 +122,8 @@
         "llmModel": "claude-sonnet-4-6"
       }
     ],
-    "allowImprovements": false
+    "allowImprovements": false,
+    "backups": null
   },
   {
     "id": "2026/03/26/raffle-night-caller",
@@ -186,7 +152,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/25/neon-slot-rush",
@@ -257,7 +224,8 @@
         "llmModel": "claude-sonnet-4-6"
       }
     ],
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/25/peg-solitaire",
@@ -291,7 +259,8 @@
       "requestor": "Perplexity"
     },
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/24/charades-chaos-deck",
@@ -339,7 +308,8 @@
         "llmModel": "claude-sonnet-4-6"
       }
     ],
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/24/foley-scene-mixer",
@@ -368,7 +338,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/24/story-beat-remixer",
@@ -397,7 +368,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/23/dungeon-puzzle-run",
@@ -441,7 +413,8 @@
         "llmModel": "claude-sonnet-4-6"
       }
     ],
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/23/tic-tac-toe-strategy-lab",
@@ -470,7 +443,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/21/texas-lotto-generator",
@@ -504,7 +478,8 @@
       "requestor": "Gary S."
     },
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/21/neighborhood-home-ranker",
@@ -547,7 +522,8 @@
       "requestor": "Alexander M."
     },
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/21/tetris-classic",
@@ -581,7 +557,8 @@
       "requestor": "Jeff Holst"
     },
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/21/morse-code-radio",
@@ -610,7 +587,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/21/pattern-pulse-memory",
@@ -639,7 +617,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/20/sudoku-sprint",
@@ -668,7 +647,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/20/neon-lane-sprinter",
@@ -697,7 +677,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/19/slide-2048",
@@ -726,7 +707,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/19/orbit-memory-match",
@@ -755,7 +737,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/18/cyber-hop",
@@ -793,7 +776,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/17/hangman-word-game",
@@ -822,7 +806,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/17/focus-timer",
@@ -851,7 +836,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/16/mindful-breathing-tracker",
@@ -880,7 +866,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/16/memory-sequence",
@@ -909,7 +896,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/15/focus-sprint-planner",
@@ -938,7 +926,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/15/hydration-nudge-tracker",
@@ -967,7 +956,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/14/decision-spinner",
@@ -996,7 +986,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/14/password-entropy-lab",
@@ -1025,7 +1016,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/14/focus-flip-cards",
@@ -1054,7 +1046,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/13/interval-breathing-coach",
@@ -1083,7 +1076,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/13/bubble-tap",
@@ -1112,7 +1106,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/12/meeting-cost-calculator",
@@ -1141,7 +1136,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/12/timezone-overlap-finder",
@@ -1170,7 +1166,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/12/constellation-explorer",
@@ -1199,7 +1196,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/12/sorting-race-visualizer",
@@ -1228,7 +1226,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/11/lucky-decision-wheel",
@@ -1257,7 +1256,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/10/maze-runner",
@@ -1286,7 +1286,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/10/habit-streak-garden",
@@ -1315,7 +1316,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/10/neon-breakout",
@@ -1344,7 +1346,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/10/pixel-painter",
@@ -1373,7 +1376,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/09/pixel-planet-clicker",
@@ -1402,7 +1406,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/09/gravity-dodge",
@@ -1431,7 +1436,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/typing-speed-sprint",
@@ -1460,7 +1466,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/daredevil-moto-jump",
@@ -1489,7 +1496,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/mini-putt-gauntlet",
@@ -1518,7 +1526,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/orbit-harmonics",
@@ -1547,7 +1556,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/eagle-eye-teacher",
@@ -1576,7 +1586,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/logic-lights-out",
@@ -1605,7 +1616,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/08/space-invaders-clone",
@@ -1634,7 +1646,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/workout-timer-pulse",
@@ -1663,7 +1676,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/road-rage",
@@ -1692,7 +1706,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/neon-velocity",
@@ -1721,7 +1736,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/fishing-frenzy",
@@ -1750,7 +1766,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/design-dash",
@@ -1779,7 +1796,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/realtor-tycoon",
@@ -1808,7 +1826,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/zorkish-text-adventure",
@@ -1837,7 +1856,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/halftime-hustle",
@@ -1866,7 +1886,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/pacman-classic",
@@ -1895,7 +1916,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/debug-rush",
@@ -1924,7 +1946,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/blackjack",
@@ -1953,7 +1976,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/archery-physics",
@@ -1982,7 +2006,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/disco-runner",
@@ -2011,7 +2036,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/flappy-bird",
@@ -2040,7 +2066,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/07/contrast-lab",
@@ -2069,7 +2096,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/habit-heatmap",
@@ -2098,7 +2126,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/word-weaver",
@@ -2127,7 +2156,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/reaction-ripple",
@@ -2156,7 +2186,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/memory-match",
@@ -2185,7 +2216,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/focus-fountain",
@@ -2214,7 +2246,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/sorting-visualizer",
@@ -2243,7 +2276,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/06/word-scramble",
@@ -2272,7 +2306,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/05/snake-game",
@@ -2301,7 +2336,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/05/breathing-orb",
@@ -2330,7 +2366,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/05/pomodoro-timer",
@@ -2359,7 +2396,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/05/color-palette-generator",
@@ -2388,7 +2426,8 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   },
   {
     "id": "2026/03/05/example-app",
@@ -2417,6 +2456,7 @@
     },
     "suggestion": null,
     "improvements": null,
-    "allowImprovements": true
+    "allowImprovements": true,
+    "backups": null
   }
 ]

--- a/scripts/apps-registry.js
+++ b/scripts/apps-registry.js
@@ -19,6 +19,9 @@ export function findMetaFiles(dir, files = []) {
     const fullPath = path.join(dir, entry.name);
 
     if (entry.isDirectory()) {
+      if (entry.name === 'backups') {
+        continue;
+      }
       findMetaFiles(fullPath, files);
     } else if (entry.name === 'meta.json') {
       files.push(fullPath);
@@ -26,6 +29,29 @@ export function findMetaFiles(dir, files = []) {
   }
 
   return files;
+}
+
+function findBackups(appDir) {
+  const backupsDir = path.join(appDir, 'backups');
+  if (!fs.existsSync(backupsDir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(backupsDir, { withFileTypes: true });
+  const backups = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const runId = entry.name;
+    if (fs.existsSync(path.join(backupsDir, runId, 'index.html'))) {
+      backups.push({ runId, path: `backups/${runId}/index.html` });
+    }
+  }
+
+  backups.sort((a, b) => a.runId.localeCompare(b.runId));
+  return backups;
 }
 
 export function parseDateFromPath(appsDir, filePath) {
@@ -44,7 +70,7 @@ export function parseDateFromPath(appsDir, filePath) {
   return null;
 }
 
-export function transformMeta(appsDir, meta, filePath, dateInfo, basePath = '') {
+export function transformMeta(appsDir, meta, filePath, dateInfo, basePath = '', backups = []) {
   const appDir = path.dirname(filePath);
   const relativeAppDir = path.relative(appsDir, appDir);
   const normalizedAppDir = relativeAppDir.split(path.sep).join('/');
@@ -69,6 +95,14 @@ export function transformMeta(appsDir, meta, filePath, dateInfo, basePath = '') 
     suggestion: meta.suggestion || null,
     improvements: meta.improvements || null,
     allowImprovements: meta.allowImprovements ?? true,
+    backups:
+      backups.length > 0
+        ? backups.map((b) => ({
+            runId: b.runId,
+            path: b.path,
+            url: `${basePath}/apps/${normalizedAppDir}/${b.path}`,
+          }))
+        : null,
   };
 }
 
@@ -96,7 +130,8 @@ export function buildAppsRegistry({ appsDir, basePath = '', onWarning } = {}) {
         continue;
       }
 
-      apps.push(transformMeta(appsDir, meta, filePath, dateInfo, basePath));
+      const backups = findBackups(path.dirname(filePath));
+      apps.push(transformMeta(appsDir, meta, filePath, dateInfo, basePath, backups));
     } catch (error) {
       const warning = `Error processing ${filePath}: ${error.message}`;
       warnings.push(warning);


### PR DESCRIPTION
## Summary

- **Fixes duplicate app entries** caused by `generate:apps` recursing into `backups/` subdirectories and treating each backup's `meta.json` as a top-level app
- **Adds backup version tracking** to `data/apps.json` — each app entry now includes a `backups` array (or `null`) derived from its `backups/` folder on disk
- **Adds a version picker** on the showcase page so users can launch prior versions of an app alongside the current one

## Changes

### `scripts/apps-registry.js`
- `findMetaFiles`: skip any directory named `backups` during recursion — eliminates the root cause of duplicate entries
- `findBackups` (new): scans `<appDir>/backups/` for subdirectories containing `index.html`; returns entries sorted by `runId` with `{ runId, path, url }`
- `transformMeta`: accepts `backups` parameter and maps entries into the registry output; `null` when no backups exist
- `buildAppsRegistry`: calls `findBackups` per app and passes results through to `transformMeta`

### `data/apps.json`
- Regenerated: duplicate backup entry removed (78 → 77 scanned)
- Sokoban Warehouse now carries its existing backup (`run-20260327T145952Z-b90288`); all other apps have `backups: null`

### `app/showcase/[...id]/page.jsx`
- Adds `selectedVersionUrl` state (defaults to `app.appPath`)
- Hero image `<a>` always opens the current version (unchanged)
- "Launch App" button now uses `selectedVersionUrl`
- When `app.backups` has entries, a `<select>` dropdown appears next to the button — "Current (latest)" as the default option, followed by one option per backup labeled with its `runId`

## Test plan
- [x] `npm run generate:apps` — no duplicate entries, sokoban-warehouse has backups array
- [x] `npm run validate:apps` — all passed
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 204 tests passed
- [x] `npm run build` — successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)