### PR TITLE
improve: multiplayer Word Scramble Party flow

### DIFF
--- a/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/index.html
+++ b/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/index.html
@@ -1,0 +1,800 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="auto">
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '__GA_MEASUREMENT_ID__');
+    </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Word Scramble - __MAIN_SITE_NAME__</title>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🔤%3C/text%3E%3C/svg%3E">
+  <style>
+    :root {
+      --primary: #8b5cf6;
+      --primary-hover: #7c3aed;
+      --success: #10b981;
+      --error: #ef4444;
+      --warning: #f59e0b;
+      --bg: #fafaf9;
+      --bg-card: #ffffff;
+      --text: #1c1917;
+      --text-secondary: #78716c;
+      --border: #e7e5e4;
+      --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    ;--surface:#101a31;--accent:#22d3ee;}
+
+    [data-theme="dark"] {
+      --primary: #a78bfa;
+      --primary-hover: #8b5cf6;
+      --bg: #1c1917;
+      --bg-card: #292524;
+      --text: #fafaf9;
+      --text-secondary: #a8a29e;
+      --border: #44403c;
+      --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3);
+      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme="light"]) {
+        --primary: #a78bfa;
+        --primary-hover: #8b5cf6;
+        --bg: #1c1917;
+        --bg-card: #292524;
+        --text: #fafaf9;
+        --text-secondary: #a8a29e;
+        --border: #44403c;
+        --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3);
+        --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3);
+      }
+    }
+
+    .theme-toggle {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      background: var(--bg-card, #fff);
+      border: 1px solid var(--border, #ccc);
+      border-radius: 50%;
+      width: 44px;
+      height: 44px;
+      font-size: 1.3rem;
+      cursor: pointer;
+      z-index: 100;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+      line-height: 1.6;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 500px;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+
+    .subtitle {
+      color: var(--text-secondary);
+      font-size: 1rem;
+    }
+
+    .stats {
+      display: flex;
+      justify-content: center;
+      gap: 2rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .stat {
+      text-align: center;
+    }
+
+    .stat-value {
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--primary);
+    }
+
+    .stat-label {
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .game-card {
+      background: var(--bg-card);
+      border-radius: 16px;
+      padding: 2rem;
+      box-shadow: var(--shadow-lg);
+      margin-bottom: 1.5rem;
+    }
+
+    .hint {
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+      margin-bottom: 1rem;
+    }
+
+    .hint strong {
+      color: var(--text);
+    }
+
+    .scrambled-word {
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .letter-tile {
+      width: 48px;
+      height: 56px;
+      background: linear-gradient(135deg, var(--primary) 0%, var(--primary-hover) 100%);
+      color: white;
+      font-size: 1.5rem;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 0.15s, box-shadow 0.15s;
+      user-select: none;
+      touch-action: manipulation;
+    }
+
+    .letter-tile:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-lg);
+    }
+
+    .letter-tile:active {
+      transform: translateY(0);
+    }
+
+    .letter-tile.used {
+      opacity: 0.3;
+      pointer-events: none;
+    }
+
+    .answer-area {
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+      min-height: 56px;
+      flex-wrap: wrap;
+    }
+
+    .answer-slot {
+      width: 48px;
+      height: 56px;
+      background: var(--bg);
+      border: 2px dashed var(--border);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--text);
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .answer-slot.filled {
+      border-style: solid;
+      border-color: var(--primary);
+      background: var(--bg-card);
+      cursor: pointer;
+    }
+
+    .answer-slot.filled:hover {
+      background: var(--border);
+    }
+
+    .answer-slot.filled {
+      touch-action: manipulation;
+    }
+
+    .answer-slot.correct {
+      border-color: var(--success);
+      background: rgba(16, 185, 129, 0.1);
+    }
+
+    .answer-slot.wrong {
+      border-color: var(--error);
+      background: rgba(239, 68, 68, 0.1);
+      animation: shake 0.4s ease-in-out;
+    }
+
+    @keyframes shake {
+      0%, 100% { transform: translateX(0); }
+      25% { transform: translateX(-8px); }
+      75% { transform: translateX(8px); }
+    }
+
+    .actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+    }
+
+    button {
+      min-height: 44px;
+      padding: 0.75rem 1.5rem;
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, var(--primary) 0%, var(--primary-hover) 100%);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(139, 92, 246, 0.4);
+    }
+
+    .btn-secondary {
+      background: var(--bg);
+      color: var(--text);
+      border: 2px solid var(--border);
+    }
+
+    .btn-secondary:hover {
+      background: var(--border);
+    }
+
+    .message {
+      text-align: center;
+      padding: 1rem;
+      border-radius: 8px;
+      margin-bottom: 1rem;
+      font-weight: 500;
+      animation: fadeIn 0.3s ease-out;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(-10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .message.success {
+      background: rgba(16, 185, 129, 0.1);
+      color: var(--success);
+    }
+
+    .message.error {
+      background: rgba(239, 68, 68, 0.1);
+      color: var(--error);
+    }
+
+    .level-indicator {
+      text-align: center;
+      margin-bottom: 1rem;
+    }
+
+    .level-badge {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      background: var(--primary);
+      color: white;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .timer {
+      color: var(--warning);
+      font-weight: 600;
+    }
+
+    footer {
+      text-align: center;
+      margin-top: 2rem;
+    }
+
+    .badge {
+      display: inline-block;
+      background: var(--border);
+      color: var(--text-secondary);
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+
+    @media (max-width: 640px) {
+      body {
+        justify-content: flex-start;
+        padding: 0.75rem;
+      }
+
+      .container {
+        max-width: 100%;
+      }
+
+      header {
+        margin-bottom: 1rem;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+      }
+
+      .stats {
+        gap: 0.75rem;
+        justify-content: space-between;
+      }
+
+      .stat {
+        flex: 1;
+        min-width: 72px;
+      }
+
+      .stat-value {
+        font-size: 1.35rem;
+      }
+
+      .game-card {
+        padding: 1rem;
+      }
+
+      .letter-tile,
+      .answer-slot {
+        width: 42px;
+        height: 50px;
+        font-size: 1.3rem;
+      }
+
+      .actions {
+        flex-direction: column;
+      }
+
+      .actions button {
+        width: 100%;
+      }
+
+      .theme-toggle {
+        top: 10px;
+        right: 10px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  [data-theme='light']{--bg:#eef4ff;--surface:#ffffff;--text:#1f2f52;--accent:#0891b2;--shadow:rgba(31, 47, 82, 0.12);}
+</style>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
+    <meta name="voa-social-x-url" content="__SOCIAL_X_URL__">
+  <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__">
+  <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__">
+  <meta name="voa-app-id" content="2026/03/06/word-scramble" />
+  <script src="/apps/shared/app-shell.js" defer></script>
+</head>
+<body>
+  <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>
+  <div class="container">
+    <header>
+      <h1>🔤 Word Scramble</h1>
+      <p class="subtitle">Unscramble the letters to reveal the word! Tap letters on mobile.</p>
+    </header>
+
+    <div class="stats">
+      <div class="stat">
+        <div class="stat-value" id="score">0</div>
+        <div class="stat-label">Score</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value" id="streak">0</div>
+        <div class="stat-label">Streak</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value timer" id="timer">30</div>
+        <div class="stat-label">Seconds</div>
+      </div>
+    </div>
+
+    <div class="game-card">
+      <div class="level-indicator">
+        <span class="level-badge" id="level">Level 1</span>
+      </div>
+
+      <div class="hint" id="hint">
+        Hint: <strong>Loading...</strong>
+      </div>
+
+      <div id="message"></div>
+
+      <div class="scrambled-word" id="scrambled"></div>
+
+      <div class="answer-area" id="answer"></div>
+
+      <div class="actions">
+        <button class="btn-secondary" onclick="clearAnswer()">
+          ↩️ Clear
+        </button>
+        <button class="btn-primary" onclick="submitAnswer()">
+          ✓ Submit
+        </button>
+        <button class="btn-secondary" onclick="skipWord()">
+          ⏭️ Skip
+        </button>
+      </div>
+    </div>
+
+    <footer>
+      <span class="badge">Generated by AI</span>
+    </footer>
+    <footer style="text-align: center; padding: 20px; margin-top: 20px; opacity: 0.7;">
+      <a href="https://www.valleyofai.com" target="_blank" rel="noopener" style="color: var(--primary, #3b82f6); text-decoration: none;">← Back to Valley of AI</a>
+    </footer>
+  </div>
+
+  <script>
+    // Word list with hints organized by difficulty
+    const WORDS = {
+      easy: [
+        { word: 'apple', hint: 'A red or green fruit' },
+        { word: 'house', hint: 'A place to live' },
+        { word: 'water', hint: 'Essential for life, H2O' },
+        { word: 'happy', hint: 'Feeling of joy' },
+        { word: 'music', hint: 'Sound arranged in patterns' },
+        { word: 'dance', hint: 'Moving to rhythm' },
+        { word: 'light', hint: 'Opposite of dark' },
+        { word: 'dream', hint: 'What happens when you sleep' },
+        { word: 'cloud', hint: 'White fluffy thing in the sky' },
+        { word: 'smile', hint: 'Happy facial expression' },
+      ],
+      medium: [
+        { word: 'purple', hint: 'A mix of red and blue' },
+        { word: 'garden', hint: 'Where flowers grow' },
+        { word: 'bridge', hint: 'Crosses over water' },
+        { word: 'planet', hint: 'Earth is one of these' },
+        { word: 'frozen', hint: 'Solid water state' },
+        { word: 'silent', hint: 'Without any sound' },
+        { word: 'guitar', hint: 'A stringed instrument' },
+        { word: 'market', hint: 'Place to buy food' },
+        { word: 'winter', hint: 'Cold season' },
+        { word: 'castle', hint: 'Where kings live' },
+      ],
+      hard: [
+        { word: 'computer', hint: 'Electronic device for work' },
+        { word: 'elephant', hint: 'Large gray animal with trunk' },
+        { word: 'treasure', hint: 'Valuable hidden items' },
+        { word: 'mountain', hint: 'Very tall landform' },
+        { word: 'sandwich', hint: 'Food between two slices' },
+        { word: 'calendar', hint: 'Shows dates and months' },
+        { word: 'umbrella', hint: 'Protection from rain' },
+        { word: 'keyboard', hint: 'Input device with keys' },
+        { word: 'starfish', hint: 'Sea creature with five arms' },
+        { word: 'dinosaur', hint: 'Extinct prehistoric creature' },
+      ]
+    };
+
+    // Game state
+    let currentWord = '';
+    let currentHint = '';
+    let scrambledLetters = [];
+    let answerLetters = [];
+    let usedIndices = new Set();
+    let score = 0;
+    let streak = 0;
+    let level = 1;
+    let timeLeft = 30;
+    let timerInterval = null;
+    let usedWords = new Set();
+
+    // DOM Elements
+    const scoreEl = document.getElementById('score');
+    const streakEl = document.getElementById('streak');
+    const timerEl = document.getElementById('timer');
+    const levelEl = document.getElementById('level');
+    const hintEl = document.getElementById('hint');
+    const messageEl = document.getElementById('message');
+    const scrambledEl = document.getElementById('scrambled');
+    const answerEl = document.getElementById('answer');
+
+    // Get difficulty based on level
+    function getDifficulty() {
+      if (level <= 3) return 'easy';
+      if (level <= 6) return 'medium';
+      return 'hard';
+    }
+
+    // Shuffle array (Fisher-Yates)
+    function shuffle(array) {
+      const arr = [...array];
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    }
+
+    // Get a new word
+    function getNewWord() {
+      const difficulty = getDifficulty();
+      const words = WORDS[difficulty].filter(w => !usedWords.has(w.word));
+      
+      // Reset used words if we've gone through all
+      if (words.length === 0) {
+        usedWords.clear();
+        return getNewWord();
+      }
+      
+      const selected = words[Math.floor(Math.random() * words.length)];
+      usedWords.add(selected.word);
+      return selected;
+    }
+
+    // Start new round
+    function newRound() {
+      const wordData = getNewWord();
+      currentWord = wordData.word;
+      currentHint = wordData.hint;
+      
+      // Make sure scrambled version is different from original
+      do {
+        scrambledLetters = shuffle(currentWord.split(''));
+      } while (scrambledLetters.join('') === currentWord);
+      
+      answerLetters = [];
+      usedIndices.clear();
+      
+      // Reset timer
+      timeLeft = Math.max(15, 30 - (level - 1) * 2); // Decreases with level, min 15
+      
+      renderGame();
+      startTimer();
+    }
+
+    // Render the game
+    function renderGame() {
+      // Update stats
+      scoreEl.textContent = score;
+      streakEl.textContent = streak;
+      timerEl.textContent = timeLeft;
+      levelEl.textContent = `Level ${level}`;
+      hintEl.innerHTML = `Hint: <strong>${currentHint}</strong>`;
+      
+      // Render scrambled letters
+      scrambledEl.innerHTML = scrambledLetters.map((letter, idx) => `
+        <div class="letter-tile ${usedIndices.has(idx) ? 'used' : ''}" 
+             onclick="selectLetter(${idx})"
+             role="button" 
+             tabindex="0"
+             aria-label="Letter ${letter}">
+          ${letter}
+        </div>
+      `).join('');
+      
+      // Render answer slots
+      answerEl.innerHTML = '';
+      for (let i = 0; i < currentWord.length; i++) {
+        const letter = answerLetters[i];
+        const slot = document.createElement('div');
+        slot.className = 'answer-slot' + (letter ? ' filled' : '');
+        slot.textContent = letter?.letter || '';
+        if (letter) {
+          slot.onclick = () => removeLetter(i);
+        }
+        answerEl.appendChild(slot);
+      }
+    }
+
+    // Select a letter from scrambled
+    function selectLetter(idx) {
+      if (usedIndices.has(idx)) return;
+      if (answerLetters.length >= currentWord.length) return;
+      
+      usedIndices.add(idx);
+      answerLetters.push({ letter: scrambledLetters[idx], sourceIdx: idx });
+      renderGame();
+      
+      // Auto-submit if all letters placed
+      if (answerLetters.length === currentWord.length) {
+        setTimeout(submitAnswer, 300);
+      }
+    }
+
+    // Remove letter from answer
+    function removeLetter(idx) {
+      if (!answerLetters[idx]) return;
+      
+      usedIndices.delete(answerLetters[idx].sourceIdx);
+      answerLetters.splice(idx, 1);
+      renderGame();
+    }
+
+    // Clear answer
+    function clearAnswer() {
+      answerLetters = [];
+      usedIndices.clear();
+      messageEl.innerHTML = '';
+      renderGame();
+    }
+
+    // Submit answer
+    function submitAnswer() {
+      if (answerLetters.length !== currentWord.length) {
+        showMessage('Fill in all letters!', 'error');
+        return;
+      }
+      
+      const answer = answerLetters.map(l => l.letter).join('');
+      
+      if (answer === currentWord) {
+        // Correct!
+        stopTimer();
+        const slots = answerEl.querySelectorAll('.answer-slot');
+        slots.forEach(s => s.classList.add('correct'));
+        
+        const timeBonus = Math.floor(timeLeft / 2);
+        const streakBonus = streak * 5;
+        const points = 10 + timeBonus + streakBonus;
+        
+        score += points;
+        streak++;
+        
+        // Level up every 3 correct answers
+        if (streak > 0 && streak % 3 === 0) {
+          level++;
+        }
+        
+        showMessage(`🎉 Correct! +${points} points`, 'success');
+        
+        setTimeout(newRound, 1500);
+      } else {
+        // Wrong!
+        const slots = answerEl.querySelectorAll('.answer-slot');
+        slots.forEach(s => s.classList.add('wrong'));
+        
+        streak = 0;
+        showMessage('❌ Not quite! Try again.', 'error');
+        
+        setTimeout(() => {
+          slots.forEach(s => s.classList.remove('wrong'));
+        }, 400);
+      }
+    }
+
+    // Skip word
+    function skipWord() {
+      stopTimer();
+      streak = 0;
+      showMessage(`The word was: ${currentWord.toUpperCase()}`, 'error');
+      setTimeout(newRound, 1500);
+    }
+
+    // Show message
+    function showMessage(text, type) {
+      messageEl.innerHTML = `<div class="message ${type}">${text}</div>`;
+    }
+
+    // Timer functions
+    function startTimer() {
+      stopTimer();
+      timerInterval = setInterval(() => {
+        timeLeft--;
+        timerEl.textContent = timeLeft;
+        
+        if (timeLeft <= 5) {
+          timerEl.style.color = 'var(--error)';
+        } else {
+          timerEl.style.color = 'var(--warning)';
+        }
+        
+        if (timeLeft <= 0) {
+          stopTimer();
+          streak = 0;
+          showMessage(`⏰ Time's up! The word was: ${currentWord.toUpperCase()}`, 'error');
+          setTimeout(newRound, 2000);
+        }
+      }, 1000);
+    }
+
+    function stopTimer() {
+      if (timerInterval) {
+        clearInterval(timerInterval);
+        timerInterval = null;
+      }
+    }
+
+    // Keyboard support
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        submitAnswer();
+      } else if (e.key === 'Backspace') {
+        if (answerLetters.length > 0) {
+          removeLetter(answerLetters.length - 1);
+        }
+      } else if (e.key === 'Escape') {
+        clearAnswer();
+      } else if (e.key.length === 1 && e.key.match(/[a-zA-Z]/)) {
+        // Find first unused occurrence of this letter
+        const letter = e.key.toLowerCase();
+        const idx = scrambledLetters.findIndex((l, i) => 
+          l === letter && !usedIndices.has(i)
+        );
+        if (idx !== -1) {
+          selectLetter(idx);
+        }
+      }
+    });
+
+    // Initialize game
+    newRound();
+
+    function getPreferredTheme() {
+      const stored = localStorage.getItem('theme');
+      if (stored) return stored;
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    function applyTheme(theme) {
+      document.documentElement.setAttribute('data-theme', theme);
+      document.querySelector('.theme-toggle').textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+    function toggleTheme() {
+      const current = document.documentElement.getAttribute('data-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('theme', next);
+      applyTheme(next);
+    }
+    applyTheme(getPreferredTheme());
+  </script>
+</body>
+</html>

--- a/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/meta.json
+++ b/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "word-scramble",
+  "name": "Word Scramble",
+  "shortDescription": "A fun word puzzle game where you unscramble letters to reveal words. Features multiple difficulty levels, time pressure, streak bonuses, and keyboard support.",
+  "thumbnail": "thumbnail.svg",
+  "createdAt": "2026-03-06T14:30:00Z",
+  "category": "Games",
+  "visible": true,
+  "allowImprovements": true,
+  "status": "active",
+  "tags": ["game", "puzzle", "words", "educational", "keyboard-controls"],
+  "homepagePath": "index.html",
+  "inputMode": "desktop",
+  "generation": {
+    "agentName": "claude-opus-4.5",
+    "llmModel": "claude-opus-4.5",
+    "startTime": "2026-03-06T14:25:00Z",
+    "endTime": "2026-03-06T14:32:00Z",
+    "totalTokensIn": 8500,
+    "totalTokensOut": 12200,
+    "runId": "run-20260306T143200Z-318d76",
+    "notes": "Generated as a test of the full agent workflow including git operations and transactional logging."
+  }
+}

--- a/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/thumbnail.svg
+++ b/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/thumbnail.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#fafaf9"/>
+      <stop offset="100%" style="stop-color:#e7e5e4"/>
+    </linearGradient>
+    <linearGradient id="tile-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#7c3aed"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-opacity="0.15"/>
+    </filter>
+    <filter id="tile-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="3" stdDeviation="4" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="800" height="450" fill="url(#bg-grad)"/>
+  
+  <!-- Title -->
+  <text x="400" y="45" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="32" font-weight="700" fill="#1c1917">🔤 Word Scramble</text>
+  <text x="400" y="75" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="14" fill="#78716c">Unscramble the letters to reveal the word!</text>
+  
+  <!-- Stats bar -->
+  <g transform="translate(200, 95)">
+    <text x="0" y="30" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="28" font-weight="700" fill="#8b5cf6">85</text>
+    <text x="0" y="48" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="10" fill="#78716c" letter-spacing="0.05em">SCORE</text>
+    
+    <text x="200" y="30" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="28" font-weight="700" fill="#8b5cf6">4</text>
+    <text x="200" y="48" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="10" fill="#78716c" letter-spacing="0.05em">STREAK</text>
+    
+    <text x="400" y="30" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="28" font-weight="700" fill="#f59e0b">18</text>
+    <text x="400" y="48" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="10" fill="#78716c" letter-spacing="0.05em">SECONDS</text>
+  </g>
+  
+  <!-- Game card -->
+  <rect x="150" y="150" width="500" height="250" rx="16" fill="#ffffff" filter="url(#shadow)"/>
+  
+  <!-- Level badge -->
+  <rect x="350" y="165" width="100" height="24" rx="12" fill="#8b5cf6"/>
+  <text x="400" y="182" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="11" font-weight="600" fill="white" letter-spacing="0.05em">LEVEL 2</text>
+  
+  <!-- Hint -->
+  <text x="400" y="215" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="13" fill="#78716c">Hint: <tspan fill="#1c1917" font-weight="500">A mix of red and blue</tspan></text>
+  
+  <!-- Scrambled letters: P R L P U E (purple scrambled) -->
+  <g filter="url(#tile-shadow)">
+    <rect x="195" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)"/>
+    <text x="219" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="white">P</text>
+    
+    <rect x="253" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)"/>
+    <text x="277" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="white">R</text>
+    
+    <rect x="311" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)"/>
+    <text x="335" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="white">L</text>
+    
+    <rect x="369" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)" opacity="0.3"/>
+    <text x="393" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="white" opacity="0.3">P</text>
+    
+    <rect x="427" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)" opacity="0.3"/>
+    <text x="451" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="white" opacity="0.3">U</text>
+    
+    <rect x="485" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)" opacity="0.3"/>
+    <text x="509" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="white" opacity="0.3">E</text>
+  </g>
+  
+  <!-- Answer slots showing: P U R _ _ _ -->
+  <g>
+    <rect x="195" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="219" y="342" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="#1c1917">P</text>
+    
+    <rect x="253" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="277" y="342" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="#1c1917">U</text>
+    
+    <rect x="311" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="335" y="342" text-anchor="middle" font-family="system-ui, sans-serif" 
+          font-size="24" font-weight="700" fill="#1c1917">E</text>
+    
+    <rect x="369" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2" stroke-dasharray="4 2"/>
+    
+    <rect x="427" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2" stroke-dasharray="4 2"/>
+    
+    <rect x="485" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2" stroke-dasharray="4 2"/>
+  </g>
+  
+  <!-- Buttons -->
+  <rect x="220" y="375" width="80" height="36" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2"/>
+  <text x="260" y="398" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="13" font-weight="600" fill="#1c1917">↩️ Clear</text>
+  
+  <rect x="310" y="375" width="90" height="36" rx="8" fill="url(#tile-grad)"/>
+  <text x="355" y="398" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="13" font-weight="600" fill="white">✓ Submit</text>
+  
+  <rect x="410" y="375" width="80" height="36" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2"/>
+  <text x="450" y="398" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="13" font-weight="600" fill="#1c1917">⏭️ Skip</text>
+  
+  <!-- Footer badge -->
+  <rect x="325" y="420" width="150" height="24" rx="12" fill="#e7e5e4"/>
+  <text x="400" y="436" text-anchor="middle" font-family="system-ui, sans-serif" 
+        font-size="11" font-weight="500" fill="#78716c">Generated by AI</text>
+</svg>

--- a/apps/2026/03/06/word-scramble/index.html
+++ b/apps/2026/03/06/word-scramble/index.html
@@ -1,800 +1,939 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="auto">
 <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', '__GA_MEASUREMENT_ID__');
-    </script>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Word Scramble - __MAIN_SITE_NAME__</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🔤%3C/text%3E%3C/svg%3E">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', '__GA_MEASUREMENT_ID__');
+  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Word Scramble Party - __MAIN_SITE_NAME__</title>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__" />
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__" />
+  <meta name="voa-github-url" content="__GITHUB_URL__" />
+  <meta name="voa-social-x-url" content="__SOCIAL_X_URL__" />
+  <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__" />
+  <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__" />
+  <meta name="application-name" content="Word Scramble Party" />
+  <meta name="voa-app-id" content="2026/03/06/word-scramble" />
+  <script src="/apps/shared/app-shell.js" defer></script>
   <style>
     :root {
-      --primary: #8b5cf6;
-      --primary-hover: #7c3aed;
-      --success: #10b981;
-      --error: #ef4444;
+      --bg: #0f172a;
+      --text: #f9fafb;
+      --surface: #1e293b;
+      --card: #15213e;
+      --muted: #9ca3af;
+      --accent: #22d3ee;
+      --accent-2: #38bdf8;
+      --success: #22c55e;
       --warning: #f59e0b;
-      --bg: #fafaf9;
-      --bg-card: #ffffff;
-      --text: #1c1917;
-      --text-secondary: #78716c;
-      --border: #e7e5e4;
-      --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-    ;--surface:#101a31;--accent:#22d3ee;}
-
-    [data-theme="dark"] {
-      --primary: #a78bfa;
-      --primary-hover: #8b5cf6;
-      --bg: #1c1917;
-      --bg-card: #292524;
-      --text: #fafaf9;
-      --text-secondary: #a8a29e;
-      --border: #44403c;
-      --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3);
-      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3);
+      --danger: #ef4444;
+      --border: #334155;
     }
 
-    @media (prefers-color-scheme: dark) {
-      :root:not([data-theme="light"]) {
-        --primary: #a78bfa;
-        --primary-hover: #8b5cf6;
-        --bg: #1c1917;
-        --bg-card: #292524;
-        --text: #fafaf9;
-        --text-secondary: #a8a29e;
-        --border: #44403c;
-        --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3);
-        --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3);
-      }
+    [data-theme='light'] {
+      --bg: #ffffff;
+      --text: #1f2937;
+      --surface: #f3f4f6;
+      --card: #ffffff;
+      --muted: #6b7280;
+      --accent: #0891b2;
+      --accent-2: #0369a1;
+      --success: #16a34a;
+      --warning: #d97706;
+      --danger: #dc2626;
+      --border: #d1d5db;
     }
 
