### PR TITLE
feat: add Similar Apps section on app detail page

### DIFF
--- a/__tests__/lib/similarApps.test.js
+++ b/__tests__/lib/similarApps.test.js
@@ -3,7 +3,7 @@ import { getSimilarApps } from '@/lib/similarApps';
 const makeApp = (overrides) => ({
   id: 'default-id',
   name: 'Default App',
-  category: 'Tools',
+  category: 'Utilities',
   tags: [],
   createdAt: '2026-01-01T00:00:00Z',
   visible: true,
@@ -26,7 +26,7 @@ describe('getSimilarApps', () => {
   it('excludes apps with visible: false', () => {
     const current = makeApp({ id: 'current', category: 'Games' });
     const hidden = makeApp({ id: 'hidden', category: 'Games', visible: false });
-    const visible = makeApp({ id: 'visible', category: 'Tools' });
+    const visible = makeApp({ id: 'visible', category: 'Utilities' });
     const results = getSimilarApps(current, [current, hidden, visible]);
     expect(results.find((r) => r.id === 'hidden')).toBeUndefined();
   });
@@ -34,7 +34,7 @@ describe('getSimilarApps', () => {
   it('prioritizes same-category apps over cross-category apps', () => {
     const current = makeApp({ id: 'current', category: 'Games', tags: [] });
     const sameCategory = makeApp({ id: 'same-cat', category: 'Games', tags: [] });
-    const differentCategory = makeApp({ id: 'diff-cat', category: 'Tools', tags: [] });
+    const differentCategory = makeApp({ id: 'diff-cat', category: 'Utilities', tags: [] });
     const results = getSimilarApps(current, [current, differentCategory, sameCategory]);
     expect(results[0].id).toBe('same-cat');
   });
@@ -64,19 +64,18 @@ describe('getSimilarApps', () => {
     expect(results).toHaveLength(4);
   });
 
-  it('includes cross-category apps when needed to fill results', () => {
+  it('returns empty array when no apps have a positive score', () => {
     const current = makeApp({ id: 'current', category: 'Games', tags: [] });
-    const crossCat = makeApp({ id: 'cross', category: 'Tools', tags: [] });
+    const crossCat = makeApp({ id: 'cross', category: 'Utilities', tags: [] });
     const results = getSimilarApps(current, [current, crossCat], 5);
-    expect(results).toHaveLength(1);
-    expect(results[0].id).toBe('cross');
+    expect(results).toHaveLength(0);
   });
 
   it('scores shared tags from cross-category apps correctly', () => {
     const current = makeApp({ id: 'current', category: 'Games', tags: ['canvas', 'mobile'] });
     const sameTagsDiffCat = makeApp({
       id: 'tags-match',
-      category: 'Tools',
+      category: 'Utilities',
       tags: ['canvas', 'mobile'],
     });
     const sameCatNoTags = makeApp({ id: 'cat-match', category: 'Games', tags: [] });

--- a/__tests__/lib/similarApps.test.js
+++ b/__tests__/lib/similarApps.test.js
@@ -1,0 +1,94 @@
+import { getSimilarApps } from '@/lib/similarApps';
+
+const makeApp = (overrides) => ({
+  id: 'default-id',
+  name: 'Default App',
+  category: 'Tools',
+  tags: [],
+  createdAt: '2026-01-01T00:00:00Z',
+  visible: true,
+  ...overrides,
+});
+
+describe('getSimilarApps', () => {
+  it('returns empty array when no other apps exist', () => {
+    const app = makeApp({ id: 'only-app' });
+    expect(getSimilarApps(app, [app])).toEqual([]);
+  });
+
+  it('excludes the current app from results', () => {
+    const current = makeApp({ id: 'current', category: 'Games' });
+    const other = makeApp({ id: 'other', category: 'Games' });
+    const results = getSimilarApps(current, [current, other]);
+    expect(results.every((r) => r.id !== 'current')).toBe(true);
+  });
+
+  it('excludes apps with visible: false', () => {
+    const current = makeApp({ id: 'current', category: 'Games' });
+    const hidden = makeApp({ id: 'hidden', category: 'Games', visible: false });
+    const visible = makeApp({ id: 'visible', category: 'Tools' });
+    const results = getSimilarApps(current, [current, hidden, visible]);
+    expect(results.find((r) => r.id === 'hidden')).toBeUndefined();
+  });
+
+  it('prioritizes same-category apps over cross-category apps', () => {
+    const current = makeApp({ id: 'current', category: 'Games', tags: [] });
+    const sameCategory = makeApp({ id: 'same-cat', category: 'Games', tags: [] });
+    const differentCategory = makeApp({ id: 'diff-cat', category: 'Tools', tags: [] });
+    const results = getSimilarApps(current, [current, differentCategory, sameCategory]);
+    expect(results[0].id).toBe('same-cat');
+  });
+
+  it('breaks category ties by shared tag count', () => {
+    const current = makeApp({ id: 'current', category: 'Games', tags: ['a', 'b', 'c'] });
+    const fewTags = makeApp({ id: 'few-tags', category: 'Games', tags: ['a'] });
+    const moreTags = makeApp({ id: 'more-tags', category: 'Games', tags: ['a', 'b'] });
+    const results = getSimilarApps(current, [current, fewTags, moreTags]);
+    expect(results[0].id).toBe('more-tags');
+  });
+
+  it('breaks score ties by recency (newest first)', () => {
+    const current = makeApp({ id: 'current', category: 'Games' });
+    const older = makeApp({ id: 'older', category: 'Games', createdAt: '2026-01-01T00:00:00Z' });
+    const newer = makeApp({ id: 'newer', category: 'Games', createdAt: '2026-03-01T00:00:00Z' });
+    const results = getSimilarApps(current, [current, older, newer]);
+    expect(results[0].id).toBe('newer');
+  });
+
+  it('returns at most `limit` results', () => {
+    const current = makeApp({ id: 'current', category: 'Games' });
+    const others = Array.from({ length: 10 }, (_, i) =>
+      makeApp({ id: `app-${i}`, category: 'Games' })
+    );
+    const results = getSimilarApps(current, [current, ...others], 4);
+    expect(results).toHaveLength(4);
+  });
+
+  it('includes cross-category apps when needed to fill results', () => {
+    const current = makeApp({ id: 'current', category: 'Games', tags: [] });
+    const crossCat = makeApp({ id: 'cross', category: 'Tools', tags: [] });
+    const results = getSimilarApps(current, [current, crossCat], 5);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('cross');
+  });
+
+  it('scores shared tags from cross-category apps correctly', () => {
+    const current = makeApp({ id: 'current', category: 'Games', tags: ['canvas', 'mobile'] });
+    const sameTagsDiffCat = makeApp({
+      id: 'tags-match',
+      category: 'Tools',
+      tags: ['canvas', 'mobile'],
+    });
+    const sameCatNoTags = makeApp({ id: 'cat-match', category: 'Games', tags: [] });
+    // sameCatNoTags: score 10; sameTagsDiffCat: score 4
+    const results = getSimilarApps(current, [current, sameTagsDiffCat, sameCatNoTags]);
+    expect(results[0].id).toBe('cat-match');
+    expect(results[1].id).toBe('tags-match');
+  });
+
+  it('handles apps with no tags gracefully', () => {
+    const current = makeApp({ id: 'current', tags: undefined });
+    const other = makeApp({ id: 'other', tags: null });
+    expect(() => getSimilarApps(current, [current, other])).not.toThrow();
+  });
+});

--- a/app/showcase/[...id]/AppDetailClient.jsx
+++ b/app/showcase/[...id]/AppDetailClient.jsx
@@ -5,10 +5,11 @@ import { useState } from 'react';
 import { useVotes } from '@/hooks/useVotes';
 import VoteButtons from '@/components/VoteButtons';
 import AppLog from '@/components/AppLog';
+import AppCard from '@/components/AppCard';
 import ShareButton from '@/components/ShareButton';
 import { githubUrl, siteName } from '@/lib/siteConfig';
 
-export default function AppDetailClient({ app, id }) {
+export default function AppDetailClient({ app, id, similarApps }) {
   const { upvoteCount, downvoteCount, myVote, isLoading, isVoting, vote } = useVotes(id);
   const [selectedVersionUrl, setSelectedVersionUrl] = useState(app.appPath);
 
@@ -305,6 +306,20 @@ export default function AppDetailClient({ app, id }) {
                 </div>
               )}
             </dl>
+          </div>
+        )}
+
+        {/* Similar Apps */}
+        {similarApps && similarApps.length > 0 && (
+          <div className="mt-8">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              Similar Apps
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {similarApps.map((similar) => (
+                <AppCard key={similar.id} app={similar} />
+              ))}
+            </div>
           </div>
         )}
 

--- a/app/showcase/[...id]/AppDetailClient.jsx
+++ b/app/showcase/[...id]/AppDetailClient.jsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
-import { useVotes } from '@/hooks/useVotes';
+import { useVotes, useAllVoteCounts } from '@/hooks/useVotes';
 import VoteButtons from '@/components/VoteButtons';
 import AppLog from '@/components/AppLog';
 import AppCard from '@/components/AppCard';
@@ -11,6 +11,8 @@ import { githubUrl, siteName } from '@/lib/siteConfig';
 
 export default function AppDetailClient({ app, id, similarApps }) {
   const { upvoteCount, downvoteCount, myVote, isLoading, isVoting, vote } = useVotes(id);
+  const similarAppIds = similarApps?.map((a) => a.id) ?? [];
+  const { voteCounts: similarVoteCounts } = useAllVoteCounts(similarAppIds);
   const [selectedVersionUrl, setSelectedVersionUrl] = useState(app.appPath);
 
   const formattedDate = new Date(app.createdAt).toLocaleDateString('en-US', {
@@ -317,7 +319,11 @@ export default function AppDetailClient({ app, id, similarApps }) {
             </h2>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {similarApps.map((similar) => (
-                <AppCard key={similar.id} app={similar} />
+                <AppCard
+                  key={similar.id}
+                  app={similar}
+                  initialCounts={similarVoteCounts[similar.id]}
+                />
               ))}
             </div>
           </div>

--- a/app/showcase/[...id]/page.jsx
+++ b/app/showcase/[...id]/page.jsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { siteName, siteUrl } from '@/lib/siteConfig';
 import appsData from '@/data/apps.json';
+import { getSimilarApps } from '@/lib/similarApps';
 import AppDetailClient from './AppDetailClient';
 
 export const dynamic = 'force-static';
@@ -116,10 +117,12 @@ export default async function AppDetailPage({ params }) {
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
 
+  const similarApps = getSimilarApps(app, appsData, 5);
+
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd }} />
-      <AppDetailClient app={app} id={id} />
+      <AppDetailClient app={app} id={id} similarApps={similarApps} />
     </>
   );
 }

--- a/lib/similarApps.js
+++ b/lib/similarApps.js
@@ -1,0 +1,41 @@
+/**
+ * Returns up to `limit` apps similar to `currentApp`.
+ *
+ * Scoring:
+ *   +10  same category  (primary signal)
+ *   +2   per shared tag (secondary signal)
+ * Ties broken by createdAt descending (newest first).
+ *
+ * Apps with score 0 are still eligible to pad results, sorted by recency.
+ *
+ * @param {object}   currentApp - the app being viewed
+ * @param {object[]} allApps    - full app registry (data/apps.json)
+ * @param {number}   [limit=5]  - max results to return
+ * @returns {object[]}
+ */
+export function getSimilarApps(currentApp, allApps, limit = 5) {
+  const currentTags = new Set(currentApp.tags || []);
+
+  const scored = allApps
+    .filter((app) => app.id !== currentApp.id && app.visible !== false)
+    .map((app) => {
+      let score = 0;
+      if (app.category === currentApp.category) {
+        score += 10;
+      }
+      for (const tag of app.tags || []) {
+        if (currentTags.has(tag)) {
+          score += 2;
+        }
+      }
+      return { app, score };
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return new Date(b.app.createdAt) - new Date(a.app.createdAt);
+    });
+
+  return scored.slice(0, limit).map(({ app }) => app);
+}

--- a/lib/similarApps.js
+++ b/lib/similarApps.js
@@ -28,13 +28,14 @@ export function getSimilarApps(currentApp, allApps, limit = 5) {
           score += 2;
         }
       }
-      return { app, score };
+      const createdAtMs = new Date(app.createdAt).getTime();
+      return { app, score, createdAtMs };
     })
     .sort((a, b) => {
       if (b.score !== a.score) {
         return b.score - a.score;
       }
-      return new Date(b.app.createdAt) - new Date(a.app.createdAt);
+      return b.createdAtMs - a.createdAtMs;
     });
 
   return scored.slice(0, limit).map(({ app }) => app);

--- a/lib/similarApps.js
+++ b/lib/similarApps.js
@@ -6,7 +6,7 @@
  *   +2   per shared tag (secondary signal)
  * Ties broken by createdAt descending (newest first).
  *
- * Apps with score 0 are still eligible to pad results, sorted by recency.
+ * Apps with score 0 are excluded; returns [] when no positive-score matches exist.
  *
  * @param {object}   currentApp - the app being viewed
  * @param {object[]} allApps    - full app registry (data/apps.json)
@@ -38,5 +38,8 @@ export function getSimilarApps(currentApp, allApps, limit = 5) {
       return b.createdAtMs - a.createdAtMs;
     });
 
-  return scored.slice(0, limit).map(({ app }) => app);
+  return scored
+    .filter(({ score }) => score > 0)
+    .slice(0, limit)
+    .map(({ app }) => app);
 }


### PR DESCRIPTION
## Summary

- Adds a **Similar Apps** section on each app detail page showing up to 5 related apps
- Scoring: same category (+10), shared tags (+2 each), ties broken by recency (newest first)
- Section is hidden when no similar apps are found (e.g. only one app in a category)
- Computed server-side at static generation time — no runtime cost

## Test plan

- [ ] `npm test` passes (257 tests, including 10 new `similarApps` unit tests)
- [ ] `npm run lint` passes with 0 warnings
- [ ] Navigate to any app detail page and confirm the Similar Apps section appears below Generation Info
- [ ] Confirm the current app is not listed among similar apps
- [ ] Confirm same-category apps appear before cross-category tag matches

Closes growth plan item 2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)