### PR TITLE
feat: add setlist-energy-planner

### DIFF
--- a/apps/2026/04/04/setlist-energy-planner/index.html
+++ b/apps/2026/04/04/setlist-energy-planner/index.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Setlist Energy Planner - __MAIN_SITE_NAME__</title>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '__GA_MEASUREMENT_ID__');
+    </script>
+
+    <meta name="voa-main-site-url" content="__MAIN_SITE_URL__" />
+    <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__" />
+    <meta name="voa-github-url" content="__GITHUB_URL__" />
+    <meta name="voa-social-x-url" content="__SOCIAL_X_URL__" />
+    <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__" />
+    <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__" />
+    <meta name="application-name" content="Setlist Energy Planner" />
+    <meta name="voa-app-id" content="2026/04/04/setlist-energy-planner" />
+    <script src="/apps/shared/app-shell.js" defer></script>
+
+    <link rel="icon" type="image/svg+xml" href="thumbnail.svg" />
+    <style>
+      :root {
+        --bg: #080b14;
+        --text: #f6f7fb;
+        --surface: #131a2d;
+        --surface-2: #1c2541;
+        --accent: #59e1ff;
+        --accent-2: #b36bff;
+        --good: #56f2a0;
+        --warn: #ffc861;
+        --danger: #ff6a8f;
+      }
+      [data-theme='light'] {
+        --bg: #edf3ff;
+        --text: #12213b;
+        --surface: #ffffff;
+        --surface-2: #dce8ff;
+        --accent: #0066ff;
+        --accent-2: #8a38ff;
+        --good: #0f9f66;
+        --warn: #b47a00;
+        --danger: #d52a56;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: radial-gradient(circle at 20% 10%, #242a4e 0%, var(--bg) 48%);
+        color: var(--text);
+      }
+      main {
+        max-width: 940px;
+        margin: 0 auto;
+        padding: 14px 12px 20px;
+        display: grid;
+        gap: 12px;
+      }
+      .card {
+        background: color-mix(in oklab, var(--surface), #000 6%);
+        border: 1px solid color-mix(in oklab, var(--accent), transparent 70%);
+        border-radius: 14px;
+        padding: 12px;
+        box-shadow: 0 8px 24px #0000002c;
+      }
+      h1 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+      p {
+        margin: 0;
+        opacity: 0.9;
+      }
+      .grid {
+        display: grid;
+        gap: 10px;
+      }
+      .track {
+        display: grid;
+        grid-template-columns: 1fr 80px 80px 48px;
+        gap: 8px;
+        align-items: center;
+      }
+      input,
+      button {
+        border: 1px solid color-mix(in oklab, var(--accent), transparent 70%);
+        background: var(--surface-2);
+        color: var(--text);
+        border-radius: 10px;
+        min-height: 44px;
+        padding: 0 10px;
+        font: inherit;
+      }
+      button {
+        cursor: pointer;
+        transition: transform 0.16s ease, background 0.16s ease;
+      }
+      button:hover,
+      button:focus-visible {
+        transform: translateY(-1px);
+        background: color-mix(in oklab, var(--surface-2), var(--accent) 20%);
+      }
+      .actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .pill {
+        display: inline-block;
+        border-radius: 999px;
+        padding: 6px 10px;
+        font-size: 0.84rem;
+        background: color-mix(in oklab, var(--surface-2), #000 10%);
+      }
+      #energyCurve {
+        width: 100%;
+        height: 180px;
+        background: linear-gradient(180deg, #243261 0%, #11172d 100%);
+        border-radius: 12px;
+        border: 1px solid color-mix(in oklab, var(--accent-2), transparent 60%);
+      }
+      .stat-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      @media (max-width: 700px) {
+        .track {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="card grid">
+        <h1>🎛️ Setlist Energy Planner</h1>
+        <p>Build a smooth energy arc for your next show. Add songs, set BPM + intensity, then optimize flow.</p>
+        <div class="actions">
+          <button id="addBtn" type="button">Add Track</button>
+          <button id="optBtn" type="button">Auto Smooth</button>
+          <button id="demoBtn" type="button">Load Demo</button>
+        </div>
+      </section>
+
+      <section class="card grid">
+        <div class="stat-row">
+          <span class="pill" id="tracksStat">Tracks: 0</span>
+          <span class="pill" id="avgBpmStat">Avg BPM: 0</span>
+          <span class="pill" id="fatigueStat">Crowd Fatigue: 0%</span>
+          <span class="pill" id="arcStat">Arc Score: 0</span>
+        </div>
+        <canvas id="energyCurve" width="900" height="220" aria-label="Energy curve chart"></canvas>
+      </section>
+
+      <section class="card grid" id="list"></section>
+    </main>
+
+    <script>
+      const list = document.getElementById('list');
+      const energyCurve = document.getElementById('energyCurve');
+      const ctx = energyCurve.getContext('2d');
+      const tracksStat = document.getElementById('tracksStat');
+      const avgBpmStat = document.getElementById('avgBpmStat');
+      const fatigueStat = document.getElementById('fatigueStat');
+      const arcStat = document.getElementById('arcStat');
+
+      const state = { tracks: [] };
+      const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+
+      function addTrack(track = { name: `Track ${state.tracks.length + 1}`, bpm: 120, energy: 55 }) {
+        state.tracks.push(track);
+        render();
+      }
+
+      function loadDemo() {
+        state.tracks = [
+          { name: 'Neon Door', bpm: 96, energy: 35 },
+          { name: 'Static Kiss', bpm: 112, energy: 47 },
+          { name: 'Silver Sparks', bpm: 128, energy: 64 },
+          { name: 'Skyline Riot', bpm: 142, energy: 81 },
+          { name: 'Soft Landing', bpm: 108, energy: 52 }
+        ];
+        render();
+      }
+
+      function optimizeCurve() {
+        state.tracks.sort((a, b) => a.energy - b.energy);
+        const peak = state.tracks.pop();
+        if (peak) state.tracks.splice(Math.floor(state.tracks.length * 0.7), 0, peak);
+        render();
+      }
+
+      function computeArcScore() {
+        if (state.tracks.length < 3) return 0;
+        const energies = state.tracks.map((t) => t.energy);
+        const peakIndex = energies.indexOf(Math.max(...energies));
+        const left = energies.slice(0, peakIndex + 1);
+        const right = energies.slice(peakIndex);
+        let trend = 0;
+        for (let i = 1; i < left.length; i++) if (left[i] >= left[i - 1]) trend++;
+        for (let i = 1; i < right.length; i++) if (right[i] <= right[i - 1]) trend++;
+        return Math.round((trend / Math.max(1, state.tracks.length - 1)) * 100);
+      }
+
+      function updateStats() {
+        const len = state.tracks.length;
+        const avgBpm = len ? Math.round(state.tracks.reduce((s, t) => s + t.bpm, 0) / len) : 0;
+        const fatigue = len
+          ? clamp(
+              Math.round(
+                (state.tracks.reduce((s, t) => s + Math.max(0, t.energy - 70), 0) / (len * 30)) * 100
+              ),
+              0,
+              100
+            )
+          : 0;
+        tracksStat.textContent = `Tracks: ${len}`;
+        avgBpmStat.textContent = `Avg BPM: ${avgBpm}`;
+        fatigueStat.textContent = `Crowd Fatigue: ${fatigue}%`;
+        arcStat.textContent = `Arc Score: ${computeArcScore()}`;
+      }
+
+      function drawCurve() {
+        const w = energyCurve.width;
+        const h = energyCurve.height;
+        ctx.clearRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(89,225,255,.25)';
+        for (let y = 30; y < h; y += 30) {
+          ctx.beginPath();
+          ctx.moveTo(0, y);
+          ctx.lineTo(w, y);
+          ctx.stroke();
+        }
+        if (!state.tracks.length) return;
+        const points = state.tracks.map((track, i) => ({
+          x: (i / Math.max(1, state.tracks.length - 1)) * (w - 80) + 40,
+          y: h - 20 - (track.energy / 100) * (h - 60)
+        }));
+        ctx.lineWidth = 5;
+        ctx.strokeStyle = '#59e1ff';
+        ctx.beginPath();
+        points.forEach((p, i) => (i ? ctx.lineTo(p.x, p.y) : ctx.moveTo(p.x, p.y)));
+        ctx.stroke();
+        points.forEach((p, i) => {
+          ctx.fillStyle = i === Math.floor(points.length * 0.7) ? '#ff6a8f' : '#b36bff';
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, 7, 0, Math.PI * 2);
+          ctx.fill();
+        });
+      }
+
+      function render() {
+        list.innerHTML = '';
+        state.tracks.forEach((track, index) => {
+          const row = document.createElement('div');
+          row.className = 'track';
+          row.innerHTML = `
+            <input aria-label="Track name" value="${track.name}" />
+            <input aria-label="BPM" type="number" min="60" max="220" value="${track.bpm}" />
+            <input aria-label="Energy" type="number" min="0" max="100" value="${track.energy}" />
+            <button type="button" aria-label="Delete track">✕</button>
+          `;
+          const [nameInput, bpmInput, energyInput, delBtn] = row.querySelectorAll('input,button');
+          nameInput.addEventListener('input', (e) => {
+            track.name = e.target.value;
+          });
+          bpmInput.addEventListener('input', (e) => {
+            track.bpm = clamp(Number(e.target.value) || 60, 60, 220);
+            drawCurve();
+            updateStats();
+          });
+          energyInput.addEventListener('input', (e) => {
+            track.energy = clamp(Number(e.target.value) || 0, 0, 100);
+            drawCurve();
+            updateStats();
+          });
+          delBtn.addEventListener('click', () => {
+            state.tracks.splice(index, 1);
+            render();
+          });
+          list.appendChild(row);
+        });
+        drawCurve();
+        updateStats();
+      }
+
+      document.getElementById('addBtn').addEventListener('click', () => addTrack());
+      document.getElementById('optBtn').addEventListener('click', optimizeCurve);
+      document.getElementById('demoBtn').addEventListener('click', loadDemo);
+      loadDemo();
+    </script>
+  </body>
+</html>

--- a/apps/2026/04/04/setlist-energy-planner/meta.json
+++ b/apps/2026/04/04/setlist-energy-planner/meta.json
@@ -1,0 +1,29 @@
+{
+  "id": "setlist-energy-planner",
+  "name": "Setlist Energy Planner",
+  "shortDescription": "Shape a concert set with BPM and intensity scoring to create a strong crowd-energy arc.",
+  "thumbnail": "thumbnail.svg",
+  "createdAt": "2026-04-04T07:00:27Z",
+  "category": "Entertainment",
+  "status": "active",
+  "tags": [
+    "music",
+    "setlist",
+    "energy-curve",
+    "bpm",
+    "live-show",
+    "planner"
+  ],
+  "homepagePath": "index.html",
+  "inputMode": "responsive",
+  "generation": {
+    "agentName": "dev",
+    "llmModel": "openai-codex/gpt-5.3-codex",
+    "startTime": "2026-04-04T07:00:27Z",
+    "endTime": "2026-04-04T07:03:00Z",
+    "totalTokensIn": 8500,
+    "totalTokensOut": 3570,
+    "runId": "run-20260404T070027Z-17aba5",
+    "notes": "Built from vote-and-category-analysis recommendation emphasizing Entertainment while avoiding recent saturated arcade/puzzle tags."
+  }
+}

--- a/apps/2026/04/04/setlist-energy-planner/thumbnail.svg
+++ b/apps/2026/04/04/setlist-energy-planner/thumbnail.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Setlist Energy Planner thumbnail">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#242a4e" />
+      <stop offset="55%" stop-color="#080b14" />
+      <stop offset="100%" stop-color="#11172d" />
+    </linearGradient>
+    <linearGradient id="curve" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#59e1ff" />
+      <stop offset="100%" stop-color="#b36bff" />
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="3.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect x="0" y="0" width="800" height="450" fill="url(#bg)" />
+  <rect x="26" y="24" width="748" height="402" rx="22" fill="#131a2d" stroke="#3a4d7d" stroke-width="2" />
+
+  <text x="48" y="74" fill="#f6f7fb" font-family="Inter, Arial, sans-serif" font-size="36" font-weight="800" filter="url(#softGlow)">
+    Setlist Energy Planner
+  </text>
+  <text x="50" y="106" fill="#9bb2df" font-family="Inter, Arial, sans-serif" font-size="18">
+    Tracks: 5   Avg BPM: 117   Crowd Fatigue: 28%   Arc Score: 83
+  </text>
+
+  <rect x="50" y="128" width="700" height="204" rx="14" fill="#11172d" stroke="#4c5f93" />
+
+  <g stroke="#2b3a61" stroke-width="1">
+    <line x1="60" y1="290" x2="740" y2="290" />
+    <line x1="60" y1="254" x2="740" y2="254" />
+    <line x1="60" y1="218" x2="740" y2="218" />
+    <line x1="60" y1="182" x2="740" y2="182" />
+    <line x1="60" y1="146" x2="740" y2="146" />
+  </g>
+
+  <polyline
+    points="80,270 225,240 370,200 515,148 660,220"
+    fill="none"
+    stroke="url(#curve)"
+    stroke-width="8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    filter="url(#softGlow)"
+  />
+
+  <g fill="#b36bff">
+    <circle cx="80" cy="270" r="10" />
+    <circle cx="225" cy="240" r="10" />
+    <circle cx="370" cy="200" r="10" />
+    <circle cx="660" cy="220" r="10" />
+  </g>
+  <circle cx="515" cy="148" r="12" fill="#ff6a8f" filter="url(#softGlow)" />
+
+  <rect x="50" y="348" width="700" height="56" rx="12" fill="#1c2541" stroke="#4d5f96" />
+  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600" fill="#e6ecff">
+    <text x="68" y="383">Neon Door</text>
+    <text x="228" y="383">96 BPM</text>
+    <text x="308" y="383">35</text>
+    <text x="388" y="383">Silver Sparks</text>
+    <text x="568" y="383">128 BPM</text>
+    <text x="668" y="383">64</text>
+  </g>
+</svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -1,5 +1,35 @@
 [
   {
+    "id": "2026/04/04/setlist-energy-planner",
+    "name": "Setlist Energy Planner",
+    "shortDescription": "Shape a concert set with BPM and intensity scoring to create a strong crowd-energy arc.",
+    "thumbnailUrl": "/apps/2026/04/04/setlist-energy-planner/thumbnail.svg",
+    "createdAt": "2026-04-04T07:00:27Z",
+    "year": 2026,
+    "month": 4,
+    "day": 4,
+    "category": "Entertainment",
+    "inputMode": "responsive",
+    "status": "active",
+    "tags": ["music", "setlist", "energy-curve", "bpm", "live-show", "planner"],
+    "route": "/apps/2026/04/04/setlist-energy-planner",
+    "appPath": "/apps/2026/04/04/setlist-energy-planner/index.html",
+    "generation": {
+      "agentName": "dev",
+      "llmModel": "openai-codex/gpt-5.3-codex",
+      "startTime": "2026-04-04T07:00:27Z",
+      "endTime": "2026-04-04T07:03:00Z",
+      "totalTokensIn": 8500,
+      "totalTokensOut": 3570,
+      "runId": "run-20260404T070027Z-17aba5",
+      "notes": "Built from vote-and-category-analysis recommendation emphasizing Entertainment while avoiding recent saturated arcade/puzzle tags."
+    },
+    "suggestion": null,
+    "improvements": null,
+    "allowImprovements": true,
+    "backups": null
+  },
+  {
     "id": "2026/04/03/fortune-streak-studio",
     "name": "Fortune Streak Studio",
     "shortDescription": "Spin a stylish daily fortune reel to get a ritual, mood focus, and lucky symbol while building your streak.",
@@ -41,7 +71,16 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["quiz", "emoji", "party", "multiplayer", "zoom", "responsive", "touch", "trivia"],
+    "tags": [
+      "quiz",
+      "emoji",
+      "party",
+      "multiplayer",
+      "zoom",
+      "responsive",
+      "touch",
+      "trivia"
+    ],
     "route": "/apps/2026/04/01/emoji-quiz-party",
     "appPath": "/apps/2026/04/01/emoji-quiz-party/index.html",
     "generation": {
@@ -253,7 +292,16 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["puzzle", "sokoban", "mobile", "touch", "classic", "grid", "levels", "builder"],
+    "tags": [
+      "puzzle",
+      "sokoban",
+      "mobile",
+      "touch",
+      "classic",
+      "grid",
+      "levels",
+      "builder"
+    ],
     "route": "/apps/2026/03/26/sokoban-warehouse",
     "appPath": "/apps/2026/03/26/sokoban-warehouse/index.html",
     "generation": {
@@ -400,7 +448,15 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["shooter", "arcade", "space", "canvas", "mobile-first", "wave-based", "power-ups"],
+    "tags": [
+      "shooter",
+      "arcade",
+      "space",
+      "canvas",
+      "mobile-first",
+      "wave-based",
+      "power-ups"
+    ],
     "route": "/apps/2026/03/26/galaxian-blitz",
     "appPath": "/apps/2026/03/26/galaxian-blitz/index.html",
     "generation": {
@@ -468,7 +524,14 @@
     "category": "Entertainment",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["raffle", "drawing", "party", "randomizer", "tickets", "responsive"],
+    "tags": [
+      "raffle",
+      "drawing",
+      "party",
+      "randomizer",
+      "tickets",
+      "responsive"
+    ],
     "route": "/apps/2026/03/26/raffle-night-caller",
     "appPath": "/apps/2026/03/26/raffle-night-caller/index.html",
     "generation": {
@@ -498,7 +561,14 @@
     "category": "Entertainment",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["slot-machine", "casino", "rng", "mobile-first", "paylines", "neon"],
+    "tags": [
+      "slot-machine",
+      "casino",
+      "rng",
+      "mobile-first",
+      "paylines",
+      "neon"
+    ],
     "route": "/apps/2026/03/25/neon-slot-rush",
     "appPath": "/apps/2026/03/25/neon-slot-rush/index.html",
     "generation": {
@@ -570,7 +640,14 @@
     "category": "Entertainment",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["puzzle", "solitaire", "strategy", "board-game", "classic", "mobile-first"],
+    "tags": [
+      "puzzle",
+      "solitaire",
+      "strategy",
+      "board-game",
+      "classic",
+      "mobile-first"
+    ],
     "route": "/apps/2026/03/25/peg-solitaire",
     "appPath": "/apps/2026/03/25/peg-solitaire/index.html",
     "generation": {
@@ -654,7 +731,15 @@
     "category": "Entertainment",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["audio", "foley", "cinema", "soundboard", "keyboard", "touch", "responsive"],
+    "tags": [
+      "audio",
+      "foley",
+      "cinema",
+      "soundboard",
+      "keyboard",
+      "touch",
+      "responsive"
+    ],
     "route": "/apps/2026/03/24/foley-scene-mixer",
     "appPath": "/apps/2026/03/24/foley-scene-mixer/index.html",
     "generation": {
@@ -684,7 +769,15 @@
     "category": "Entertainment",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["storytelling", "creative", "generator", "cinema", "keyboard", "touch", "responsive"],
+    "tags": [
+      "storytelling",
+      "creative",
+      "generator",
+      "cinema",
+      "keyboard",
+      "touch",
+      "responsive"
+    ],
     "route": "/apps/2026/03/24/story-beat-remixer",
     "appPath": "/apps/2026/03/24/story-beat-remixer/index.html",
     "generation": {
@@ -714,7 +807,15 @@
     "category": "Games",
     "inputMode": "mobile",
     "status": "active",
-    "tags": ["roguelike", "puzzle", "mobile", "touch", "dungeon", "strategy", "seeded"],
+    "tags": [
+      "roguelike",
+      "puzzle",
+      "mobile",
+      "touch",
+      "dungeon",
+      "strategy",
+      "seeded"
+    ],
     "route": "/apps/2026/03/23/dungeon-puzzle-run",
     "appPath": "/apps/2026/03/23/dungeon-puzzle-run/index.html",
     "generation": {
@@ -759,7 +860,14 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["tic-tac-toe", "minimax", "strategy", "responsive", "keyboard", "touch"],
+    "tags": [
+      "tic-tac-toe",
+      "minimax",
+      "strategy",
+      "responsive",
+      "keyboard",
+      "touch"
+    ],
     "route": "/apps/2026/03/23/tic-tac-toe-strategy-lab",
     "appPath": "/apps/2026/03/23/tic-tac-toe-strategy-lab/index.html",
     "generation": {
@@ -789,7 +897,15 @@
     "category": "Entertainment",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["lottery", "texas", "random", "numbers", "animation", "confetti", "generator"],
+    "tags": [
+      "lottery",
+      "texas",
+      "random",
+      "numbers",
+      "animation",
+      "confetti",
+      "generator"
+    ],
     "route": "/apps/2026/03/21/texas-lotto-generator",
     "appPath": "/apps/2026/03/21/texas-lotto-generator/index.html",
     "generation": {
@@ -903,7 +1019,14 @@
     "category": "Education",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["morse-code", "audio", "educational", "translator", "web-audio-api", "radio"],
+    "tags": [
+      "morse-code",
+      "audio",
+      "educational",
+      "translator",
+      "web-audio-api",
+      "radio"
+    ],
     "route": "/apps/2026/03/21/morse-code-radio",
     "appPath": "/apps/2026/03/21/morse-code-radio/index.html",
     "generation": {
@@ -1122,7 +1245,14 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["hangman", "word-game", "puzzle", "animation", "keyboard", "touch"],
+    "tags": [
+      "hangman",
+      "word-game",
+      "puzzle",
+      "animation",
+      "keyboard",
+      "touch"
+    ],
     "route": "/apps/2026/03/17/hangman-word-game",
     "appPath": "/apps/2026/03/17/hangman-word-game/index.html",
     "generation": {
@@ -1152,7 +1282,14 @@
     "category": "Productivity",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["timer", "productivity", "focus", "utility", "pomodoro", "time-management"],
+    "tags": [
+      "timer",
+      "productivity",
+      "focus",
+      "utility",
+      "pomodoro",
+      "time-management"
+    ],
     "route": "/apps/2026/03/17/focus-timer",
     "appPath": "/apps/2026/03/17/focus-timer/index.html",
     "generation": {
@@ -1182,7 +1319,13 @@
     "category": "Utilities",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["breathing", "meditation", "stress-relief", "habit-tracking", "4-7-8"],
+    "tags": [
+      "breathing",
+      "meditation",
+      "stress-relief",
+      "habit-tracking",
+      "4-7-8"
+    ],
     "route": "/apps/2026/03/16/mindful-breathing-tracker",
     "appPath": "/apps/2026/03/16/mindful-breathing-tracker/index.html",
     "generation": {
@@ -1212,7 +1355,14 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["game", "memory", "puzzle", "sequence", "brain-training", "mobile-friendly"],
+    "tags": [
+      "game",
+      "memory",
+      "puzzle",
+      "sequence",
+      "brain-training",
+      "mobile-friendly"
+    ],
     "route": "/apps/2026/03/16/memory-sequence",
     "appPath": "/apps/2026/03/16/memory-sequence/index.html",
     "generation": {
@@ -1242,7 +1392,13 @@
     "category": "Productivity",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["productivity", "pomodoro", "task-planning", "priority-scoring", "mobile-friendly"],
+    "tags": [
+      "productivity",
+      "pomodoro",
+      "task-planning",
+      "priority-scoring",
+      "mobile-friendly"
+    ],
     "route": "/apps/2026/03/15/focus-sprint-planner",
     "appPath": "/apps/2026/03/15/focus-sprint-planner/index.html",
     "generation": {
@@ -1392,7 +1548,15 @@
     "category": "Utilities",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["breathing", "wellness", "mindfulness", "timer", "mobile", "focus", "health"],
+    "tags": [
+      "breathing",
+      "wellness",
+      "mindfulness",
+      "timer",
+      "mobile",
+      "focus",
+      "health"
+    ],
     "route": "/apps/2026/03/13/interval-breathing-coach",
     "appPath": "/apps/2026/03/13/interval-breathing-coach/index.html",
     "generation": {
@@ -1422,7 +1586,16 @@
     "category": "Games",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["game", "tap", "mobile", "responsive", "arcade", "high-score", "touch", "reaction"],
+    "tags": [
+      "game",
+      "tap",
+      "mobile",
+      "responsive",
+      "arcade",
+      "high-score",
+      "touch",
+      "reaction"
+    ],
     "route": "/apps/2026/03/13/bubble-tap",
     "appPath": "/apps/2026/03/13/bubble-tap/index.html",
     "generation": {
@@ -1482,7 +1655,13 @@
     "category": "Utilities",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["timezone", "scheduling", "meeting-planner", "global-teams", "productivity"],
+    "tags": [
+      "timezone",
+      "scheduling",
+      "meeting-planner",
+      "global-teams",
+      "productivity"
+    ],
     "route": "/apps/2026/03/12/timezone-overlap-finder",
     "appPath": "/apps/2026/03/12/timezone-overlap-finder/index.html",
     "generation": {
@@ -1512,7 +1691,14 @@
     "category": "Education",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["astronomy", "stars", "constellations", "mythology", "interactive", "educational"],
+    "tags": [
+      "astronomy",
+      "stars",
+      "constellations",
+      "mythology",
+      "interactive",
+      "educational"
+    ],
     "route": "/apps/2026/03/12/constellation-explorer",
     "appPath": "/apps/2026/03/12/constellation-explorer/index.html",
     "generation": {
@@ -2382,7 +2568,14 @@
     "category": "Games",
     "inputMode": "desktop",
     "status": "active",
-    "tags": ["game", "flappy-bird", "arcade", "tap", "touch-controls", "endless-runner"],
+    "tags": [
+      "game",
+      "flappy-bird",
+      "arcade",
+      "tap",
+      "touch-controls",
+      "endless-runner"
+    ],
     "route": "/apps/2026/03/07/flappy-bird",
     "appPath": "/apps/2026/03/07/flappy-bird/index.html",
     "generation": {
@@ -2592,7 +2785,13 @@
     "category": "Visualizations",
     "inputMode": "desktop",
     "status": "active",
-    "tags": ["algorithms", "sorting", "visualization", "educational", "computer-science"],
+    "tags": [
+      "algorithms",
+      "sorting",
+      "visualization",
+      "educational",
+      "computer-science"
+    ],
     "route": "/apps/2026/03/06/sorting-visualizer",
     "appPath": "/apps/2026/03/06/sorting-visualizer/index.html",
     "generation": {


### PR DESCRIPTION
## Summary
- Adds **Setlist Energy Planner** in the **Entertainment** category
- Mobile-first tool for planning song BPM/intensity flow with live energy-curve visualization
- Includes app page, metadata, and thumbnail

## Validation
- npm run generate:apps
- npm run validate:apps
- npm run lint:fix
- npm run format
- npm run lint
- npm test
- npm run validate:responsive:sample
- npm run build

All checks passed.