### PR TITLE
feat: versus comparison table, agent harness, and how-to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ stripe trigger checkout.session.completed
 | `npm run issues:decide`              | 🏷️ Apply an issue review decision. Removes `status:pending` and adds `status:approved` or `status:rejected`, or for `needs-human-review` keeps pending in place, adds `status:needs-human-review`, and comments the reason. Requires `--issue`, `--status`, and `--reason`.                                                                                                                              |
 | `npm run select:app:suggestion`      | 🤖 Recommend the next **new app** concept to build — checks GitHub for boosted/approved `suggestion` issues first (ranked by verified tip total), then falls back to Supabase vote analysis and category gap scoring when no issues exist. Outputs a JSON recommendation with duplication-risk scoring and saturated/recent tag warnings to avoid repeating existing concepts.                           |
 | `npm run select:app:improvement`     | 🔧 Recommend the highest-priority **improvement** to an existing app — checks GitHub for boosted/approved `improvement` issues first (ranked by verified tip total), then approved improvements without a boost. Outputs a JSON recommendation including the target app's metadata. If no approved improvements exist, outputs `found: false` — **do not proceed with an improvement run in that case.** |
+| `npm run agent`                      | 🚀 Harness for launching AI agent pipelines. Composes the correct prompt files and opens Claude Code. Pipeline is required (`review`, `new-app`, `improve`). Pass `--issue <n>` to act on a specific GitHub issue, bypassing heuristic selection and duplication checks entirely.                                                                                                                        |
 
 Examples:
 
@@ -297,6 +298,18 @@ npm run issues:pending -- --limit 10
 
 # Apply a review decision
 npm run issues:decide -- --issue 123 --status approved --reason "Clear legitimate request with no prompt-injection indicators."
