### PR TITLE
improve: two-truths-lie-game — spinner fix, statement capture, thumbnail redo [skip deploy]

### DIFF
--- a/apps/2026/03/31/two-truths-lie-game/index.html
+++ b/apps/2026/03/31/two-truths-lie-game/index.html
@@ -583,37 +583,193 @@
         <h3>Now speaking…</h3>
         <div class="winner-name" id="turnSpeakerName"></div>
 
-        <div class="card">
+        <!-- Phase 1: host enters the 3 statements -->
+        <div id="statementCapture" class="card">
           <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 10px">
-            After <strong id="turnSpeakerName2"></strong> reads their 3 statements, record each
-            player's guess — which number is the lie?
+            Ask <strong id="turnSpeakerName2"></strong> to share their 3 statements, then type them
+            in below.
           </p>
-          <div class="guess-grid" id="guessGrid"></div>
-        </div>
-
-        <div class="card">
-          <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px">
-            Which statement was the LIE?
-          </p>
-          <div class="flex-row" id="lieButtons">
-            <button class="btn btn-ghost" onclick="selectLie(1)">Statement 1</button>
-            <button class="btn btn-ghost" onclick="selectLie(2)">Statement 2</button>
-            <button class="btn btn-ghost" onclick="selectLie(3)">Statement 3</button>
+          <div style="display: flex; flex-direction: column; gap: 10px">
+            <div style="display: flex; gap: 10px; align-items: center">
+              <span
+                style="
+                  background: var(--accent);
+                  color: white;
+                  border-radius: 50%;
+                  width: 28px;
+                  height: 28px;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-weight: 700;
+                  flex-shrink: 0;
+                "
+                >1</span
+              >
+              <input
+                id="stmt1"
+                class="input"
+                type="text"
+                placeholder="Statement 1…"
+                maxlength="140"
+                autocomplete="off"
+              />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center">
+              <span
+                style="
+                  background: var(--accent);
+                  color: white;
+                  border-radius: 50%;
+                  width: 28px;
+                  height: 28px;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-weight: 700;
+                  flex-shrink: 0;
+                "
+                >2</span
+              >
+              <input
+                id="stmt2"
+                class="input"
+                type="text"
+                placeholder="Statement 2…"
+                maxlength="140"
+                autocomplete="off"
+              />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center">
+              <span
+                style="
+                  background: var(--accent);
+                  color: white;
+                  border-radius: 50%;
+                  width: 28px;
+                  height: 28px;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-weight: 700;
+                  flex-shrink: 0;
+                "
+                >3</span
+              >
+              <input
+                id="stmt3"
+                class="input"
+                type="text"
+                placeholder="Statement 3…"
+                maxlength="140"
+                autocomplete="off"
+              />
+            </div>
           </div>
-          <p
-            id="lieSelectedMsg"
-            style="display: none; margin-top: 8px; font-size: 0.9rem; color: var(--success); font-weight: 600"
-          ></p>
+          <button
+            id="showStatementsBtn"
+            class="btn btn-primary full-width"
+            style="margin-top: 14px"
+            onclick="submitStatements()"
+            disabled
+          >
+            Show Statements on Screen →
+          </button>
         </div>
 
