### PR TITLE
feat: harden issue pipeline against prompt injection and unauthorized submissions

### DIFF
--- a/__tests__/scripts/issues/retrieve-pending-issues.test.js
+++ b/__tests__/scripts/issues/retrieve-pending-issues.test.js
@@ -531,11 +531,12 @@ describe('normalizeIssue — body truncation', () => {
     expect(normalizeIssue(makeIssue({ body })).body).toBe(body);
   });
 
-  it('truncates body over 1000 chars and appends [truncated]', () => {
+  it('truncates body over 1000 chars and keeps result within 1000 chars', () => {
     const body = 'x'.repeat(1001);
     const result = normalizeIssue(makeIssue({ body })).body;
-    expect(result).toBe('x'.repeat(1000) + ' [truncated]');
-    expect(result.length).toBe(1012);
+    const marker = ' [truncated]';
+    expect(result).toBe('x'.repeat(1000 - marker.length) + marker);
+    expect(result.length).toBe(1000);
   });
 
   it('handles null body gracefully', () => {

--- a/scripts/issues/retrieve-pending-issues.js
+++ b/scripts/issues/retrieve-pending-issues.js
@@ -36,7 +36,12 @@ function normalizeLabels(labels = []) {
 
 export function normalizeIssue(issue) {
   const rawBody = issue.body ?? '';
-  const body = rawBody.length > 1000 ? rawBody.slice(0, 1000) + ' [truncated]' : rawBody;
+  const TRUNCATION_MARKER = ' [truncated]';
+  const BODY_LIMIT = 1000;
+  const body =
+    rawBody.length > BODY_LIMIT
+      ? rawBody.slice(0, BODY_LIMIT - TRUNCATION_MARKER.length) + TRUNCATION_MARKER
+      : rawBody;
   return {
     number: issue.number,
     type: inferIssueType(issue),

--- a/scripts/issues/select-app-improvement.js
+++ b/scripts/issues/select-app-improvement.js
@@ -61,7 +61,14 @@ function getTipTotal(issueNumber, repoOwner) {
   return total;
 }
 
-function getBoostedImprovements() {
+function isAuthorAllowed(issue, repoOwner) {
+  if (!repoOwner) {
+    return true;
+  } // fail open if owner lookup failed
+  return (issue.author?.login ?? null) === repoOwner;
+}
+
+function getBoostedImprovements(repoOwner, rejectPhrases) {
   log('  Checking boosted+approved improvement issues...');
   const issues = listIssuesByLabels({
     labels: ['improvement', 'status:approved', 'boosted'],
@@ -73,18 +80,22 @@ function getBoostedImprovements() {
     return [];
   }
 
-  const owner = getRepoOwner();
+  // Apply author/injection filters BEFORE fetching tip totals to avoid
+  // unnecessary API calls for issues that will be dropped anyway.
+  const eligible = issues
+    .filter((issue) => isAuthorAllowed(issue, repoOwner))
+    .filter((issue) => !containsInjectionPhrase(issue, rejectPhrases));
 
-  const ranked = issues.map((issue) => ({
+  const ranked = eligible.map((issue) => ({
     ...issue,
-    tipTotal: getTipTotal(issue.number, owner),
+    tipTotal: getTipTotal(issue.number, repoOwner),
   }));
   ranked.sort((a, b) => b.tipTotal - a.tipTotal || a.number - b.number);
 
   return ranked;
 }
 
-function getApprovedImprovements() {
+function getApprovedImprovements(repoOwner, rejectPhrases) {
   log('  Checking approved (non-boosted) improvement issues...');
   const issues = listIssuesByLabels({
     labels: ['improvement', 'status:approved'],
@@ -95,8 +106,11 @@ function getApprovedImprovements() {
   if (!issues || issues.length === 0) {
     return [];
   }
-  issues.sort((a, b) => a.number - b.number);
-  return issues;
+  const eligible = issues
+    .filter((issue) => isAuthorAllowed(issue, repoOwner))
+    .filter((issue) => !containsInjectionPhrase(issue, rejectPhrases));
+  eligible.sort((a, b) => a.number - b.number);
+  return eligible;
 }
 
 // ---------------------------------------------------------------------------
@@ -180,9 +194,7 @@ function loadRejectPhrases() {
       return [];
     }
     const phraseMatches = [...match[1].matchAll(/"([^"]+)"|'([^']+)'/g)];
-    const phrases = phraseMatches
-      .map((m) => (m[1] ?? m[2])?.toLowerCase())
-      .filter(Boolean);
+    const phrases = phraseMatches.map((m) => (m[1] ?? m[2])?.toLowerCase()).filter(Boolean);
     return phrases;
   } catch {
     return [];
@@ -272,20 +284,11 @@ async function main() {
   const rejectPhrases = loadRejectPhrases();
   log(`  Loaded ${rejectPhrases.length} injection reject phrase(s) from guardrails.`);
 
-  function isAuthorAllowed(issue) {
-    if (!repoOwner) {
-      return true;
-    } // fail open if owner lookup failed
-    return (issue.author?.login ?? null) === repoOwner;
-  }
-
   // ---------------------------------------------------------------------------
   // Pass 1: Boosted improvement issues
   // ---------------------------------------------------------------------------
   log('Pass 1: GitHub boosted improvement issues');
-  const boostedList = getBoostedImprovements()
-    .filter((issue) => isAuthorAllowed(issue))
-    .filter((issue) => !containsInjectionPhrase(issue, rejectPhrases));
+  const boostedList = getBoostedImprovements(repoOwner, rejectPhrases);
   for (const issue of boostedList) {
     const result = buildResult('github-boosted', issue, apps);
     if (result.found) {
@@ -300,9 +303,7 @@ async function main() {
   // Pass 2: Approved improvement issues
   // ---------------------------------------------------------------------------
   log('Pass 2: GitHub approved improvement issues');
-  const approvedList = getApprovedImprovements()
-    .filter((issue) => isAuthorAllowed(issue))
-    .filter((issue) => !containsInjectionPhrase(issue, rejectPhrases));
+  const approvedList = getApprovedImprovements(repoOwner, rejectPhrases);
   for (const issue of approvedList) {
     const result = buildResult('github-approved', issue, apps);
     if (result.found) {


### PR DESCRIPTION
## Description
Hardens the automated issue review/selection pipeline by restricting which GitHub issues are eligible for processing and reducing the amount of untrusted text that reaches agent prompts.

## Type of Change
- [ ] 🐛 Bug fix (fixes an issue without changing feature behavior)
- [ ] ✨ New feature (adds functionality)
- [x] 🔄 Refactoring (improves code without changing behavior)
- [ ] 📚 Documentation (updates docs, README, guides)
- [x] ⚡ Performance improvement
- [ ] 🎨 Style/formatting (code style, theme updates)

## Changes Made
- **Author filter**: `retrieve-pending-issues.js` and `select-app-improvement.js` now only process issues created by the repo owner — determined via `getRepoOwner()`. Fails open (no filtering) if the owner lookup is unavailable.
- **Body truncation**: `normalizeIssue()` caps issue body at exactly 1,000 chars (marker included) by slicing to `1000 - marker.length` (988 chars) before appending the 12-char `' [truncated]'` marker, ensuring the result never exceeds the hard 1,000-char cap.
- **Prompt narrowing**: `select-app-improvement.js` passes `description` (the extracted field from the issue body) to the agent prompt instead of the full raw `issue.body`.
- **Injection keyword scan**: `select-app-improvement.js` loads the `[review.reject_if_contains]` phrase list from `guardrails.production` (falling back to `guardrails.example`) and silently drops any issue whose title or body contains a known injection phrase before it reaches the agent. Both double- and single-quoted TOML strings are supported.
- **Filter-before-fetch**: `isAuthorAllowed()` is extracted as a module-level helper accepting `repoOwner`. Author and injection filters are applied inside `getBoostedImprovements(repoOwner, rejectPhrases)` and `getApprovedImprovements(repoOwner, rejectPhrases)` — before `getTipTotal()` is called — so `getIssueComments()` API calls are only made for issues that survive both filters, avoiding wasted GitHub API rate-limit consumption.

## How to Test
1. Run `npm run select:app:improvement` — verify only repo-owner issues are considered and tip totals are not fetched for filtered-out issues.
2. Submit an issue body longer than 1,000 chars and verify `normalizeIssue()` returns exactly 1,000 chars including the `[truncated]` marker.
3. Add a reject phrase to `guardrails.example` and verify an issue matching that phrase is silently skipped.
4. Run `npm test` — 214 tests pass.
5. Run `npm run lint` — 0 errors, 0 warnings.

## Screenshots / Videos (if applicable)
N/A — no UI changes.

## Checklist
- [x] Code follows [STYLE_GUIDE.md](../docs/STYLE_GUIDE.md)
- [x] ESLint passes: `npm run lint`
- [x] Code is formatted: `npm run format`
- [x] Build succeeds: `npm run build`
- [x] No new console warnings or errors
- [ ] Responsive design tested (mobile & desktop)
- [ ] Dark mode tested (if UI changes)
- [ ] Accessibility checked (`alt` text, ARIA labels, keyboard nav)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Documentation updated (if user-facing change)
- [x] Related tests pass (if applicable)

## Deployment Notes
No migrations, env var changes, or config changes required.

## Reviewers
N/A

## Additional Context
The truncation test was updated to assert `result.length === 1000` (was 1012 under the old off-by-marker-length behaviour). The filter-before-fetch refactor moves all filtering into the fetcher functions so `main()` simply calls `getBoostedImprovements(repoOwner, rejectPhrases)` and `getApprovedImprovements(repoOwner, rejectPhrases)` without any post-call filter chains.