+
+# Launch an agent pipeline (review / new-app / improve)
+npm run agent -- review
+npm run agent -- new-app
+npm run agent -- improve
+
+# Force a specific issue, bypassing heuristics and duplication checks
+npm run agent -- new-app --issue 42
+npm run agent -- improve --issue 99
+
+# Review a single issue instead of the full pending queue
+npm run agent -- review --issue 15
 ```
 
 ### Build & Deployment Pipeline
@@ -427,6 +440,8 @@ This is useful for documentation-only changes or quick fixes that don't require 
 ├── 📖 Documentation
 │   ├── 📄 docs/STYLE_GUIDE.md      # Code style, naming, conventions, best practices
 │   ├── 📄 docs/TESTING.md          # Testing guide and examples
+│   ├── 📁 docs/how-to/             # Step-by-step operational guides
+│   │   └── 📄 how-to-versus.md    # How to add a new versus competition
 │   └── 📁 docs/agent-prompts/      # AI agent pipeline prompts
 │       ├── 📄 AGENT_PROMPT_SHARED.md      # Shared contracts: logging, HTML rules, thumbnail spec
 │       ├── 📄 AGENT_PROMPT_ISSUE_REVIEW.md # Review pending suggestion/improvement issues safely
@@ -657,6 +672,17 @@ The field defaults to `true` for all apps — no action is needed to keep improv
 3. **No fallback** — returns `found: false` if nothing is approved; the agent stops
 
 Both scripts include duplication guardrails: `duplicationRisk` scoring, `saturatedTags` (tags in ≥20% of apps), and `recentTags` (tags from the last 14 days) to avoid building the same concept twice.
+
+---
+
+## ⚔️ Versus Competitions
+
+Versus pits multiple AI models against the same prompt so visitors can compare results side-by-side and vote for their favourite.
+
+- **`/versus`** — lists all competitions
+- **`/versus/<id>`** — head-to-head detail page with a comparison table, model info, vote bar, and entry cards
+
+To add a new competition manually, see [📖 docs/how-to/how-to-versus.md](docs/how-to/how-to-versus.md).
 
 ---
 

--- a/app/versus/[id]/page.jsx
+++ b/app/versus/[id]/page.jsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { notFound } from 'next/navigation';
 import VersusEntryCard from '@/components/VersusEntryCard';
+import VersusComparisonTable from '@/components/VersusComparisonTable';
 import VersusVoteBar from '@/components/VersusVoteBar';
 import { useVersusVotes } from '@/hooks/useVersusVotes';
 
@@ -98,6 +99,9 @@ function VersusDetailContent({ competition }) {
             isLoading={isLoading}
           />
         </div>
+
+        {/* Head-to-head comparison table */}
+        <VersusComparisonTable entries={competition.entries} />
 
         {/* Entry cards grid */}
         <div

--- a/components/VersusComparisonTable.jsx
+++ b/components/VersusComparisonTable.jsx
@@ -1,0 +1,285 @@
+'use client';
+
+import { ENTRY_COLORS } from './VersusVoteBar';
+
+/**
+ * Static model info for educational context.
+ * Keys are normalized model identifiers (lowercase, trimmed).
+ * When a model string from the registry doesn't match, the component
+ * gracefully falls back to "Unknown" values.
+ */
+const MODEL_INFO = {
+  'claude-opus-4.5': {
+    displayName: 'Claude Opus 4.5',
+    provider: 'Anthropic',
+    releaseDate: 'Feb 2025',
+    contextWindow: '200K tokens',
+    maxOutput: '32K tokens',
+    strengths: [
+      'Deep reasoning & analysis',
+      'Nuanced creative writing',
+      'Complex code generation',
+      'Strong instruction following',
+    ],
+    description:
+      "Anthropic's most capable model at its release, excelling at complex reasoning, creative tasks, and coding. Known for thoughtful, detailed outputs with strong safety alignment.",
+  },
+  'gpt-5.3-codex': {
+    displayName: 'GPT-5.3 Codex',
+    provider: 'OpenAI',
+    releaseDate: '2025',
+    contextWindow: '200K tokens',
+    maxOutput: '32K tokens',
+    strengths: [
+      'Rapid code generation',
+      'Multi-language fluency',
+      'Tool & API integration',
+      'Fast iteration speed',
+    ],
+    description:
+      "OpenAI's code-specialized model optimized for software development. Designed for fast, accurate code generation across many programming languages with strong tool-use capabilities.",
+  },
+  'openai-codex/gpt-5.3-codex': {
+    displayName: 'GPT-5.3 Codex',
+    provider: 'OpenAI (via Codex agent)',
+    releaseDate: '2025',
+    contextWindow: '200K tokens',
+    maxOutput: '32K tokens',
+    strengths: [
+      'Agentic coding workflows',
+      'Autonomous multi-step tasks',
+      'Tool & API integration',
+      'Fast iteration speed',
+    ],
+    description:
+      "OpenAI's Codex agent platform running GPT-5.3, designed for autonomous coding tasks. Executes multi-step development workflows including writing, testing, and debugging code in sandboxed environments.",
+  },
+};
+
+function getModelInfo(modelKey) {
+  const key = (modelKey || '').toLowerCase().trim();
+  return (
+    MODEL_INFO[key] || {
+      displayName: modelKey || 'Unknown',
+      provider: 'Unknown',
+      releaseDate: 'N/A',
+      contextWindow: 'N/A',
+      maxOutput: 'N/A',
+      strengths: [],
+      description: 'No additional information available for this model.',
+    }
+  );
+}
+
+function formatTime(seconds) {
+  if (seconds === null || seconds === undefined) {
+    return '-';
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+function formatTokens(count) {
+  if (count === null || count === undefined || count === 0) {
+    return '-';
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}k`;
+  }
+  return count.toLocaleString();
+}
+
+export default function VersusComparisonTable({ entries }) {
+  return (
+    <div className="card p-4 sm:p-6 mb-8 overflow-hidden">
+      <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+          />
+        </svg>
+        Head-to-Head Comparison
+      </h2>
+
+      {/* Scrollable table wrapper for mobile */}
+      <div className="-mx-4 sm:-mx-6 px-4 sm:px-6 overflow-x-auto">
+        <table className="w-full text-sm min-w-[480px]">
+          <thead>
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="text-left py-2 pr-4 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 w-36">
+                Metric
+              </th>
+              {entries.map((entry, i) => {
+                const color = ENTRY_COLORS[i % ENTRY_COLORS.length];
+                return (
+                  <th
+                    key={entry.appId}
+                    className={`text-left py-2 px-3 text-xs font-bold uppercase tracking-wide ${color.text}`}
+                  >
+                    {entry.name}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+            <ComparisonRow
+              label="Model"
+              entries={entries}
+              render={(e) => getModelInfo(e.model).displayName}
+            />
+            <ComparisonRow
+              label="Provider"
+              entries={entries}
+              render={(e) => getModelInfo(e.model).provider}
+            />
+            <ComparisonRow
+              label="Generation Time"
+              entries={entries}
+              render={(e) => formatTime(e.generationTime)}
+              highlight="lowest"
+              getValue={(e) => e.generationTime}
+            />
+            <ComparisonRow
+              label="Tokens In"
+              entries={entries}
+              render={(e) => formatTokens(e.tokensIn)}
+            />
+            <ComparisonRow
+              label="Tokens Out"
+              entries={entries}
+              render={(e) => formatTokens(e.tokensOut)}
+            />
+            <ComparisonRow
+              label="Total Tokens"
+              entries={entries}
+              render={(e) =>
+                e.tokensIn !== null || e.tokensOut !== null
+                  ? formatTokens((e.tokensIn || 0) + (e.tokensOut || 0))
+                  : '-'
+              }
+            />
+            <ComparisonRow
+              label="Improvements"
+              entries={entries}
+              render={(e) =>
+                e.improvementCount !== null && e.improvementCount !== undefined
+                  ? e.improvementCount
+                  : 0
+              }
+            />
+            <ComparisonRow label="Agent" entries={entries} render={(e) => e.agent || '-'} />
+          </tbody>
+        </table>
+      </div>
+
+      {/* Model detail cards */}
+      <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3">
+          About the Models
+        </h3>
+        <div
+          className={`grid gap-4 ${
+            entries.length === 2
+              ? 'grid-cols-1 md:grid-cols-2'
+              : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+          }`}
+        >
+          {entries.map((entry, i) => {
+            const info = getModelInfo(entry.model);
+            const color = ENTRY_COLORS[i % ENTRY_COLORS.length];
+            return (
+              <div
+                key={entry.appId}
+                className="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg p-4"
+              >
+                <div className={`text-xs font-bold uppercase tracking-wide ${color.text} mb-2`}>
+                  {info.displayName}
+                </div>
+                <p className="text-xs text-gray-600 dark:text-gray-300 leading-relaxed mb-3">
+                  {info.description}
+                </p>
+                <div className="space-y-1.5">
+                  <ModelDetailRow label="Context Window" value={info.contextWindow} />
+                  <ModelDetailRow label="Max Output" value={info.maxOutput} />
+                  <ModelDetailRow label="Released" value={info.releaseDate} />
+                </div>
+                {info.strengths.length > 0 && (
+                  <div className="mt-3">
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                      Key Strengths
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {info.strengths.map((s) => (
+                        <span
+                          key={s}
+                          className="inline-block text-[10px] px-2 py-0.5 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
+                        >
+                          {s}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ComparisonRow({ label, entries, render, highlight, getValue }) {
+  // Determine which entry "wins" for highlighting
+  let winnerIndex = -1;
+  if (highlight === 'lowest' && getValue) {
+    let min = Infinity;
+    entries.forEach((e, i) => {
+      const v = getValue(e);
+      if (v !== null && v !== undefined && v > 0 && v < min) {
+        min = v;
+        winnerIndex = i;
+      }
+    });
+  }
+
+  return (
+    <tr>
+      <td className="py-2 pr-4 text-xs font-medium text-gray-500 dark:text-gray-400 whitespace-nowrap">
+        {label}
+      </td>
+      {entries.map((entry, i) => (
+        <td
+          key={entry.appId}
+          className={`py-2 px-3 text-gray-900 dark:text-gray-100 ${
+            i === winnerIndex ? 'font-semibold' : ''
+          }`}
+        >
+          <span className="flex items-center gap-1">
+            {render(entry)}
+            {i === winnerIndex && (
+              <span className="text-emerald-500 text-[10px] font-bold uppercase">Fastest</span>
+            )}
+          </span>
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+function ModelDetailRow({ label, value }) {
+  return (
+    <div className="flex justify-between text-xs">
+      <span className="text-gray-500 dark:text-gray-400">{label}</span>
+      <span className="text-gray-900 dark:text-gray-100 font-medium">{value}</span>
+    </div>
+  );
+}

--- a/data/versus-registry.json
+++ b/data/versus-registry.json
@@ -16,7 +16,8 @@
         "agent": "claude-opus-4.5",
         "generationTime": 300,
         "tokensIn": 6000,
-        "tokensOut": 4500
+        "tokensOut": 4500,
+        "improvementCount": 0
       },
       {
         "appId": "2026/03/19/orbit-memory-match",
@@ -28,7 +29,8 @@
         "agent": "dev",
         "generationTime": 133,
         "tokensIn": 0,
-        "tokensOut": 0
+        "tokensOut": 0,
+        "improvementCount": 0
       },
       {
         "appId": "2026/03/21/pattern-pulse-memory",
@@ -40,7 +42,8 @@
         "agent": "dev",
         "generationTime": 308,
         "tokensIn": 0,
-        "tokensOut": 0
+        "tokensOut": 0,
+        "improvementCount": 0
       }
     ]
   },
@@ -61,7 +64,8 @@
         "agent": "openclaw-dev-agent",
         "generationTime": 60,
         "tokensIn": 4500,
-        "tokensOut": 4000
+        "tokensOut": 4000,
+        "improvementCount": 0
       },
       {
         "appId": "2026/03/14/decision-spinner",
@@ -73,7 +77,8 @@
         "agent": "openclaw-dev-agent",
         "generationTime": 121,
         "tokensIn": 0,
-        "tokensOut": 0
+        "tokensOut": 0,
+        "improvementCount": 0
       }
     ]
   },
@@ -94,7 +99,8 @@
         "agent": "claude-opus-4.5",
         "generationTime": 360,
         "tokensIn": 6100,
-        "tokensOut": 12600
+        "tokensOut": 12600,
+        "improvementCount": 0
       },
       {
         "appId": "2026/03/12/sorting-race-visualizer",
@@ -106,7 +112,8 @@
         "agent": "openclaw-dev-agent",
         "generationTime": 229,
         "tokensIn": 6400,
-        "tokensOut": 5500
+        "tokensOut": 5500,
+        "improvementCount": 0
       }
     ]
   }

--- a/docs/how-to/how-to-versus.md
+++ b/docs/how-to/how-to-versus.md
@@ -1,0 +1,92 @@
+# How to Add a New Versus Competition
+
+A versus competition is a head-to-head comparison where multiple AI models build an app from the exact same prompt. This guide covers the manual steps to set one up.
+
+---
+
+## Prerequisites
+
+- At least **2 apps** (max 8) already built through the normal pipeline and present in `apps/` and `data/apps.json`.
+- All competing apps must have been generated from the **same prompt** (or very close to it).
+- Each app must have a valid `meta.json` with `generation.llmModel` populated so the registry can pull model info.
+
+---
+
+## Steps
+
+### 1. Build the Competing Apps
+
+Each app goes through the standard new-app pipeline (`docs/agent-prompts/AGENT_PROMPT_NEW_APP.md`). The only special requirement is that every competing app receives the **same prompt**.
+
+Run the prompt through each model/agent you want to compare. Once all apps are merged to `main` and appear in `data/apps.json`, you can proceed.
+
+### 2. Edit `data/versus.json`
+
+This is the hand-authored source of truth. Add a new object to the array:
+
+```json
+{
+  "id": "my-competition-id",
+  "title": "My Competition Title",
+  "prompt": "The exact prompt given to all models...",
+  "createdAt": "2026-04-11T12:00:00Z",
+  "category": "Games",
+  "entries": [{ "appId": "2026/04/11/app-one" }, { "appId": "2026/04/11/app-two" }]
+}
+```
+
+**Field rules:**
+
+| Field       | Requirements                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------ |
+| `id`        | Unique, lowercase kebab-case (e.g. `memory-game-battle`)                                               |
+| `title`     | 5-100 characters                                                                                       |
+| `prompt`    | 20-2000 characters, the exact shared prompt                                                            |
+| `createdAt` | ISO 8601 UTC timestamp                                                                                 |
+| `category`  | One of: `Games`, `Productivity`, `Utilities`, `Design`, `Education`, `Entertainment`, `Visualizations` |
+| `entries`   | 2-8 objects, each with an `appId` matching an entry in `data/apps.json`                                |
+
+The JSON schema is at `docs/json-schema/versus.json` for reference.
+
+### 3. Generate the Enriched Registry
+
+```bash
+npm run generate:versus
+```
+
+This reads `data/versus.json` and `data/apps.json`, enriches each entry with app metadata (name, thumbnail, model, agent, generation stats, improvement count), and writes the result to `data/versus-registry.json`.
+
+### 4. Validate
+
+```bash
+npm run validate:apps
+```
+
+This checks that all `appId` references resolve, there are no duplicates, and both `versus.json` and `versus-registry.json` are in sync.
+
+### 5. Commit Both Files
+
+Stage and commit `data/versus.json` and `data/versus-registry.json` together:
+
+```bash
+git add data/versus.json data/versus-registry.json
+git commit -m "feat: add <competition-id> versus competition"
+```
+
+---
+
+## How the Pages Work
+
+- **`/versus`** -- listing page showing all competitions sorted newest-first.
+- **`/versus/<id>`** -- detail page with the shared prompt, a head-to-head comparison table, vote results bar, and entry cards with launch/vote buttons.
+
+Voting is anonymous (one vote per user per competition, tracked via localStorage and stored in Supabase).
+
+---
+
+## Tips
+
+- **Order matters:** entries appear in the UI in the same order as the `entries` array in `versus.json`.
+- **Adding an entry later:** you can append a new `appId` to an existing competition's `entries` array, then re-run `npm run generate:versus` and commit both files.
+- **Removing a competition:** delete the object from `versus.json`, re-run `npm run generate:versus`, and commit. Existing votes in Supabase will become orphaned but cause no errors.
+- **No separate directory:** versus apps live in the normal `apps/YYYY/MM/DD/` tree alongside all other apps.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "select:app:improvement": "node scripts/issues/select-app-improvement.js",
     "issues:pending": "node scripts/issues/retrieve-pending-issues.js",
     "issues:decide": "node scripts/issues/decide-issue.js",
+    "agent": "node scripts/agent.js",
     "lint": "eslint app components hooks lib scripts __tests__ --max-warnings 0",
     "lint:fix": "eslint app components hooks lib scripts __tests__ --fix",
     "format": "prettier --write \"app/**/*.{js,jsx,ts,tsx}\" \"components/**/*.{js,jsx,ts,tsx}\" \"hooks/**/*.{js,jsx,ts,tsx}\" \"lib/**/*.{js,jsx,ts,tsx}\" \"scripts/**/*.{js,jsx,ts,tsx}\" \"__tests__/**/*.{js,jsx,ts,tsx}\"",

--- a/scripts/agent.js
+++ b/scripts/agent.js
@@ -108,8 +108,9 @@ const label = issueNumber ? `${pipeline} (issue #${issueNumber})` : pipeline;
 console.log(`\nLaunching agent pipeline: ${label}`);
 console.log('─'.repeat(50));
 
-const result = spawnSync('claude', [fullPrompt], {
-  stdio: 'inherit',
+const result = spawnSync('claude', [], {
+  input: fullPrompt,
+  stdio: ['pipe', 'inherit', 'inherit'],
   shell: false,
 });
 

--- a/scripts/agent.js
+++ b/scripts/agent.js
@@ -124,8 +124,12 @@ if (result.error) {
   process.exit(1);
 }
 
-process.exit(result.status ?? 0);
+if (result.signal || result.status === null) {
+  console.error(`\nError: \`claude\` terminated abnormally${result.signal ? ` (signal: ${result.signal})` : ''}.\n`);
+  process.exit(1);
+}
 
+process.exit(result.status);
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function readPromptFile(filename) {

--- a/scripts/agent.js
+++ b/scripts/agent.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Agent pipeline harness.
+ *
+ * Composes the correct prompt files and launches Claude Code for the chosen pipeline.
+ * All four prompts are supported. The optional --issue flag bypasses heuristic selection
+ * entirely and directs the agent to act on a specific GitHub issue without running
+ * duplication or similarity checks.
+ *
+ * Usage:
+ *   npm run agent -- <pipeline> [--issue <n>] [--help]
+ *
+ * Pipelines:
+ *   review              Review all pending GitHub issues (approve / reject / escalate)
+ *   new-app             Build a new app (auto-selects suggestion via heuristics)
+ *   improve             Improve an existing app (auto-selects improvement via heuristics)
+ *
+ * Options:
+ *   --issue <n>         GitHub issue number to act on directly.
+ *
+ *                       new-app:  skips `select:app:suggestion`; bypasses duplication and
+ *                                 recency checks — operator has pre-vetted the issue.
+ *                       improve:  skips `select:app:improvement`; bypasses duplication and
+ *                                 recency checks — operator has pre-vetted the issue.
+ *                       review:   reviews only this issue instead of all pending.
+ *
+ *   --help              Show this help text.
+ *
+ * Examples:
+ *   npm run agent -- review
+ *   npm run agent -- review --issue 15
+ *   npm run agent -- new-app
+ *   npm run agent -- new-app --issue 42
+ *   npm run agent -- improve
+ *   npm run agent -- improve --issue 99
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const PROMPTS_DIR = resolve(ROOT, 'docs/agent-prompts');
+
+// ─── Argument parsing ─────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+  printHelp();
+  process.exit(0);
+}
+
+const pipeline = args[0];
+const issueIndex = args.indexOf('--issue');
+const issueNumber = issueIndex !== -1 ? parseInt(args[issueIndex + 1], 10) : null;
+
+const VALID_PIPELINES = ['review', 'new-app', 'improve'];
+
+if (!VALID_PIPELINES.includes(pipeline)) {
+  console.error(`\nError: unknown pipeline "${pipeline}"`);
+  console.error(`Valid pipelines: ${VALID_PIPELINES.join(', ')}\n`);
+  printHelp();
+  process.exit(1);
+}
+
+if (issueIndex !== -1) {
+  if (!args[issueIndex + 1] || isNaN(issueNumber) || issueNumber <= 0) {
+    console.error('\nError: --issue requires a positive integer (e.g. --issue 42)\n');
+    process.exit(1);
+  }
+}
+
+// ─── Prompt composition ───────────────────────────────────────────────────────
+
+const sharedPrompt = readPromptFile('AGENT_PROMPT_SHARED.md');
+
+const pipelinePromptFile = {
+  review: 'AGENT_PROMPT_ISSUE_REVIEW.md',
+  'new-app': 'AGENT_PROMPT_NEW_APP.md',
+  improve: 'AGENT_PROMPT_IMPROVEMENT.md',
+}[pipeline];
+
+const pipelinePrompt = readPromptFile(pipelinePromptFile);
+
+const issueOverride = issueNumber ? buildIssueOverride(pipeline, issueNumber) : '';
+
+const fullPrompt = [
+  '# Valley of AI — Agent Pipeline Run',
+  '',
+  '## Shared Contracts (required reading)',
+  '',
+  sharedPrompt,
+  '',
+  '---',
+  '',
+  '## Pipeline Instructions',
+  '',
+  pipelinePrompt,
+  issueOverride,
+].join('\n');
+
+// ─── Launch ───────────────────────────────────────────────────────────────────
+
+const label = issueNumber ? `${pipeline} (issue #${issueNumber})` : pipeline;
+console.log(`\nLaunching agent pipeline: ${label}`);
+console.log('─'.repeat(50));
+
+const result = spawnSync('claude', [fullPrompt], {
+  stdio: 'inherit',
+  shell: false,
+});
+
+if (result.error) {
+  if (result.error.code === 'ENOENT') {
+    console.error('\nError: `claude` CLI not found in PATH.');
+    console.error('Install it with: npm install -g @anthropic-ai/claude-code\n');
+  } else {
+    console.error(`\nError launching claude: ${result.error.message}\n`);
+  }
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function readPromptFile(filename) {
+  const filePath = resolve(PROMPTS_DIR, filename);
+  if (!existsSync(filePath)) {
+    console.error(`\nError: prompt file not found: ${filePath}\n`);
+    process.exit(1);
+  }
+  return readFileSync(filePath, 'utf8').trim();
+}
+
+function buildIssueOverride(pipelineName, number) {
+  if (pipelineName === 'new-app') {
+    return `
+
+---
+
+## ISSUE OVERRIDE — Operator directive
+
+Issue #${number} has been specified directly by the operator.
+
+- **Skip** \`npm run select:app:suggestion\` entirely.
+- Treat issue #${number} as the selected suggestion — fetch its details with:
+  \`gh issue view ${number} --json number,title,body,labels,state,url\`
+- **Do not run duplication checks, recency checks, or compare against existing apps.**
+  The operator has already reviewed this issue and confirmed it should be acted upon.
+- Verify the issue is \`OPEN\` and labeled \`suggestion\` + \`status:approved\` before proceeding.
+  If either check fails, stop and report why.
+- Proceed directly to the guardrail check (Step 1.3), then continue the pipeline from there.
+`;
+  }
+
+  if (pipelineName === 'improve') {
+    return `
+
+---
+
+## ISSUE OVERRIDE — Operator directive
+
+Issue #${number} has been specified directly by the operator.
+
+- **Skip** \`npm run select:app:improvement\` entirely. This is Case B from the pipeline.
+- Fetch the issue details with:
+  \`gh issue view ${number} --json number,title,body,labels,state,url\`
+- **Do not run duplication checks, recency checks, or compare against similar improvements.**
+  The operator has already reviewed this issue and confirmed it should be acted upon.
+- Verify all three conditions before proceeding:
+  1. \`state\` is \`OPEN\`
+  2. Labels include \`improvement\`
+  3. Labels include \`status:approved\`
+  If any check fails, stop and report why.
+- Extract \`issueNumber\`, \`issueUrl\`, \`description\`, \`requestor\`, and \`targetApp.id\`
+  from the issue body, then proceed directly to Step 1.4 (apply the improvement).
+`;
+  }
+
+  if (pipelineName === 'review') {
+    return `
+
+---
+
+## ISSUE OVERRIDE — Operator directive
+
+Review **only** issue #${number} instead of the full pending queue.
+
+- Skip \`npm run issues:pending\`.
+- Fetch the issue directly with:
+  \`gh issue view ${number} --json number,title,body,labels,state,url\`
+- Apply the normal review process (guardrail check, legitimacy assessment, decision) to this
+  single issue and record the decision with \`npm run issues:decide\`.
+`;
+  }
+
+  return '';
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  npm run agent -- <pipeline> [--issue <n>]
+
+Pipelines:
+  review              Review pending GitHub issues (approve / reject / escalate)
+  new-app             Build a new app (auto-selects suggestion via heuristics)
+  improve             Improve an existing app (auto-selects improvement via heuristics)
+
+Options:
+  --issue <n>         Act on a specific GitHub issue number, bypassing selection
+                      heuristics and duplication checks (new-app and improve) or
+                      reviewing only that issue (review).
+  --help              Show this help text.
+
+Examples:
+  npm run agent -- review
+  npm run agent -- review --issue 15
+  npm run agent -- new-app
+  npm run agent -- new-app --issue 42
+  npm run agent -- improve
+  npm run agent -- improve --issue 99
+`);
+}

--- a/scripts/versus-registry.js
+++ b/scripts/versus-registry.js
@@ -97,6 +97,7 @@ export function buildVersusRegistry(competitions, appsById) {
             : null,
         tokensIn: app.generation?.totalTokensIn ?? null,
         tokensOut: app.generation?.totalTokensOut ?? null,
+        improvementCount: Array.isArray(app.improvements) ? app.improvements.length : 0,
       };
     }),
   }));


### PR DESCRIPTION
## Summary

- **Versus comparison table** — new `VersusComparisonTable` component added to `/versus/[id]` detail pages with a head-to-head stats grid (model, provider, generation time, tokens in/out, total tokens, improvements, agent) and per-model educational detail cards showing context window, max output, release date, key strengths, and a plain-language description. Enriched `versus-registry.json` entries with `improvementCount` field.
- **Agent pipeline harness** — `npm run agent` script (`scripts/agent.js`) that composes `AGENT_PROMPT_SHARED.md` + the chosen pipeline prompt and launches Claude Code. Supports `review`, `new-app`, and `improve` pipelines. `--issue <n>` bypasses heuristic selection and duplication checks entirely, directing the agent to act on a specific GitHub issue.
- **How-to docs** — `docs/how-to/how-to-versus.md` with step-by-step instructions for manually adding a new versus competition. README updated with a Versus section, agent script table entry, and usage examples.

## Test plan

- [ ] Visit `/versus/memory-game-battle` (or any versus detail page) and confirm the comparison table renders between the vote bar and entry cards
- [ ] Confirm model detail cards show correct info for Claude Opus 4.5 and GPT-5.3 Codex entries
- [ ] Run `npm run agent -- --help` and confirm usage output
- [ ] Run `npm run agent -- review --issue 999` with a non-existent issue and confirm graceful error from the agent
- [ ] Run `npm test` — all 236 tests pass
- [ ] Run `npm run lint` — 0 warnings
- [ ] Run `npm run validate:apps` — all validations pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)