-        <button
-          id="revealBtn"
-          class="btn btn-danger btn-lg full-width"
-          onclick="revealLie()"
-          disabled
-        >
-          Reveal the Lie!
-        </button>
+        <!-- Phase 2: statements displayed + guess recording (shown after submitStatements) -->
+        <div id="statementsDisplay" style="display: none; width: 100%">
+          <div class="card">
+            <h3 style="margin-bottom: 10px">Statements</h3>
+            <div style="display: flex; flex-direction: column; gap: 8px">
+              <div class="guess-row" style="border-color: var(--accent-dark)">
+                <span
+                  style="
+                    background: var(--accent);
+                    color: white;
+                    border-radius: 50%;
+                    width: 28px;
+                    height: 28px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-weight: 700;
+                    flex-shrink: 0;
+                  "
+                  >1</span
+                >
+                <span id="stmtDisplay1" class="guess-name" style="font-weight: 400"></span>
+              </div>
+              <div class="guess-row" style="border-color: var(--accent-dark)">
+                <span
+                  style="
+                    background: var(--accent);
+                    color: white;
+                    border-radius: 50%;
+                    width: 28px;
+                    height: 28px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-weight: 700;
+                    flex-shrink: 0;
+                  "
+                  >2</span
+                >
+                <span id="stmtDisplay2" class="guess-name" style="font-weight: 400"></span>
+              </div>
+              <div class="guess-row" style="border-color: var(--accent-dark)">
+                <span
+                  style="
+                    background: var(--accent);
+                    color: white;
+                    border-radius: 50%;
+                    width: 28px;
+                    height: 28px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-weight: 700;
+                    flex-shrink: 0;
+                  "
+                  >3</span
+                >
+                <span id="stmtDisplay3" class="guess-name" style="font-weight: 400"></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top: 0">
+            <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 10px">
+              Each player: which number is the lie?
+            </p>
+            <div class="guess-grid" id="guessGrid"></div>
+          </div>
+
+          <div class="card" style="margin-top: 0">
+            <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px">
+              Which statement was the LIE?
+            </p>
+            <div class="flex-row" id="lieButtons">
+              <button class="btn btn-ghost" onclick="selectLie(1)">Statement 1</button>
+              <button class="btn btn-ghost" onclick="selectLie(2)">Statement 2</button>
+              <button class="btn btn-ghost" onclick="selectLie(3)">Statement 3</button>
+            </div>
+            <p
+              id="lieSelectedMsg"
+              style="display: none; margin-top: 8px; font-size: 0.9rem; color: var(--success); font-weight: 600"
+            ></p>
+          </div>
+
+          <button
+            id="revealBtn"
+            class="btn btn-danger btn-lg full-width"
+            onclick="revealLie()"
+            disabled
+          >
+            Reveal the Lie!
+          </button>
+        </div>
       </div>
 
       <!-- ── SCREEN: Reveal ── -->
@@ -621,6 +777,10 @@
         <div class="round-badge" id="roundBadgeReveal"></div>
         <h2>The Lie was Statement <span id="lieNumDisplay"></span>!</h2>
         <p class="text-center" id="revealSpeakerNote" style="color: var(--text-muted)"></p>
+
+        <div id="revealStatements" class="card" style="display: none; width: 100%">
+          <div style="display: flex; flex-direction: column; gap: 8px" id="revealStmtList"></div>
+        </div>
 
         <div class="guess-grid" id="revealGrid"></div>
 
@@ -703,6 +863,9 @@
 
       /** Map of guesser name → guessed statement number. */
       let guesses = {};
+
+      /** The 3 statements entered by the host for the current speaker. */
+      let currentStatements = ['', '', ''];
 
       let timerInterval = null;
       let timerSecs = 60;
@@ -990,15 +1153,18 @@
 
         // Pick a random target segment
         const winnerIdx = Math.floor(Math.random() * n);
-        // Spin 3–6 full rotations then land with winner at the pointer (angle 0 = right)
-        const extraRotations = 3 + Math.random() * 3;
+        // Use an integer number of extra rotations so the correction math is exact.
+        const extraRotations = 3 + Math.floor(Math.random() * 4); // 3, 4, 5, or 6
         const targetSegmentCenter = winnerIdx * slice + slice / 2;
-        // Pointer is at angle 0 relative to drawing start; land pointer on winner
-        const spinTarget =
-          spinAngle +
-          extraRotations * 2 * Math.PI +
-          (2 * Math.PI - (spinAngle % (2 * Math.PI))) -
-          targetSegmentCenter;
+        // Compute how much we need to rotate from the current position so that
+        // segment winnerIdx's center lands at angle 0 (where the pointer is).
+        // We want: (spinAngle + delta + targetSegmentCenter) ≡ 0 (mod 2π)
+        // → delta = -spinAngle - targetSegmentCenter + k*2π for the smallest positive k
+        const correction =
+          ((2 * Math.PI - ((spinAngle + targetSegmentCenter) % (2 * Math.PI))) %
+            (2 * Math.PI)) +
+          extraRotations * 2 * Math.PI;
+        const spinTarget = spinAngle + correction;
 
         const duration = 3500;
         const startTime = performance.now();