-    .theme-toggle {
-      position: fixed;
-      top: 16px;
-      right: 16px;
-      background: var(--bg-card, #fff);
-      border: 1px solid var(--border, #ccc);
-      border-radius: 50%;
-      width: 44px;
-      height: 44px;
-      font-size: 1.3rem;
-      cursor: pointer;
-      z-index: 100;
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
     }
-
-    * { margin: 0; padding: 0; box-sizing: border-box; }
 
     body {
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background: var(--bg);
-      color: var(--text);
       min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 1rem;
-      line-height: 1.6;
+      font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 10% 20%, rgb(34 211 238 / 18%), transparent 45%),
+        radial-gradient(circle at 85% 0%, rgb(56 189 248 / 18%), transparent 40%),
+        var(--bg);
+      line-height: 1.4;
     }
 
-    .container {
-      width: 100%;
-      max-width: 500px;
+    .app {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 1.25rem 1rem 1.5rem;
+      display: grid;
+      gap: 1rem;
     }
 
-    header {
-      text-align: center;
-      margin-bottom: 2rem;
+    .hero {
+      background: linear-gradient(135deg, rgb(15 23 42 / 92%), rgb(30 41 59 / 92%));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 1rem 1.25rem;
+      box-shadow: 0 18px 28px rgb(2 6 23 / 25%);
+    }
+
+    [data-theme='light'] .hero {
+      background: linear-gradient(135deg, rgb(240 249 255 / 95%), rgb(236 253 245 / 95%));
+      box-shadow: 0 14px 24px rgb(15 23 42 / 10%);
     }
 
     h1 {
-      font-size: 2rem;
-      font-weight: 700;
-      margin-bottom: 0.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.5rem;
+      font-size: clamp(1.5rem, 2.4vw, 2rem);
+      margin-bottom: 0.3rem;
     }
 
-    .subtitle {
-      color: var(--text-secondary);
-      font-size: 1rem;
+    .hero p {
+      color: var(--muted);
+      font-size: 0.98rem;
     }
 
-    .stats {
-      display: flex;
-      justify-content: center;
-      gap: 2rem;
-      margin-bottom: 1.5rem;
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 1rem;
+      box-shadow: 0 10px 20px rgb(2 6 23 / 22%);
     }
 
-    .stat {
-      text-align: center;
+    [data-theme='light'] .card {
+      box-shadow: 0 10px 20px rgb(15 23 42 / 8%);
     }
 
-    .stat-value {
-      font-size: 1.75rem;
-      font-weight: 700;
-      color: var(--primary);
+    .screen {
+      display: none;
     }
 
-    .stat-label {
-      font-size: 0.75rem;
-      color: var(--text-secondary);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+    .screen.active {
+      display: grid;
+      gap: 1rem;
     }
 
-    .game-card {
-      background: var(--bg-card);
-      border-radius: 16px;
-      padding: 2rem;
-      box-shadow: var(--shadow-lg);
-      margin-bottom: 1.5rem;
-    }
-
-    .hint {
-      text-align: center;
-      color: var(--text-secondary);
-      font-size: 0.875rem;
-      margin-bottom: 1rem;
-    }
-
-    .hint strong {
-      color: var(--text);
-    }
-
-    .scrambled-word {
-      display: flex;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-bottom: 1.5rem;
-      flex-wrap: wrap;
-    }
-
-    .letter-tile {
-      width: 48px;
-      height: 56px;
-      background: linear-gradient(135deg, var(--primary) 0%, var(--primary-hover) 100%);
-      color: white;
-      font-size: 1.5rem;
-      font-weight: 700;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 8px;
-      box-shadow: var(--shadow);
-      text-transform: uppercase;
-      cursor: pointer;
-      transition: transform 0.15s, box-shadow 0.15s;
-      user-select: none;
-      touch-action: manipulation;
-    }
-
-    .letter-tile:hover {
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-lg);
-    }
-
-    .letter-tile:active {
-      transform: translateY(0);
-    }
-
-    .letter-tile.used {
-      opacity: 0.3;
-      pointer-events: none;
-    }
-
-    .answer-area {
-      display: flex;
-      justify-content: center;
-      gap: 0.5rem;
-      margin-bottom: 1.5rem;
-      min-height: 56px;
-      flex-wrap: wrap;
-    }
-
-    .answer-slot {
-      width: 48px;
-      height: 56px;
-      background: var(--bg);
-      border: 2px dashed var(--border);
-      border-radius: 8px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.5rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      color: var(--text);
-      transition: border-color 0.2s, background 0.2s;
-    }
-
-    .answer-slot.filled {
-      border-style: solid;
-      border-color: var(--primary);
-      background: var(--bg-card);
-      cursor: pointer;
-    }
-
-    .answer-slot.filled:hover {
-      background: var(--border);
-    }
-
-    .answer-slot.filled {
-      touch-action: manipulation;
-    }
-
-    .answer-slot.correct {
-      border-color: var(--success);
-      background: rgba(16, 185, 129, 0.1);
-    }
-
-    .answer-slot.wrong {
-      border-color: var(--error);
-      background: rgba(239, 68, 68, 0.1);
-      animation: shake 0.4s ease-in-out;
-    }
-
-    @keyframes shake {
-      0%, 100% { transform: translateX(0); }
-      25% { transform: translateX(-8px); }
-      75% { transform: translateX(8px); }
-    }
-
-    .actions {
+    .row {
       display: flex;
       gap: 0.75rem;
-      justify-content: center;
+      flex-wrap: wrap;
+      align-items: center;
     }
 
+    label {
+      font-weight: 700;
+      font-size: 0.92rem;
+    }
+
+    input,
     button {
+      font: inherit;
+      border-radius: 10px;
+      border: 1px solid var(--border);
       min-height: 44px;
-      padding: 0.75rem 1.5rem;
-      border: none;
-      border-radius: 8px;
-      font-size: 1rem;
-      font-weight: 600;
-      cursor: pointer;
-      transition: all 0.2s;
-      display: inline-flex;
-      align-items: center;
+    }
+
+    input {
+      background: var(--surface);
+      color: var(--text);
+      padding: 0.5rem 0.7rem;
+      width: min(100%, 320px);
+    }
+
+    .name-list {
+      display: flex;
+      flex-wrap: wrap;
       gap: 0.5rem;
     }
 
-    .btn-primary {
-      background: linear-gradient(135deg, var(--primary) 0%, var(--primary-hover) 100%);
-      color: white;
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 0.3rem 0.7rem;
+      font-weight: 700;
+      font-size: 0.87rem;
     }
 
-    .btn-primary:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(139, 92, 246, 0.4);
+    .pill button {
+      min-height: 24px;
+      width: 24px;
+      border-radius: 50%;
+      border: none;
+      background: var(--danger);
+      color: #fff;
+      cursor: pointer;
+    }
+
+    .btn {
+      cursor: pointer;
+      color: #fff;
+      font-weight: 700;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      border: none;
+      padding: 0.5rem 1rem;
+    }
+
+    .btn:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
     }
 
     .btn-secondary {
-      background: var(--bg);
+      background: var(--surface);
       color: var(--text);
-      border: 2px solid var(--border);
+      border: 1px solid var(--border);
     }
 
-    .btn-secondary:hover {
-      background: var(--border);
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.65rem;
+    }
+
+    .stat {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 0.6rem;
+      text-align: center;
+    }
+
+    .stat b {
+      display: block;
+      font-size: 1.2rem;
+    }
+
+    .timer-urgent {
+      color: var(--danger);
+    }
+
+    .hint {
+      background: var(--surface);
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      padding: 0.7rem;
+      font-size: 0.95rem;
+    }
+
+    .scramble,
+    .answer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+      justify-content: center;
+    }
+
+    .tile {
+      width: 48px;
+      height: 56px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.35rem;
+      font-weight: 800;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      user-select: none;
+      text-transform: uppercase;
+    }
+
+    .tile.letter {
+      cursor: pointer;
+      color: #fff;
+      border: none;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+    }
+
+    .tile.letter.used {
+      opacity: 0.25;
+      pointer-events: none;
+    }
+
+    .tile.slot {
+      background: var(--surface);
+      border-style: dashed;
+    }
+
+    .tile.slot.filled {
+      border-style: solid;
+      cursor: pointer;
+      background: rgb(8 145 178 / 14%);
     }
 
     .message {
-      text-align: center;
-      padding: 1rem;
-      border-radius: 8px;
-      margin-bottom: 1rem;
-      font-weight: 500;
-      animation: fadeIn 0.3s ease-out;
+      border-radius: 10px;
+      padding: 0.7rem 0.8rem;
+      font-weight: 700;
+      font-size: 0.95rem;
+      border: 1px solid transparent;
     }
 
-    @keyframes fadeIn {
-      from { opacity: 0; transform: translateY(-10px); }
-      to { opacity: 1; transform: translateY(0); }
+    .message.info {
+      background: rgb(34 211 238 / 14%);
+      border-color: rgb(34 211 238 / 45%);
     }
 
     .message.success {
-      background: rgba(16, 185, 129, 0.1);
-      color: var(--success);
+      background: rgb(34 197 94 / 14%);
+      border-color: rgb(34 197 94 / 45%);
     }
 
-    .message.error {
-      background: rgba(239, 68, 68, 0.1);
-      color: var(--error);
+    .message.warn {
+      background: rgb(245 158 11 / 14%);
+      border-color: rgb(245 158 11 / 45%);
     }
 
-    .level-indicator {
-      text-align: center;
-      margin-bottom: 1rem;
+    .winner-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.5rem;
     }
 
-    .level-badge {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      background: var(--primary);
-      color: white;
-      border-radius: 9999px;
-      font-size: 0.75rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+    .score-list {
+      display: grid;
+      gap: 0.55rem;
     }
 
-    .timer {
-      color: var(--warning);
-      font-weight: 600;
+    .score-row {
+      display: grid;
+      grid-template-columns: 80px 1fr auto;
+      gap: 0.6rem;
+      align-items: center;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.55rem 0.7rem;
     }
 
-    footer {
-      text-align: center;
-      margin-top: 2rem;
+    .rank {
+      font-weight: 800;
     }
 
-    .badge {
-      display: inline-block;
-      background: var(--border);
-      color: var(--text-secondary);
-      padding: 0.25rem 0.75rem;
-      border-radius: 9999px;
-      font-size: 0.75rem;
-      font-weight: 500;
+    .score {
+      font-weight: 700;
+      color: var(--accent);
     }
 
+    .muted {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
 
     @media (max-width: 640px) {
-      body {
-        justify-content: flex-start;
-        padding: 0.75rem;
-      }
-
-      .container {
-        max-width: 100%;
-      }
-
-      header {
-        margin-bottom: 1rem;
-      }
-
-      h1 {
-        font-size: 1.5rem;
-      }
-
       .stats {
-        gap: 0.75rem;
-        justify-content: space-between;
+        grid-template-columns: 1fr;
       }
 
-      .stat {
-        flex: 1;
-        min-width: 72px;
+      .app {
+        padding: 0.85rem;
       }
 
-      .stat-value {
-        font-size: 1.35rem;
-      }
-
-      .game-card {
-        padding: 1rem;
-      }
-
-      .letter-tile,
-      .answer-slot {
-        width: 42px;
-        height: 50px;
-        font-size: 1.3rem;
-      }
-
-      .actions {
-        flex-direction: column;
-      }
-
-      .actions button {
-        width: 100%;
-      }
-
-      .theme-toggle {
-        top: 10px;
-        right: 10px;
+      .score-row {
+        grid-template-columns: 64px 1fr auto;
       }
     }
-
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        transition-duration: 0.01ms !important;
-      }
-    }
-  [data-theme='light']{--bg:#eef4ff;--surface:#ffffff;--text:#1f2f52;--accent:#0891b2;--shadow:rgba(31, 47, 82, 0.12);}
-</style>
-  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__">
-  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__">
-    <meta name="voa-social-x-url" content="__SOCIAL_X_URL__">
-  <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__">
-  <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__">
-  <meta name="voa-app-id" content="2026/03/06/word-scramble" />
-  <script src="/apps/shared/app-shell.js" defer></script>
+  </style>
 </head>
 <body>
-  <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>
-  <div class="container">
-    <header>
-      <h1>🔤 Word Scramble</h1>
-      <p class="subtitle">Unscramble the letters to reveal the word! Tap letters on mobile.</p>
-    </header>
+  <main class="app">
+    <section class="hero">
+      <h1>Word Scramble Party</h1>
+      <p>
+        Multiplayer icebreaker mode for live groups. Add players, run timed rounds, award each round
+        to the first correct responder, and finish with tie-aware placements.
+      </p>
+    </section>
 
-    <div class="stats">
-      <div class="stat">
-        <div class="stat-value" id="score">0</div>
-        <div class="stat-label">Score</div>
+    <section id="setupScreen" class="card screen active" aria-label="Setup screen">
+      <h2>1) Setup Round</h2>
+      <p class="muted">Participant settings are saved to local storage for your next session.</p>
+      <div class="row">
+        <label for="participantInput">Participant Name</label>
+        <input id="participantInput" maxlength="24" placeholder="Add player" />
+        <button id="addParticipantBtn" class="btn" type="button">Add Participant</button>
       </div>
-      <div class="stat">
-        <div class="stat-value" id="streak">0</div>
-        <div class="stat-label">Streak</div>
+      <div id="nameList" class="name-list" aria-live="polite"></div>
+      <div class="row">
+        <label for="roundsInput">Number of Rounds</label>
+        <input id="roundsInput" type="number" min="1" max="30" value="6" />
       </div>
-      <div class="stat">
-        <div class="stat-value timer" id="timer">30</div>
-        <div class="stat-label">Seconds</div>
+      <div class="row">
+        <button id="startBtn" class="btn" type="button">Start Game</button>
       </div>
-    </div>
+      <p class="muted">Need at least two participants to start.</p>
+    </section>
 
-    <div class="game-card">
-      <div class="level-indicator">
-        <span class="level-badge" id="level">Level 1</span>
+    <section id="playScreen" class="card screen" aria-label="Round play screen">
+      <h2>2) Live Round</h2>
+      <div class="stats">
+        <div class="stat">
+          <span>Round</span>
+          <b id="roundStat">1 / 6</b>
+        </div>
+        <div class="stat">
+          <span>Timer</span>
+          <b id="timerStat">30</b>
+        </div>
+        <div class="stat">
+          <span>Solved</span>
+          <b id="solvedStat">0</b>
+        </div>
       </div>
 
-      <div class="hint" id="hint">
-        Hint: <strong>Loading...</strong>
+      <div id="roundMessage" class="message info">Moderator: choose winner after each solved round.</div>
+      <div id="hintBox" class="hint">Hint: <strong>Loading...</strong></div>
+      <div id="scramble" class="scramble" aria-label="Scrambled letters"></div>
+      <div id="answer" class="answer" aria-label="Answer slots"></div>
+
+      <div class="row">
+        <button id="clearBtn" class="btn btn-secondary" type="button">Clear Answer</button>
+        <button id="submitBtn" class="btn" type="button">Check Answer</button>
+        <button id="skipBtn" class="btn btn-secondary" type="button">Skip Round</button>
       </div>
 
-      <div id="message"></div>
-
-      <div class="scrambled-word" id="scrambled"></div>
-
-      <div class="answer-area" id="answer"></div>
-
-      <div class="actions">
-        <button class="btn-secondary" onclick="clearAnswer()">
-          ↩️ Clear
-        </button>
-        <button class="btn-primary" onclick="submitAnswer()">
-          ✓ Submit
-        </button>
-        <button class="btn-secondary" onclick="skipWord()">
-          ⏭️ Skip
-        </button>
+      <div class="row">
+        <button id="openPanelBtn" class="btn btn-secondary" type="button">Open Answer Panel Window</button>
       </div>
-    </div>
 
-    <footer>
-      <span class="badge">Generated by AI</span>
-    </footer>
-    <footer style="text-align: center; padding: 20px; margin-top: 20px; opacity: 0.7;">
-      <a href="https://www.valleyofai.com" target="_blank" rel="noopener" style="color: var(--primary, #3b82f6); text-decoration: none;">← Back to Valley of AI</a>
-    </footer>
-  </div>
+      <div>
+        <h3>Award This Round</h3>
+        <p class="muted">Click the participant who answered first. This ends the current round.</p>
+        <div id="winnerGrid" class="winner-grid"></div>
+      </div>
+    </section>
+
+    <section id="scoreScreen" class="card screen" aria-label="Final scoreboard">
+      <h2>3) Final Scoreboard</h2>
+      <p class="muted">Placements use fair shared ranking for ties (1, 1, 3 style).</p>
+      <div id="scoreList" class="score-list"></div>
+      <div class="row">
+        <button id="playAgainBtn" class="btn" type="button">Play Again</button>
+        <button id="editSetupBtn" class="btn btn-secondary" type="button">Edit Participants</button>
+      </div>
+    </section>
+  </main>
 
   <script>
-    // Word list with hints organized by difficulty
-    const WORDS = {
-      easy: [
-        { word: 'apple', hint: 'A red or green fruit' },
-        { word: 'house', hint: 'A place to live' },
-        { word: 'water', hint: 'Essential for life, H2O' },
-        { word: 'happy', hint: 'Feeling of joy' },
-        { word: 'music', hint: 'Sound arranged in patterns' },
-        { word: 'dance', hint: 'Moving to rhythm' },
-        { word: 'light', hint: 'Opposite of dark' },
-        { word: 'dream', hint: 'What happens when you sleep' },
-        { word: 'cloud', hint: 'White fluffy thing in the sky' },
-        { word: 'smile', hint: 'Happy facial expression' },
-      ],
-      medium: [
-        { word: 'purple', hint: 'A mix of red and blue' },
-        { word: 'garden', hint: 'Where flowers grow' },
-        { word: 'bridge', hint: 'Crosses over water' },
-        { word: 'planet', hint: 'Earth is one of these' },
-        { word: 'frozen', hint: 'Solid water state' },
-        { word: 'silent', hint: 'Without any sound' },
-        { word: 'guitar', hint: 'A stringed instrument' },
-        { word: 'market', hint: 'Place to buy food' },
-        { word: 'winter', hint: 'Cold season' },
-        { word: 'castle', hint: 'Where kings live' },
-      ],
-      hard: [
-        { word: 'computer', hint: 'Electronic device for work' },
-        { word: 'elephant', hint: 'Large gray animal with trunk' },
-        { word: 'treasure', hint: 'Valuable hidden items' },
-        { word: 'mountain', hint: 'Very tall landform' },
-        { word: 'sandwich', hint: 'Food between two slices' },
-        { word: 'calendar', hint: 'Shows dates and months' },
-        { word: 'umbrella', hint: 'Protection from rain' },
-        { word: 'keyboard', hint: 'Input device with keys' },
-        { word: 'starfish', hint: 'Sea creature with five arms' },
-        { word: 'dinosaur', hint: 'Extinct prehistoric creature' },
-      ]
-    };
+    const STORAGE_KEY = 'voa-word-scramble-party-config';
 
-    // Game state
-    let currentWord = '';
-    let currentHint = '';
-    let scrambledLetters = [];
-    let answerLetters = [];
-    let usedIndices = new Set();
-    let score = 0;
-    let streak = 0;
-    let level = 1;
-    let timeLeft = 30;
-    let timerInterval = null;
-    let usedWords = new Set();
+    const WORDS = [
+      { word: 'apple', hint: 'A common fruit often in lunch boxes' },
+      { word: 'dance', hint: 'Move to rhythm and music' },
+      { word: 'guitar', hint: 'String instrument with six strings' },
+      { word: 'planet', hint: 'Earth is one of these' },
+      { word: 'bridge', hint: 'Structure used to cross water' },
+      { word: 'castle', hint: 'Historic fortress for royalty' },
+      { word: 'memory', hint: 'What this game challenges' },
+      { word: 'camera', hint: 'Device used to take photos' },
+      { word: 'rocket', hint: 'Vehicle that launches to space' },
+      { word: 'forest', hint: 'Large area full of trees' },
+      { word: 'puzzle', hint: 'A problem to solve for fun' },
+      { word: 'travel', hint: 'To go from place to place' },
+      { word: 'friend', hint: 'Someone you trust and enjoy' },
+      { word: 'silver', hint: 'Metal and also a medal color' },
+      { word: 'orange', hint: 'Color and citrus fruit' },
+      { word: 'school', hint: 'Place for classes and learning' },
+      { word: 'runner', hint: 'Someone moving quickly by foot' },
+      { word: 'market', hint: 'Place where goods are sold' },
+      { word: 'winter', hint: 'The coldest season' },
+      { word: 'bright', hint: 'Very full of light' }
+    ];
 
-    // DOM Elements
-    const scoreEl = document.getElementById('score');
-    const streakEl = document.getElementById('streak');
-    const timerEl = document.getElementById('timer');
-    const levelEl = document.getElementById('level');
-    const hintEl = document.getElementById('hint');
-    const messageEl = document.getElementById('message');
-    const scrambledEl = document.getElementById('scrambled');
+    const setupScreen = document.getElementById('setupScreen');
+    const playScreen = document.getElementById('playScreen');
+    const scoreScreen = document.getElementById('scoreScreen');
+
+    const participantInput = document.getElementById('participantInput');
+    const roundsInput = document.getElementById('roundsInput');
+    const nameList = document.getElementById('nameList');
+    const startBtn = document.getElementById('startBtn');
+
+    const roundStat = document.getElementById('roundStat');
+    const timerStat = document.getElementById('timerStat');
+    const solvedStat = document.getElementById('solvedStat');
+    const roundMessage = document.getElementById('roundMessage');
+    const hintBox = document.getElementById('hintBox');
+    const scrambleEl = document.getElementById('scramble');
     const answerEl = document.getElementById('answer');
+    const winnerGrid = document.getElementById('winnerGrid');
 
-    // Get difficulty based on level
-    function getDifficulty() {
-      if (level <= 3) return 'easy';
-      if (level <= 6) return 'medium';
-      return 'hard';
+    const scoreList = document.getElementById('scoreList');
+
+    let participants = [];
+    let roundsTotal = 6;
+    let currentRound = 1;
+    let solvedRounds = 0;
+    let timerLeft = 30;
+    let timerHandle = null;
+    let activeWord = null;
+    let scramble = [];
+    let answer = [];
+    let usedIndices = new Set();
+    let usedWords = new Set();
+    let roundClosed = false;
+    let answerPanelWindow = null;
+
+    function showScreen(name) {
+      setupScreen.classList.toggle('active', name === 'setup');
+      playScreen.classList.toggle('active', name === 'play');
+      scoreScreen.classList.toggle('active', name === 'score');
     }
 
-    // Shuffle array (Fisher-Yates)
-    function shuffle(array) {
-      const arr = [...array];
-      for (let i = arr.length - 1; i > 0; i--) {
+    function persistSetup() {
+      const payload = {
+        names: participants.map((p) => p.name),
+        roundsTotal
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    }
+
+    function loadSetup() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const data = JSON.parse(raw);
+        const names = Array.isArray(data.names) ? data.names : [];
+        participants = names
+          .filter((name) => typeof name === 'string' && name.trim().length > 0)
+          .slice(0, 12)
+          .map((name, index) => ({ id: index + 1, name: name.trim(), score: 0 }));
+        const parsedRounds = Number.parseInt(data.roundsTotal, 10);
+        roundsTotal = Number.isFinite(parsedRounds) ? Math.min(30, Math.max(1, parsedRounds)) : 6;
+        roundsInput.value = String(roundsTotal);
+      } catch (_error) {
+        participants = [];
+      }
+    }
+
+    function renderParticipants() {
+      nameList.innerHTML = '';
+      participants.forEach((participant, index) => {
+        const pill = document.createElement('div');
+        pill.className = 'pill';
+        pill.textContent = participant.name;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.setAttribute('aria-label', `Remove ${participant.name}`);
+        removeBtn.textContent = 'x';
+        removeBtn.addEventListener('click', () => {
+          participants.splice(index, 1);
+          participants = participants.map((item, idx) => ({ ...item, id: idx + 1 }));
+          renderParticipants();
+          persistSetup();
+          updateStartState();
+        });
+
+        pill.appendChild(removeBtn);
+        nameList.appendChild(pill);
+      });
+    }
+
+    function updateStartState() {
+      startBtn.disabled = participants.length < 2;
+    }
+
+    function addParticipant() {
+      const name = participantInput.value.trim();
+      if (!name) return;
+      if (participants.length >= 12) {
+        showRoundMessage('Participant limit reached (12).', 'warn');
+        return;
+      }
+      if (participants.some((item) => item.name.toLowerCase() === name.toLowerCase())) {
+        showRoundMessage('Duplicate participant names are not allowed.', 'warn');
+        return;
+      }
+      participants.push({ id: participants.length + 1, name, score: 0 });
+      participantInput.value = '';
+      renderParticipants();
+      updateStartState();
+      persistSetup();
+    }
+
+    function shuffleLetters(letters) {
+      const copy = [...letters];
+      for (let i = copy.length - 1; i > 0; i -= 1) {
         const j = Math.floor(Math.random() * (i + 1));
-        [arr[i], arr[j]] = [arr[j], arr[i]];
+        [copy[i], copy[j]] = [copy[j], copy[i]];
       }
-      return arr;
+      return copy;
     }
 
-    // Get a new word
-    function getNewWord() {
-      const difficulty = getDifficulty();
-      const words = WORDS[difficulty].filter(w => !usedWords.has(w.word));
-      
-      // Reset used words if we've gone through all
-      if (words.length === 0) {
+    function getWordForRound() {
+      const available = WORDS.filter((entry) => !usedWords.has(entry.word));
+      if (available.length === 0) {
         usedWords.clear();
-        return getNewWord();
+        return getWordForRound();
       }
-      
-      const selected = words[Math.floor(Math.random() * words.length)];
-      usedWords.add(selected.word);
-      return selected;
+      const picked = available[Math.floor(Math.random() * available.length)];
+      usedWords.add(picked.word);
+      return picked;
     }
 
-    // Start new round
-    function newRound() {
-      const wordData = getNewWord();
-      currentWord = wordData.word;
-      currentHint = wordData.hint;
-      
-      // Make sure scrambled version is different from original
+    function buildRound() {
+      activeWord = getWordForRound();
       do {
-        scrambledLetters = shuffle(currentWord.split(''));
-      } while (scrambledLetters.join('') === currentWord);
-      
-      answerLetters = [];
-      usedIndices.clear();
-      
-      // Reset timer
-      timeLeft = Math.max(15, 30 - (level - 1) * 2); // Decreases with level, min 15
-      
-      renderGame();
+        scramble = shuffleLetters(activeWord.word.split(''));
+      } while (scramble.join('') === activeWord.word);
+
+      answer = [];
+      usedIndices = new Set();
+      timerLeft = 30;
+      roundClosed = false;
+
+      roundStat.textContent = `${currentRound} / ${roundsTotal}`;
+      solvedStat.textContent = String(solvedRounds);
+      hintBox.innerHTML = `Hint: <strong>${activeWord.hint}</strong>`;
+      showRoundMessage('Unscramble the word. Moderator awards each round winner.', 'info');
+      renderRoundTiles();
+      renderWinnerButtons();
       startTimer();
+      updateAnswerPanel();
     }
 
-    // Render the game
-    function renderGame() {
-      // Update stats
-      scoreEl.textContent = score;
-      streakEl.textContent = streak;
-      timerEl.textContent = timeLeft;
-      levelEl.textContent = `Level ${level}`;
-      hintEl.innerHTML = `Hint: <strong>${currentHint}</strong>`;
-      
-      // Render scrambled letters
-      scrambledEl.innerHTML = scrambledLetters.map((letter, idx) => `
-        <div class="letter-tile ${usedIndices.has(idx) ? 'used' : ''}" 
-             onclick="selectLetter(${idx})"
-             role="button" 
-             tabindex="0"
-             aria-label="Letter ${letter}">
-          ${letter}
-        </div>
-      `).join('');
-      
-      // Render answer slots
+    function renderRoundTiles() {
+      timerStat.textContent = String(timerLeft);
+      timerStat.classList.toggle('timer-urgent', timerLeft <= 7);
+
+      scrambleEl.innerHTML = scramble
+        .map(
+          (letter, index) =>
+            `<button type="button" class="tile letter ${usedIndices.has(index) ? 'used' : ''}" data-index="${index}" aria-label="Letter ${letter}">${letter}</button>`
+        )
+        .join('');
+
       answerEl.innerHTML = '';
-      for (let i = 0; i < currentWord.length; i++) {
-        const letter = answerLetters[i];
-        const slot = document.createElement('div');
-        slot.className = 'answer-slot' + (letter ? ' filled' : '');
-        slot.textContent = letter?.letter || '';
-        if (letter) {
-          slot.onclick = () => removeLetter(i);
+      for (let i = 0; i < activeWord.word.length; i += 1) {
+        const slotData = answer[i];
+        const slot = document.createElement('button');
+        slot.type = 'button';
+        slot.className = `tile slot${slotData ? ' filled' : ''}`;
+        slot.textContent = slotData ? slotData.letter : '';
+        slot.setAttribute('aria-label', slotData ? `Remove ${slotData.letter}` : 'Empty answer slot');
+        if (slotData) {
+          slot.addEventListener('click', () => removeLetter(i));
+        } else {
+          slot.disabled = true;
         }
         answerEl.appendChild(slot);
       }
+
+      scrambleEl.querySelectorAll('button').forEach((button) => {
+        button.addEventListener('click', () => {
+          const idx = Number.parseInt(button.dataset.index, 10);
+          selectLetter(idx);
+        });
+      });
     }
 
-    // Select a letter from scrambled
-    function selectLetter(idx) {
-      if (usedIndices.has(idx)) return;
-      if (answerLetters.length >= currentWord.length) return;
-      
-      usedIndices.add(idx);
-      answerLetters.push({ letter: scrambledLetters[idx], sourceIdx: idx });
-      renderGame();
-      
-      // Auto-submit if all letters placed
-      if (answerLetters.length === currentWord.length) {
-        setTimeout(submitAnswer, 300);
-      }
+    function renderWinnerButtons() {
+      winnerGrid.innerHTML = '';
+      participants.forEach((participant) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn';
+        button.textContent = `${participant.name} +1`;
+        button.addEventListener('click', () => awardRound(participant.id));
+        winnerGrid.appendChild(button);
+      });
+      const noPoint = document.createElement('button');
+      noPoint.type = 'button';
+      noPoint.className = 'btn btn-secondary';
+      noPoint.textContent = 'No Point This Round';
+      noPoint.addEventListener('click', () => finishRound(null));
+      winnerGrid.appendChild(noPoint);
     }
 
-    // Remove letter from answer
-    function removeLetter(idx) {
-      if (!answerLetters[idx]) return;
-      
-      usedIndices.delete(answerLetters[idx].sourceIdx);
-      answerLetters.splice(idx, 1);
-      renderGame();
+    function selectLetter(index) {
+      if (roundClosed || usedIndices.has(index) || answer.length >= activeWord.word.length) return;
+      usedIndices.add(index);
+      answer.push({ letter: scramble[index], sourceIndex: index });
+      renderRoundTiles();
+      updateAnswerPanel();
     }
 
-    // Clear answer
+    function removeLetter(index) {
+      if (roundClosed || !answer[index]) return;
+      usedIndices.delete(answer[index].sourceIndex);
+      answer.splice(index, 1);
+      renderRoundTiles();
+      updateAnswerPanel();
+    }
+
     function clearAnswer() {
-      answerLetters = [];
-      usedIndices.clear();
-      messageEl.innerHTML = '';
-      renderGame();
+      if (roundClosed) return;
+      answer = [];
+      usedIndices = new Set();
+      renderRoundTiles();
+      updateAnswerPanel();
     }
 
-    // Submit answer
+    function showRoundMessage(text, tone) {
+      roundMessage.className = `message ${tone}`;
+      roundMessage.textContent = text;
+    }
+
     function submitAnswer() {
-      if (answerLetters.length !== currentWord.length) {
-        showMessage('Fill in all letters!', 'error');
+      if (roundClosed) return;
+      if (answer.length !== activeWord.word.length) {
+        showRoundMessage('Fill every slot before checking the answer.', 'warn');
         return;
       }
-      
-      const answer = answerLetters.map(l => l.letter).join('');
-      
-      if (answer === currentWord) {
-        // Correct!
-        stopTimer();
-        const slots = answerEl.querySelectorAll('.answer-slot');
-        slots.forEach(s => s.classList.add('correct'));
-        
-        const timeBonus = Math.floor(timeLeft / 2);
-        const streakBonus = streak * 5;
-        const points = 10 + timeBonus + streakBonus;
-        
-        score += points;
-        streak++;
-        
-        // Level up every 3 correct answers
-        if (streak > 0 && streak % 3 === 0) {
-          level++;
-        }
-        
-        showMessage(`🎉 Correct! +${points} points`, 'success');
-        
-        setTimeout(newRound, 1500);
+      const guess = answer.map((item) => item.letter).join('');
+      if (guess === activeWord.word) {
+        showRoundMessage('Correct answer. Moderator: choose who answered first.', 'success');
       } else {
-        // Wrong!
-        const slots = answerEl.querySelectorAll('.answer-slot');
-        slots.forEach(s => s.classList.add('wrong'));
-        
-        streak = 0;
-        showMessage('❌ Not quite! Try again.', 'error');
-        
-        setTimeout(() => {
-          slots.forEach(s => s.classList.remove('wrong'));
-        }, 400);
+        showRoundMessage('Not correct yet. Keep trying.', 'warn');
       }
+      updateAnswerPanel();
     }
 
-    // Skip word
-    function skipWord() {
-      stopTimer();
-      streak = 0;
-      showMessage(`The word was: ${currentWord.toUpperCase()}`, 'error');
-      setTimeout(newRound, 1500);
-    }
-
-    // Show message
-    function showMessage(text, type) {
-      messageEl.innerHTML = `<div class="message ${type}">${text}</div>`;
-    }
-
-    // Timer functions
     function startTimer() {
       stopTimer();
-      timerInterval = setInterval(() => {
-        timeLeft--;
-        timerEl.textContent = timeLeft;
-        
-        if (timeLeft <= 5) {
-          timerEl.style.color = 'var(--error)';
-        } else {
-          timerEl.style.color = 'var(--warning)';
-        }
-        
-        if (timeLeft <= 0) {
+      timerHandle = setInterval(() => {
+        timerLeft -= 1;
+        renderRoundTiles();
+        if (timerLeft <= 0) {
           stopTimer();
-          streak = 0;
-          showMessage(`⏰ Time's up! The word was: ${currentWord.toUpperCase()}`, 'error');
-          setTimeout(newRound, 2000);
+          showRoundMessage(`Time up. Answer was: ${activeWord.word.toUpperCase()}`, 'warn');
+          finishRound(null);
         }
       }, 1000);
     }
 
     function stopTimer() {
-      if (timerInterval) {
-        clearInterval(timerInterval);
-        timerInterval = null;
-      }
+      if (!timerHandle) return;
+      clearInterval(timerHandle);
+      timerHandle = null;
     }
 
-    // Keyboard support
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        submitAnswer();
-      } else if (e.key === 'Backspace') {
-        if (answerLetters.length > 0) {
-          removeLetter(answerLetters.length - 1);
+    function awardRound(participantId) {
+      const winner = participants.find((participant) => participant.id === participantId);
+      if (!winner) return;
+      winner.score += 1;
+      solvedRounds += 1;
+      showRoundMessage(`${winner.name} gets this round!`, 'success');
+      finishRound(participantId);
+    }
+
+    function finishRound(_winnerId) {
+      if (roundClosed) return;
+      roundClosed = true;
+      stopTimer();
+      winnerGrid.querySelectorAll('button').forEach((button) => {
+        button.disabled = true;
+      });
+
+      setTimeout(() => {
+        if (currentRound >= roundsTotal) {
+          showFinalScoreboard();
+          return;
         }
-      } else if (e.key === 'Escape') {
-        clearAnswer();
-      } else if (e.key.length === 1 && e.key.match(/[a-zA-Z]/)) {
-        // Find first unused occurrence of this letter
-        const letter = e.key.toLowerCase();
-        const idx = scrambledLetters.findIndex((l, i) => 
-          l === letter && !usedIndices.has(i)
-        );
-        if (idx !== -1) {
-          selectLetter(idx);
+        currentRound += 1;
+        buildRound();
+      }, 900);
+    }
+
+    function computePlacements(players) {
+      const sorted = [...players].sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.name.localeCompare(b.name);
+      });
+
+      let previousScore = null;
+      let currentRank = 0;
+      return sorted.map((player, index) => {
+        if (previousScore === null || player.score < previousScore) {
+          currentRank = index + 1;
         }
+        previousScore = player.score;
+        return {
+          ...player,
+          rank: currentRank
+        };
+      });
+    }
+
+    function rankLabel(rank) {
+      if (rank === 1) return 'Gold';
+      if (rank === 2) return 'Silver';
+      if (rank === 3) return 'Bronze';
+      return `${rank}th`;
+    }
+
+    function showFinalScoreboard() {
+      stopTimer();
+      showScreen('score');
+      const placements = computePlacements(participants);
+      scoreList.innerHTML = '';
+
+      placements.forEach((entry) => {
+        const row = document.createElement('div');
+        row.className = 'score-row';
+
+        const rank = document.createElement('div');
+        rank.className = 'rank';
+        rank.textContent = `${entry.rank}. ${rankLabel(entry.rank)}`;
+
+        const name = document.createElement('div');
+        name.textContent = entry.name;
+
+        const score = document.createElement('div');
+        score.className = 'score';
+        score.textContent = `${entry.score} pts`;
+
+        row.appendChild(rank);
+        row.appendChild(name);
+        row.appendChild(score);
+        scoreList.appendChild(row);
+      });
+    }
+
+    function restartGame() {
+      participants = participants.map((participant) => ({ ...participant, score: 0 }));
+      currentRound = 1;
+      solvedRounds = 0;
+      usedWords = new Set();
+      showScreen('play');
+      buildRound();
+    }
+
+    function openAnswerPanel() {
+      answerPanelWindow = window.open('', 'voa-answer-panel', 'width=520,height=620');
+      if (!answerPanelWindow) {
+        showRoundMessage('Popup blocked. Allow popups for moderator panel.', 'warn');
+        return;
+      }
+      updateAnswerPanel();
+    }
+
+    function updateAnswerPanel() {
+      if (!answerPanelWindow || answerPanelWindow.closed || !activeWord) return;
+      const partialAnswer = answer.map((entry) => entry.letter).join('').toUpperCase();
+      answerPanelWindow.document.open();
+      answerPanelWindow.document.write(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Word Scramble Moderator Panel</title>
+  <style>
+    body { font-family: 'Trebuchet MS', 'Segoe UI', sans-serif; margin: 0; padding: 16px; background: #0f172a; color: #f8fafc; }
+    .card { background: #1e293b; border: 1px solid #334155; border-radius: 12px; padding: 12px; margin-bottom: 12px; }
+    h1 { margin: 0 0 10px; font-size: 1.2rem; }
+    h2 { margin: 0 0 6px; font-size: 0.95rem; color: #67e8f9; }
+    b { color: #22d3ee; }
+  </style>
+</head>
+<body>
+  <h1>Moderator Answer Panel</h1>
+  <div class="card"><h2>Round</h2><div><b>${currentRound}</b> / ${roundsTotal}</div></div>
+  <div class="card"><h2>Hint</h2><div>${activeWord.hint}</div></div>
+  <div class="card"><h2>Answer</h2><div><b>${activeWord.word.toUpperCase()}</b></div></div>
+  <div class="card"><h2>Current Guess</h2><div>${partialAnswer || '-'}</div></div>
+  <div class="card"><h2>Timer</h2><div>${timerLeft}s</div></div>
+</body>
+</html>`);
+      answerPanelWindow.document.close();
+    }
+
+    function startGame() {
+      roundsTotal = Number.parseInt(roundsInput.value, 10);
+      if (!Number.isFinite(roundsTotal) || roundsTotal < 1 || roundsTotal > 30) {
+        showRoundMessage('Rounds must be between 1 and 30.', 'warn');
+        return;
+      }
+      participants = participants.map((participant, index) => ({
+        id: index + 1,
+        name: participant.name,
+        score: 0
+      }));
+
+      persistSetup();
+      usedWords = new Set();
+      currentRound = 1;
+      solvedRounds = 0;
+      showScreen('play');
+      buildRound();
+    }
+
+    function setupKeyboardSupport() {
+      document.addEventListener('keydown', (event) => {
+        const tag = document.activeElement ? document.activeElement.tagName : '';
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        if (!playScreen.classList.contains('active')) return;
+        if (event.key === 'Enter') {
+          submitAnswer();
+          return;
+        }
+        if (event.key === 'Backspace') {
+          if (answer.length > 0) {
+            removeLetter(answer.length - 1);
+          }
+          return;
+        }
+        if (event.key === 'Escape') {
+          clearAnswer();
+          return;
+        }
+        if (/^[a-zA-Z]$/.test(event.key)) {
+          const letter = event.key.toLowerCase();
+          const idx = scramble.findIndex((item, index) => item === letter && !usedIndices.has(index));
+          if (idx >= 0) {
+            selectLetter(idx);
+          }
+        }
+      });
+    }
+
+    document.getElementById('addParticipantBtn').addEventListener('click', addParticipant);
+    participantInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        addParticipant();
       }
     });
 
-    // Initialize game
-    newRound();
+    roundsInput.addEventListener('change', () => {
+      const value = Number.parseInt(roundsInput.value, 10);
+      if (Number.isFinite(value)) {
+        roundsTotal = Math.min(30, Math.max(1, value));
+        roundsInput.value = String(roundsTotal);
+        persistSetup();
+      }
+    });
 
-    function getPreferredTheme() {
-      const stored = localStorage.getItem('theme');
-      if (stored) return stored;
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    function applyTheme(theme) {
-      document.documentElement.setAttribute('data-theme', theme);
-      document.querySelector('.theme-toggle').textContent = theme === 'dark' ? '☀️' : '🌙';
-    }
-    function toggleTheme() {
-      const current = document.documentElement.getAttribute('data-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
-      localStorage.setItem('theme', next);
-      applyTheme(next);
-    }
-    applyTheme(getPreferredTheme());
+    startBtn.addEventListener('click', startGame);
+    document.getElementById('clearBtn').addEventListener('click', clearAnswer);
+    document.getElementById('submitBtn').addEventListener('click', submitAnswer);
+    document.getElementById('skipBtn').addEventListener('click', () => {
+      showRoundMessage(`Round skipped. Answer was ${activeWord.word.toUpperCase()}.`, 'warn');
+      finishRound(null);
+    });
+    document.getElementById('openPanelBtn').addEventListener('click', openAnswerPanel);
+    document.getElementById('playAgainBtn').addEventListener('click', restartGame);
+    document.getElementById('editSetupBtn').addEventListener('click', () => {
+      stopTimer();
+      showScreen('setup');
+    });
+
+    loadSetup();
+    renderParticipants();
+    updateStartState();
+    setupKeyboardSupport();
   </script>
 </body>
 </html>

--- a/apps/2026/03/06/word-scramble/meta.json
+++ b/apps/2026/03/06/word-scramble/meta.json
@@ -1,16 +1,27 @@
 {
   "id": "word-scramble",
-  "name": "Word Scramble",
-  "shortDescription": "A fun word puzzle game where you unscramble letters to reveal words. Features multiple difficulty levels, time pressure, streak bonuses, and keyboard support.",
+  "name": "Word Scramble Party",
+  "shortDescription": "A multiplayer icebreaker where moderators run timed word-scramble rounds, award points to the first responder, and finish with fair tie-aware rankings.",
   "thumbnail": "thumbnail.svg",
   "createdAt": "2026-03-06T14:30:00Z",
-  "category": "Games",
+  "category": "Icebreakers",
   "visible": true,
   "allowImprovements": true,
   "status": "active",
-  "tags": ["game", "puzzle", "words", "educational", "keyboard-controls"],
+  "tags": ["icebreaker", "multiplayer", "word-game", "moderator", "party", "round-based"],
   "homepagePath": "index.html",
-  "inputMode": "desktop",
+  "inputMode": "responsive",
+  "improvements": [
+    {
+      "issueNumber": 351,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/351",
+      "description": "Converted Word Scramble into a multiplayer icebreaker with participant setup, timed rounds, moderator winner assignment, answer panel window, and fair tie-ranked scoring.",
+      "requestor": "jeffholst",
+      "implementedAt": "2026-04-18T16:25:43Z",
+      "agentName": "GitHub Copilot",
+      "llmModel": "GPT-5.3-Codex"
+    }
+  ],
   "generation": {
     "agentName": "claude-opus-4.5",
     "llmModel": "claude-opus-4.5",

--- a/apps/2026/03/06/word-scramble/thumbnail.svg
+++ b/apps/2026/03/06/word-scramble/thumbnail.svg
@@ -1,123 +1,95 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
   <defs>
-    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#fafaf9"/>
-      <stop offset="100%" style="stop-color:#e7e5e4"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
     </linearGradient>
-    <linearGradient id="tile-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#7c3aed"/>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22d3ee" />
+      <stop offset="100%" stop-color="#0284c7" />
     </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-opacity="0.15"/>
-    </filter>
-    <filter id="tile-shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="3" stdDeviation="4" flood-opacity="0.25"/>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="5" result="blur" />
+      <feOffset in="blur" dx="0" dy="4" result="offsetBlur" />
+      <feFlood flood-color="#020617" flood-opacity="0.45" result="shadowColor" />
+      <feComposite in="shadowColor" in2="offsetBlur" operator="in" result="shadow" />
+      <feMerge>
+        <feMergeNode in="shadow" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
     </filter>
   </defs>
-  
-  <!-- Background -->
-  <rect width="800" height="450" fill="url(#bg-grad)"/>
-  
-  <!-- Title -->
-  <text x="400" y="45" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="32" font-weight="700" fill="#1c1917">🔤 Word Scramble</text>
-  <text x="400" y="75" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="14" fill="#78716c">Unscramble the letters to reveal the word!</text>
-  
-  <!-- Stats bar -->
-  <g transform="translate(200, 95)">
-    <text x="0" y="30" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="28" font-weight="700" fill="#8b5cf6">85</text>
-    <text x="0" y="48" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="10" fill="#78716c" letter-spacing="0.05em">SCORE</text>
-    
-    <text x="200" y="30" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="28" font-weight="700" fill="#8b5cf6">4</text>
-    <text x="200" y="48" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="10" fill="#78716c" letter-spacing="0.05em">STREAK</text>
-    
-    <text x="400" y="30" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="28" font-weight="700" fill="#f59e0b">18</text>
-    <text x="400" y="48" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="10" fill="#78716c" letter-spacing="0.05em">SECONDS</text>
+
+  <rect x="0" y="0" width="800" height="450" fill="url(#bg)" />
+
+  <rect x="26" y="18" width="748" height="62" rx="14" fill="#15213e" stroke="#334155" />
+  <text x="50" y="56" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="30" font-weight="700">
+    Word Scramble Party
+  </text>
+  <text x="748" y="56" text-anchor="end" fill="#67e8f9" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="20" font-weight="700">
+    Round 3/8
+  </text>
+
+  <rect x="40" y="100" width="510" height="310" rx="18" fill="#15213e" stroke="#334155" filter="url(#softShadow)" />
+
+  <rect x="62" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
+  <text x="76" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Timer</text>
+  <text x="76" y="172" fill="#f43f5e" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">11s</text>
+
+  <rect x="224" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
+  <text x="238" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Solved</text>
+  <text x="238" y="172" fill="#22d3ee" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">2</text>
+
+  <rect x="386" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
+  <text x="400" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Hint</text>
+  <text x="400" y="172" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16" font-weight="700">Color + Fruit</text>
+
+  <g filter="url(#softShadow)">
+    <rect x="86" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="150" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="214" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="278" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="342" y="214" width="56" height="64" rx="10" fill="url(#tile)" opacity="0.38" />
+    <rect x="406" y="214" width="56" height="64" rx="10" fill="url(#tile)" opacity="0.38" />
   </g>
-  
-  <!-- Game card -->
-  <rect x="150" y="150" width="500" height="250" rx="16" fill="#ffffff" filter="url(#shadow)"/>
-  
-  <!-- Level badge -->
-  <rect x="350" y="165" width="100" height="24" rx="12" fill="#8b5cf6"/>
-  <text x="400" y="182" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="11" font-weight="600" fill="white" letter-spacing="0.05em">LEVEL 2</text>
-  
-  <!-- Hint -->
-  <text x="400" y="215" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="13" fill="#78716c">Hint: <tspan fill="#1c1917" font-weight="500">A mix of red and blue</tspan></text>
-  
-  <!-- Scrambled letters: P R L P U E (purple scrambled) -->
-  <g filter="url(#tile-shadow)">
-    <rect x="195" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)"/>
-    <text x="219" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="white">P</text>
-    
-    <rect x="253" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)"/>
-    <text x="277" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="white">R</text>
-    
-    <rect x="311" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)"/>
-    <text x="335" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="white">L</text>
-    
-    <rect x="369" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)" opacity="0.3"/>
-    <text x="393" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="white" opacity="0.3">P</text>
-    
-    <rect x="427" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)" opacity="0.3"/>
-    <text x="451" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="white" opacity="0.3">U</text>
-    
-    <rect x="485" y="235" width="48" height="56" rx="8" fill="url(#tile-grad)" opacity="0.3"/>
-    <text x="509" y="272" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="white" opacity="0.3">E</text>
-  </g>
-  
-  <!-- Answer slots showing: P U R _ _ _ -->
-  <g>
-    <rect x="195" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#8b5cf6" stroke-width="2"/>
-    <text x="219" y="342" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="#1c1917">P</text>
-    
-    <rect x="253" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#8b5cf6" stroke-width="2"/>
-    <text x="277" y="342" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="#1c1917">U</text>
-    
-    <rect x="311" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#8b5cf6" stroke-width="2"/>
-    <text x="335" y="342" text-anchor="middle" font-family="system-ui, sans-serif" 
-          font-size="24" font-weight="700" fill="#1c1917">E</text>
-    
-    <rect x="369" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2" stroke-dasharray="4 2"/>
-    
-    <rect x="427" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2" stroke-dasharray="4 2"/>
-    
-    <rect x="485" y="305" width="48" height="56" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2" stroke-dasharray="4 2"/>
-  </g>
-  
-  <!-- Buttons -->
-  <rect x="220" y="375" width="80" height="36" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2"/>
-  <text x="260" y="398" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="13" font-weight="600" fill="#1c1917">↩️ Clear</text>
-  
-  <rect x="310" y="375" width="90" height="36" rx="8" fill="url(#tile-grad)"/>
-  <text x="355" y="398" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="13" font-weight="600" fill="white">✓ Submit</text>
-  
-  <rect x="410" y="375" width="80" height="36" rx="8" fill="#fafaf9" stroke="#e7e5e4" stroke-width="2"/>
-  <text x="450" y="398" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="13" font-weight="600" fill="#1c1917">⏭️ Skip</text>
-  
-  <!-- Footer badge -->
-  <rect x="325" y="420" width="150" height="24" rx="12" fill="#e7e5e4"/>
-  <text x="400" y="436" text-anchor="middle" font-family="system-ui, sans-serif" 
-        font-size="11" font-weight="500" fill="#78716c">Generated by AI</text>
+  <text x="114" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">O</text>
+  <text x="178" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">R</text>
+  <text x="242" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">A</text>
+  <text x="306" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">N</text>
+  <text x="370" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">G</text>
+  <text x="434" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">E</text>
+
+  <rect x="86" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="150" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="214" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="278" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="342" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="406" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="114" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">O</text>
+  <text x="178" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">R</text>
+  <text x="242" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">A</text>
+
+  <rect x="572" y="100" width="188" height="310" rx="18" fill="#15213e" stroke="#334155" filter="url(#softShadow)" />
+  <text x="666" y="128" text-anchor="middle" fill="#67e8f9" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="20" font-weight="700">
+    Scoreboard
+  </text>
+
+  <rect x="588" y="146" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="604" y="170" fill="#facc15" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="18" font-weight="700">1. Gold</text>
+  <text x="730" y="170" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Alex 2</text>
+  <text x="730" y="188" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Casey 2</text>
+
+  <rect x="588" y="208" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="604" y="238" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="18" font-weight="700">3. Bronze</text>
+  <text x="730" y="238" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Riley 1</text>
+
+  <rect x="588" y="270" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="666" y="302" text-anchor="middle" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="15">
+    Moderator Panel
+  </text>
+
+  <rect x="588" y="336" width="156" height="52" rx="10" fill="#0f172a" stroke="#22d3ee" />
+  <text x="666" y="366" text-anchor="middle" fill="#22d3ee" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16" font-weight="700">
+    Answer: ORANGE
+  </text>
 </svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -2826,17 +2826,17 @@
   },
   {
     "id": "2026/03/06/word-scramble",
-    "name": "Word Scramble",
-    "shortDescription": "A fun word puzzle game where you unscramble letters to reveal words. Features multiple difficulty levels, time pressure, streak bonuses, and keyboard support.",
+    "name": "Word Scramble Party",
+    "shortDescription": "A multiplayer icebreaker where moderators run timed word-scramble rounds, award points to the first responder, and finish with fair tie-aware rankings.",
     "thumbnailUrl": "/apps/2026/03/06/word-scramble/thumbnail.svg",
     "createdAt": "2026-03-06T14:30:00Z",
     "year": 2026,
     "month": 3,
     "day": 6,
-    "category": "Games",
-    "inputMode": "desktop",
+    "category": "Icebreakers",
+    "inputMode": "responsive",
     "status": "active",
-    "tags": ["game", "puzzle", "words", "educational", "keyboard-controls"],
+    "tags": ["icebreaker", "multiplayer", "word-game", "moderator", "party", "round-based"],
     "route": "/apps/2026/03/06/word-scramble",
     "appPath": "/apps/2026/03/06/word-scramble/index.html",
     "generation": {
@@ -2850,10 +2850,26 @@
       "notes": "Generated as a test of the full agent workflow including git operations and transactional logging."
     },
     "suggestion": null,
-    "improvements": null,
+    "improvements": [
+      {
+        "issueNumber": 351,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/351",
+        "description": "Converted Word Scramble into a multiplayer icebreaker with participant setup, timed rounds, moderator winner assignment, answer panel window, and fair tie-ranked scoring.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-04-18T16:25:43Z",
+        "agentName": "GitHub Copilot",
+        "llmModel": "GPT-5.3-Codex"
+      }
+    ],
     "allowImprovements": true,
     "maxScore": null,
-    "backups": null
+    "backups": [
+      {
+        "runId": "run-20260418T162543Z-9209f8",
+        "path": "backups/run-20260418T162543Z-9209f8/index.html",
+        "url": "/apps/2026/03/06/word-scramble/backups/run-20260418T162543Z-9209f8/index.html"
+      }
+    ]
   },
   {
     "id": "2026/03/05/snake-game",


### PR DESCRIPTION
## Summary\n- convert Word Scramble to multiplayer icebreaker flow with setup screen and localStorage participants\n- add per-round 30 second timer, moderator winner assignment, and separate answer panel window\n- add fair tie-aware final ranking (shared placements with skipped ranks) and remove automatic social-share trigger behavior\n- update metadata/category/tags/input mode plus refreshed thumbnail and backup snapshot\n\n## Validation\n- npm run generate:apps\n- npm run validate:apps\n- npm run lint:fix\n- npm run format\n- npm run lint\n- npm test\n- npm run validate:responsive:sample\n- npm run build\n\nCloses #351