### PR TITLE
feat: add Trending row above gallery on home page

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -9,6 +9,7 @@ import GalleryPagination, { PER_PAGE_OPTIONS } from '@/components/GalleryPaginat
 import OptionsDrawer from '@/components/OptionsDrawer';
 import PaymentSuccessModal from '@/components/PaymentSuccessModal';
 import PterodactylSky from '@/components/PterodactylSky';
+import TrendingRow from '@/components/TrendingRow';
 import { usePterodactyls } from '@/hooks/usePterodactyls';
 import { useAllVoteCounts } from '@/hooks/useVotes';
 import { trendingScore } from '@/lib/trendingScore';
@@ -232,6 +233,19 @@ export default function HomePage() {
     return sortedApps.slice(start, start + perPage);
   }, [sortedApps, currentPage, totalPages, perPage]);
 
+  const trendingApps = useMemo(() => {
+    const now = Date.now();
+    return appsData
+      .map((app) => ({
+        app,
+        score: trendingScore(app.createdAt, voteCounts[app.id]?.recentNet ?? 0, now),
+      }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 6)
+      .map(({ app }) => app);
+  }, [voteCounts]);
+
   const activeFilterCount = [
     categoryFilter,
     agentFilter,
@@ -314,6 +328,8 @@ export default function HomePage() {
             and our AI might bring it to life.
           </p>
         </div>
+
+        <TrendingRow apps={trendingApps} voteCounts={voteCounts} />
 
         <GalleryFilters
           searchQuery={searchQuery}

--- a/components/TrendingRow.jsx
+++ b/components/TrendingRow.jsx
@@ -1,0 +1,24 @@
+'use client';
+
+import AppCard from '@/components/AppCard';
+
+export default function TrendingRow({ apps, voteCounts }) {
+  if (!apps || apps.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-8">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+        <span aria-hidden="true">🔥</span> Trending
+      </h2>
+      <div className="flex gap-4 overflow-x-auto pb-3 snap-x snap-mandatory">
+        {apps.map((app) => (
+          <div key={app.id} className="w-64 flex-shrink-0 snap-start">
+            <AppCard app={app} initialCounts={voteCounts?.[app.id]} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/GROWTH_PLAN.md
+++ b/docs/GROWTH_PLAN.md
@@ -54,8 +54,8 @@ This document breaks the viral growth and community roadmap into checkable tasks
 
 ### 2.4 Add Featured/Trending section to home
 
-- [ ] Add a small horizontal section above the gallery
-- [ ] Use trending list for now; allow manual override later
+- [x] Add a small horizontal section above the gallery
+- [x] Use trending list for now; allow manual override later
 
 ## Phase 3: Community Onboarding
 


### PR DESCRIPTION
## Summary

- Adds a **Trending** horizontal strip between the hero block and gallery filters on the home page
- Shows up to 6 apps ranked by recent vote velocity + time decay (reuses existing `trendingScore` from `lib/trendingScore.js`)
- Horizontally scrollable with snap-scroll for mobile swipe feel
- Section renders nothing while vote data is loading; disappears if no apps have a positive trending score
- No new data fetching — reuses `voteCounts` already fetched by `useAllVoteCounts` on the page

## Test plan

- [ ] `npm run lint` passes with 0 warnings
- [ ] `npm test` passes (257 tests)
- [ ] `npm run dev` — Trending strip appears above filters after vote data loads
- [ ] Up to 6 cards shown, each linking to its detail page
- [ ] Horizontally scrollable on mobile

Closes growth plan item 2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)