@@ -1045,18 +1211,69 @@
 
       /**
        * Transition to the turn screen for the current speaker.
-       * Resets all guesses and the lie selection for this turn.
+       * Shows the statement-capture phase first; guess grid is hidden until statements are submitted.
        */
       function goToTurn() {
         guesses = {};
         currentLie = null;
+        currentStatements = ['', '', ''];
         document.getElementById('roundBadgeTurn').textContent = `Round ${round}`;
         document.getElementById('turnSpeakerName').textContent = currentSpeaker;
         document.getElementById('turnSpeakerName2').textContent = currentSpeaker;
-        buildGuessGrid();
+
+        // Reset statement inputs
+        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
+          const el = document.getElementById(id);
+          el.value = '';
+          el.disabled = false;
+        });
+        document.getElementById('showStatementsBtn').disabled = true;
+        document.getElementById('statementCapture').style.display = 'block';
+        document.getElementById('statementsDisplay').style.display = 'none';
+
         resetLieButtons();
-        document.getElementById('revealBtn').disabled = true;
         showScreen('screenTurn');
+
+        // Enable submit button when all 3 statements are non-empty
+        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
+          document.getElementById(id).addEventListener('input', checkStatementsReady);
+        });
+      }
+
+      /**
+       * Enable the "Show Statements" button only when all 3 inputs have content.
+       */
+      function checkStatementsReady() {
+        const all = ['stmt1', 'stmt2', 'stmt3'].every(
+          id => document.getElementById(id).value.trim().length > 0,
+        );
+        document.getElementById('showStatementsBtn').disabled = !all;
+      }
+
+      /**
+       * Lock the statement inputs, display them numbered on screen, and reveal the guess grid.
+       */
+      function submitStatements() {
+        currentStatements = ['stmt1', 'stmt2', 'stmt3'].map(id =>
+          document.getElementById(id).value.trim(),
+        );
+
+        // Lock inputs
+        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
+          document.getElementById(id).disabled = true;
+        });
+
+        // Display numbered statements
+        ['stmtDisplay1', 'stmtDisplay2', 'stmtDisplay3'].forEach((id, i) => {
+          document.getElementById(id).textContent = currentStatements[i];
+        });
+
+        // Switch phases
+        document.getElementById('statementCapture').style.display = 'none';
+        document.getElementById('statementsDisplay').style.display = 'block';
+
+        buildGuessGrid();
+        document.getElementById('revealBtn').disabled = true;
       }
 
       /**
@@ -1148,6 +1365,25 @@
         document.getElementById('lieNumDisplay').textContent = currentLie;
         document.getElementById('revealSpeakerNote').textContent =
           `${currentSpeaker}'s lie was statement ${currentLie}`;
+
+        // Show the 3 statements on the reveal screen if they were captured
+        const revealStmts = document.getElementById('revealStatements');
+        const revealList = document.getElementById('revealStmtList');
+        if (currentStatements.some(s => s.length > 0)) {
+          revealList.innerHTML = currentStatements
+            .map((s, i) => {
+              const isLie = i + 1 === currentLie;
+              return `<div class="guess-row ${isLie ? 'wrong' : 'correct'}">
+                <span style="background:${isLie ? 'var(--danger)' : 'var(--success)'};color:white;border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;font-weight:700;flex-shrink:0">${i + 1}</span>
+                <span style="flex:1;font-size:0.95rem">${escHtml(s)}</span>
+                <span>${isLie ? '🤥' : '✓'}</span>
+              </div>`;
+            })
+            .join('');
+          revealStmts.style.display = 'block';
+        } else {
+          revealStmts.style.display = 'none';
+        }
 
         const guessers = players.filter(p => p.name !== currentSpeaker);
         let correct = 0;
@@ -1251,6 +1487,7 @@
         players = [];
         round = 1;
         spinAngle = 0;
+        currentStatements = ['', '', ''];
         renderPlayerList();
         showScreen('screenSetup');
       }

--- a/apps/2026/03/31/two-truths-lie-game/meta.json
+++ b/apps/2026/03/31/two-truths-lie-game/meta.json
@@ -19,6 +19,15 @@
     "runId": "run-20260331T015453Z-a7f3c2",
     "notes": "Built from community suggestion #243. 6-screen host-driven flow: Setup → Think Timer (round 1 only) → Spinner wheel → Turn/Guess recording → Reveal → Round-end Scoreboard. Dark purple theme optimised for Zoom screen-sharing."
   },
+  "improvements": [
+    {
+      "issueNumber": 245,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/245",
+      "runId": "run-20260331T022221Z-d4e8f1",
+      "appliedAt": "2026-03-31T02:22:21Z",
+      "summary": "Fixed spinner wheel alignment (integer rotations + corrected modulo formula), added host statement capture on turn screen with numbered display, updated reveal screen to show statements with lie highlighted, redrew thumbnail with geometrically perfect circular wheel using SVG arc paths and clipPath."
+    }
+  ],
   "suggestion": {
     "issueNumber": 243,
     "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/243",

--- a/apps/2026/03/31/two-truths-lie-game/thumbnail.svg
+++ b/apps/2026/03/31/two-truths-lie-game/thumbnail.svg
@@ -5,16 +5,11 @@
       <stop offset="0%" stop-color="#0f172a"/>
       <stop offset="100%" stop-color="#1e1040"/>
     </linearGradient>
-    <!-- Accent glow gradient for title -->
+    <!-- Title gradient -->
     <linearGradient id="titleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" stop-color="#a78bfa"/>
       <stop offset="100%" stop-color="#818cf8"/>
     </linearGradient>
-    <!-- Wheel gradient overlay -->
-    <radialGradient id="wheelGlow" cx="50%" cy="50%" r="50%">
-      <stop offset="70%" stop-color="#000000" stop-opacity="0"/>
-      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0.3"/>
-    </radialGradient>
     <!-- Card surface gradient -->
     <linearGradient id="cardGrad" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" stop-color="#1e293b"/>
@@ -39,7 +34,7 @@
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <!-- Subtle card shadow -->
+    <!-- Card shadow -->
     <filter id="cardShadow" x="-5%" y="-5%" width="110%" height="120%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"/>
       <feOffset dx="0" dy="3"/>
@@ -48,6 +43,10 @@
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
+    <!-- Clip to enforce perfectly circular wheel boundary -->
+    <clipPath id="wheelClip">
+      <circle cx="230" cy="250" r="135"/>
+    </clipPath>
   </defs>
 
   <!-- Background -->
@@ -73,126 +72,134 @@
   <rect x="0" y="0" width="800" height="450" fill="none" stroke="#8b5cf6" stroke-width="3" opacity="0.5"/>
   <rect x="4" y="4" width="792" height="442" fill="none" stroke="#a78bfa" stroke-width="1" opacity="0.2"/>
 
-  <!-- ── Left panel: Spinner wheel (mid-use state) ── -->
-  <!-- Wheel background glow -->
-  <circle cx="230" cy="250" r="145" fill="#8b5cf6" opacity="0.08"/>
+  <!-- ── Spinner wheel ── -->
+  <!-- Glow halo behind wheel -->
+  <circle cx="230" cy="250" r="145" fill="#8b5cf6" opacity="0.07"/>
 
-  <!-- Wheel segments (8 players, partially spun) -->
-  <g filter="url(#wheelShadow)">
-    <!-- Segment 1: purple -->
-    <path d="M230,250 L230,115 A135,135 0 0,1 324.5,180.5 Z" fill="#7c3aed"/>
-    <!-- Segment 2: blue -->
-    <path d="M230,250 L324.5,180.5 A135,135 0 0,1 357,275 Z" fill="#2563eb"/>
-    <!-- Segment 3: green -->
-    <path d="M230,250 L357,275 A135,135 0 0,1 294,371 Z" fill="#059669"/>
-    <!-- Segment 4: orange -->
-    <path d="M230,250 L294,371 A135,135 0 0,1 160,375 Z" fill="#d97706"/>
-    <!-- Segment 5: red -->
-    <path d="M230,250 L160,375 A135,135 0 0,1 96,305 Z" fill="#dc2626"/>
-    <!-- Segment 6: teal -->
-    <path d="M230,250 L96,305 A135,135 0 0,1 103,195 Z" fill="#0891b2"/>
-    <!-- Segment 7: lime -->
-    <path d="M230,250 L103,195 A135,135 0 0,1 168,131 Z" fill="#65a30d"/>
-    <!-- Segment 8: purple back to start -->
-    <path d="M230,250 L168,131 A135,135 0 0,1 230,115 Z" fill="#9333ea"/>
-
-    <!-- Segment borders -->
-    <circle cx="230" cy="250" r="135" fill="none" stroke="rgba(0,0,0,0.4)" stroke-width="2"/>
-    <line x1="230" y1="250" x2="230" y2="115" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="324.5" y2="180.5" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="357" y2="275" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="294" y2="371" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="160" y2="375" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="96" y2="305" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="103" y2="195" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-    <line x1="230" y1="250" x2="168" y2="131" stroke="rgba(0,0,0,0.35)" stroke-width="1.5"/>
-
-    <!-- Segment labels -->
-    <text x="271" y="168" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(-22.5,271,168)" opacity="0.95">Alex</text>
-    <text x="308" y="238" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(22.5,308,238)" opacity="0.95">Sam</text>
-    <text x="278" y="328" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(67.5,278,328)" opacity="0.95">Jordan</text>
-    <text x="193" y="368" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(112.5,193,368)" opacity="0.95">Taylor</text>
-    <text x="126" y="305" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(157.5,126,305)" opacity="0.95">Morgan</text>
-    <text x="140" y="223" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(202.5,140,223)" opacity="0.95">Casey</text>
-    <text x="183" y="157" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(247.5,183,157)" opacity="0.95">Riley</text>
-    <text x="243" y="147" fill="white" font-size="13" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle" transform="rotate(292.5,243,147)" opacity="0.95">Jamie</text>
-
-    <!-- Center hub -->
-    <circle cx="230" cy="250" r="20" fill="#1e293b"/>
-    <circle cx="230" cy="250" r="20" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="2"/>
+  <!--
+    8 equal segments, 45deg each, clockwise from top.
+    All arcs use rx=135 ry=135 (perfect circle), large-arc-flag=0, sweep=1 (CW).
+    Segment endpoints computed from cx=230 cy=250 r=135:
+      P0 (  0deg top):    (230,   115)
+      P1 ( 45deg):        (325.5, 154.5)
+      P2 ( 90deg right):  (365,   250)
+      P3 (135deg):        (325.5, 345.5)
+      P4 (180deg bottom): (230,   385)
+      P5 (225deg):        (134.5, 345.5)
+      P6 (270deg left):   (95,    250)
+      P7 (315deg):        (134.5, 154.5)
+  -->
+  <g filter="url(#wheelShadow)" clip-path="url(#wheelClip)">
+    <!-- Seg 0: purple  0-45deg -->
+    <path d="M230,250 L230,115 A135,135 0 0,1 325.5,154.5 Z" fill="#7c3aed"/>
+    <!-- Seg 1: blue   45-90deg -->
+    <path d="M230,250 L325.5,154.5 A135,135 0 0,1 365,250 Z" fill="#2563eb"/>
+    <!-- Seg 2: green  90-135deg -->
+    <path d="M230,250 L365,250 A135,135 0 0,1 325.5,345.5 Z" fill="#059669"/>
+    <!-- Seg 3: orange 135-180deg -->
+    <path d="M230,250 L325.5,345.5 A135,135 0 0,1 230,385 Z" fill="#d97706"/>
+    <!-- Seg 4: red    180-225deg -->
+    <path d="M230,250 L230,385 A135,135 0 0,1 134.5,345.5 Z" fill="#dc2626"/>
+    <!-- Seg 5: teal   225-270deg -->
+    <path d="M230,250 L134.5,345.5 A135,135 0 0,1 95,250 Z" fill="#0891b2"/>
+    <!-- Seg 6: lime   270-315deg -->
+    <path d="M230,250 L95,250 A135,135 0 0,1 134.5,154.5 Z" fill="#65a30d"/>
+    <!-- Seg 7: violet 315-360deg -->
+    <path d="M230,250 L134.5,154.5 A135,135 0 0,1 230,115 Z" fill="#9333ea"/>
   </g>
 
-  <!-- Wheel glow overlay -->
-  <circle cx="230" cy="250" r="135" fill="url(#wheelGlow)"/>
+  <!-- Spoke lines (inside the clip) -->
+  <g clip-path="url(#wheelClip)" stroke="rgba(0,0,0,0.3)" stroke-width="1.5">
+    <line x1="230" y1="250" x2="230" y2="115"/>
+    <line x1="230" y1="250" x2="325.5" y2="154.5"/>
+    <line x1="230" y1="250" x2="365" y2="250"/>
+    <line x1="230" y1="250" x2="325.5" y2="345.5"/>
+    <line x1="230" y1="250" x2="230" y2="385"/>
+    <line x1="230" y1="250" x2="134.5" y2="345.5"/>
+    <line x1="230" y1="250" x2="95" y2="250"/>
+    <line x1="230" y1="250" x2="134.5" y2="154.5"/>
+  </g>
 
-  <!-- Pointer arrow (pointing left, at right edge of wheel) -->
-  <polygon points="375,250 365,238 365,262" fill="#a78bfa" filter="url(#titleGlow)"/>
+  <!-- Outer ring border -->
+  <circle cx="230" cy="250" r="135" fill="none" stroke="rgba(0,0,0,0.4)" stroke-width="2"/>
 
-  <!-- Result: Alex is selected (pointer lands on purple segment) -->
-  <text x="230" y="425" fill="#a78bfa" font-size="15" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">🎉 Alex!</text>
+  <!--
+    Segment labels at 65% radius (r=88) at each segment midpoint angle.
+    Midpoint angles (clockwise from top): 22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5
+    Label positions:
+      22.5:  (264, 169)   67.5:  (311, 216)   112.5: (311, 284)   157.5: (264, 331)
+      202.5: (196, 331)   247.5: (149, 284)   292.5: (149, 216)   337.5: (196, 169)
+  -->
+  <g font-family="system-ui,sans-serif" font-size="12" font-weight="600" fill="white" text-anchor="middle" dominant-baseline="central">
+    <text x="264" y="169" transform="rotate(22.5,264,169)">Alex</text>
+    <text x="311" y="216" transform="rotate(67.5,311,216)">Sam</text>
+    <text x="311" y="284" transform="rotate(112.5,311,284)">Jordan</text>
+    <text x="264" y="331" transform="rotate(157.5,264,331)">Taylor</text>
+    <text x="196" y="331" transform="rotate(202.5,196,331)">Morgan</text>
+    <text x="149" y="284" transform="rotate(247.5,149,284)">Casey</text>
+    <text x="149" y="216" transform="rotate(292.5,149,216)">Riley</text>
+    <text x="196" y="169" transform="rotate(337.5,196,169)">Jamie</text>
+  </g>
+
+  <!-- Center hub -->
+  <circle cx="230" cy="250" r="20" fill="#1e293b"/>
+  <circle cx="230" cy="250" r="20" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="2"/>
+
+  <!-- Pointer arrow pointing left, tip at wheel right edge -->
+  <polygon points="375,250 362,238 362,262" fill="#a78bfa" filter="url(#titleGlow)"/>
+
+  <!-- Spin result label -->
+  <text x="230" y="425" fill="#a78bfa" font-size="15" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">🎉 Sam!</text>
 
   <!-- ── Right panel: Guess recording ── -->
-  <!-- Panel background -->
-  <rect x="420" y="100" width="350" height="330" rx="14" fill="url(#cardGrad)" stroke="#334155" stroke-width="1.5" filter="url(#cardShadow)"/>
+  <rect x="420" y="100" width="355" height="330" rx="14" fill="url(#cardGrad)" stroke="#334155" stroke-width="1.5" filter="url(#cardShadow)"/>
 
   <!-- Panel header -->
-  <text x="595" y="133" fill="#94a3b8" font-size="11" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" letter-spacing="0.08em">NOW SPEAKING</text>
-  <text x="595" y="162" fill="#a78bfa" font-size="22" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">Alex</text>
+  <text x="597" y="133" fill="#94a3b8" font-size="11" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" letter-spacing="0.08em">NOW SPEAKING</text>
+  <text x="597" y="162" fill="#a78bfa" font-size="22" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">Sam</text>
+  <text x="597" y="180" fill="#64748b" font-size="11" font-family="system-ui,sans-serif" text-anchor="middle">Round 2</text>
 
   <!-- Divider -->
-  <line x1="436" y1="175" x2="754" y2="175" stroke="#334155" stroke-width="1"/>
+  <line x1="436" y1="190" x2="758" y2="190" stroke="#334155" stroke-width="1"/>
 
-  <!-- Guess label -->
-  <text x="436" y="196" fill="#94a3b8" font-size="11" font-family="system-ui,sans-serif">Which statement is the lie?</text>
+  <!-- Statements section label -->
+  <text x="436" y="208" fill="#94a3b8" font-size="10" font-weight="700" font-family="system-ui,sans-serif" letter-spacing="0.07em">STATEMENTS</text>
 
-  <!-- Guess rows -->
-  <!-- Sam: guessed 2 (selected) -->
-  <rect x="434" y="202" width="322" height="44" rx="8" fill="#172033" stroke="#334155" stroke-width="1.2"/>
-  <text x="450" y="229" fill="#f9fafb" font-size="13" font-weight="600" font-family="system-ui,sans-serif">Sam</text>
-  <!-- buttons 1, 2, 3 -->
-  <rect x="645" y="207" width="34" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="662" y="229" fill="#94a3b8" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">1</text>
-  <rect x="683" y="207" width="34" height="34" rx="6" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="1.2"/>
-  <text x="700" y="229" fill="white" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">2</text>
-  <rect x="721" y="207" width="34" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="738" y="229" fill="#94a3b8" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">3</text>
+  <!-- Statement 1 -->
+  <rect x="434" y="213" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
+  <circle cx="452" cy="230" r="10" fill="#8b5cf6"/>
+  <text x="452" y="230" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">1</text>
+  <text x="468" y="230" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I once swam with sharks</text>
 
-  <!-- Jordan: guessed 2 -->
-  <rect x="434" y="250" width="322" height="44" rx="8" fill="#172033" stroke="#334155" stroke-width="1.2"/>
-  <text x="450" y="277" fill="#f9fafb" font-size="13" font-weight="600" font-family="system-ui,sans-serif">Jordan</text>
-  <rect x="645" y="255" width="34" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="662" y="277" fill="#94a3b8" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">1</text>
-  <rect x="683" y="255" width="34" height="34" rx="6" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="1.2"/>
-  <text x="700" y="277" fill="white" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">2</text>
-  <rect x="721" y="255" width="34" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="738" y="277" fill="#94a3b8" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">3</text>
+  <!-- Statement 2 -->
+  <rect x="434" y="251" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
+  <circle cx="452" cy="268" r="10" fill="#8b5cf6"/>
+  <text x="452" y="268" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">2</text>
+  <text x="468" y="268" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I speak four languages</text>
 
-  <!-- Taylor: guessed 3 -->
-  <rect x="434" y="298" width="322" height="44" rx="8" fill="#172033" stroke="#334155" stroke-width="1.2"/>
-  <text x="450" y="325" fill="#f9fafb" font-size="13" font-weight="600" font-family="system-ui,sans-serif">Taylor</text>
-  <rect x="645" y="303" width="34" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="662" y="325" fill="#94a3b8" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">1</text>
-  <rect x="683" y="303" width="34" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="700" y="325" fill="#94a3b8" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">2</text>
-  <rect x="721" y="303" width="34" height="34" rx="6" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="1.2"/>
-  <text x="738" y="325" fill="white" font-size="13" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">3</text>
+  <!-- Statement 3 -->
+  <rect x="434" y="289" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
+  <circle cx="452" cy="306" r="10" fill="#8b5cf6"/>
+  <text x="452" y="306" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">3</text>
+  <text x="468" y="306" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I've climbed Mt. Rainier</text>
 
-  <!-- Lie selector row -->
-  <rect x="434" y="350" width="322" height="44" rx="8" fill="#172033" stroke="#334155" stroke-width="1.2"/>
-  <text x="450" y="377" fill="#94a3b8" font-size="11" font-family="system-ui,sans-serif">The lie is:</text>
-  <rect x="600" y="355" width="90" height="34" rx="6" fill="#ef4444" stroke="#ef4444" stroke-width="1"/>
-  <text x="645" y="376" fill="white" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle">Statement 2</text>
-  <text x="697" y="377" fill="#94a3b8" font-size="12" font-family="system-ui,sans-serif">  3</text>
-  <rect x="700" y="355" width="52" height="34" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="726" y="377" fill="#94a3b8" font-size="12" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle">3</text>
+  <!-- Divider -->
+  <line x1="436" y1="332" x2="758" y2="332" stroke="#334155" stroke-width="1"/>
+  <text x="436" y="348" fill="#94a3b8" font-size="10" font-weight="700" font-family="system-ui,sans-serif" letter-spacing="0.07em">PLAYER GUESSES</text>
 
-  <!-- Round badge -->
-  <rect x="434" y="106" width="62" height="22" rx="11" fill="#1e293b" stroke="#334155" stroke-width="1.2"/>
-  <text x="465" y="122" fill="#94a3b8" font-size="10" font-weight="600" font-family="system-ui,sans-serif" text-anchor="middle">Round 2</text>
+  <!-- Guess row: Alex → 2 -->
+  <rect x="434" y="354" width="322" height="34" rx="7" fill="#172033" stroke="#334155" stroke-width="1.2"/>
+  <text x="450" y="371" fill="#f9fafb" font-size="12" font-weight="600" font-family="system-ui,sans-serif" dominant-baseline="central">Alex</text>
+  <rect x="683" y="359" width="28" height="24" rx="5" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="697" y="371" fill="white" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">2</text>
+  <rect x="715" y="359" width="28" height="24" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
+  <text x="729" y="371" fill="#94a3b8" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">3</text>
+  <rect x="747" y="359" width="28" height="24" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
+  <text x="761" y="371" fill="#94a3b8" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">1</text>
 
   <!-- ── Title ── -->
-  <text x="400" y="62" fill="url(#titleGrad)" font-size="36" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">2 Truths and a Lie</text>
-  <text x="400" y="84" fill="#64748b" font-size="14" font-family="system-ui,sans-serif" text-anchor="middle">party game for Zoom</text>
+  <text x="400" y="55" fill="url(#titleGrad)" font-size="36" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">2 Truths and a Lie</text>
+  <text x="400" y="80" fill="#64748b" font-size="14" font-family="system-ui,sans-serif" text-anchor="middle">party game for Zoom</text>
 
   <!-- Corner accents -->
   <line x1="0" y1="0" x2="40" y2="0" stroke="#8b5cf6" stroke-width="3"/>

--- a/data/apps.json
+++ b/data/apps.json
@@ -39,9 +39,23 @@
       "prompt": "Build a browser-based \"2 Truths and a Lie\" game for a Zoom screen-share host. Start with a setup screen where the host enters participant names. Then show instructions and a 60-second countdown for everyone to think of 3 statements (2 true, 1 false). After the first round timer ends, show a wheel containing all participant names and a button to spin and randomly choose the next speaker. For each turn, show a scoreboard where the host records which statement (1, 2, or 3) each participant guessed was the lie. After reveal, mark everyone who guessed correctly as round winners. Support multiple rounds; only the first round uses the 60-second timer. Make it simple, responsive, and easy to run live on a shared screen.",
       "requestor": "Jeff Holst"
     },
-    "improvements": null,
+    "improvements": [
+      {
+        "issueNumber": 245,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/245",
+        "runId": "run-20260331T022221Z-d4e8f1",
+        "appliedAt": "2026-03-31T02:22:21Z",
+        "summary": "Fixed spinner wheel alignment (integer rotations + corrected modulo formula), added host statement capture on turn screen with numbered display, updated reveal screen to show statements with lie highlighted, redrew thumbnail with geometrically perfect circular wheel using SVG arc paths and clipPath."
+      }
+    ],
     "allowImprovements": true,
-    "backups": null
+    "backups": [
+      {
+        "runId": "run-20260331T022221Z-d4e8f1",
+        "path": "backups/run-20260331T022221Z-d4e8f1/index.html",
+        "url": "/apps/2026/03/31/two-truths-lie-game/backups/run-20260331T022221Z-d4e8f1/index.html"
+      }
+    ]
   },
   {
     "id": "2026/03/26/sokoban-warehouse",


### PR DESCRIPTION
## Summary

- **Spinner alignment fix:** `extraRotations` changed from a float to an integer (3–6), and `spinTarget` rewritten using a correct modulo formula so the winning name always matches the pointer position
- **Host statement capture:** Turn screen now has a Phase 1 where the host enters all 3 statements before the guess grid appears; statements are shown numbered 1/2/3 on screen for all players to see while guessing
- **Reveal enhancement:** Reveal screen shows all 3 statements with the lie highlighted red (🤥) and truths in green (✓)
- **Thumbnail redo:** Wheel redrawn using mathematically exact SVG arc paths (`A 135 135 0 0 1`) with a `clipPath` circle to enforce a perfectly circular boundary

## Test plan

- [ ] Spin the wheel multiple times — winner name displayed always matches the segment the pointer lands on
- [ ] Second and subsequent rounds: spinner still aligns correctly after the speaker queue shrinks
- [ ] Turn screen shows "Ask [name] to share their 3 statements" phase first
- [ ] "Show Statements" button is disabled until all 3 inputs have text
- [ ] After submitting, statements display numbered 1/2/3 and inputs are locked
- [ ] Guess grid and lie selector appear after statements are submitted
- [ ] Reveal screen shows all 3 statements with lie in red, truths in green
- [ ] thumbnail.svg renders as a perfect circle (no distortion)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)