### PR TITLE
refactor: drop Firebase naming from multiplayer session-code helpers

### DIFF
--- a/__tests__/lib/multiplayer/sessionCodes.test.js
+++ b/__tests__/lib/multiplayer/sessionCodes.test.js
@@ -2,7 +2,7 @@ import {
   generateSessionCode,
   isValidSessionCode,
   normalizeSessionCode,
-} from '../../../lib/firebase/sessionCodes';
+} from '../../../lib/multiplayer/sessionCodes';
 
 describe('generateSessionCode', () => {
   it('produces a string of the requested length', () => {

--- a/app/join/[code]/page.jsx
+++ b/app/join/[code]/page.jsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { isValidSessionCode, normalizeSessionCode } from '@/lib/firebase/sessionCodes';
+import { isValidSessionCode, normalizeSessionCode } from '@/lib/multiplayer/sessionCodes';
 import { storagePrefix } from '@/lib/siteConfig';
 
 // Reusable multiplayer join page. Any app that exposes session metadata

--- a/lib/multiplayer/sessionCodes.js
+++ b/lib/multiplayer/sessionCodes.js
@@ -1,4 +1,4 @@
-// Session-code helpers. Pure functions — no Firebase deps — so they can be
+// Session-code helpers. Pure functions — no runtime deps — so they can be
 // used from Node.js scripts, Next.js pages, and unit tests.
 
 // Avoids visually ambiguous characters (0/O, 1/I, etc.) so players can copy

--- a/supabase/migrations/20260418213000_multiplayer_sessions.sql
+++ b/supabase/migrations/20260418213000_multiplayer_sessions.sql
@@ -1,5 +1,5 @@
--- Multiplayer session storage for Team Taboo (Supabase-backed replacement
--- for Firebase Realtime Database state).
+-- Multiplayer session storage used by any app that needs a host-led
+-- session-code lobby. One row per active game, keyed by the share code.
 
 create table public.multiplayer_sessions (
   code text primary key,


### PR DESCRIPTION
## Summary
- Rename `lib/firebase/sessionCodes.js` → `lib/multiplayer/sessionCodes.js` (and the mirrored test file); Firebase is no longer used in this project, so the directory name was misleading.
- Update the one import site ([app/join/[code]/page.jsx](app/join/%5Bcode%5D/page.jsx)) and the header comment inside the helper.
- Rewrite the header comment in `supabase/migrations/20260418213000_multiplayer_sessions.sql` to describe the table generically instead of "Supabase-backed replacement for Firebase Realtime Database state."

**Left intact on purpose:** append-only log files, the team-taboo `meta.json` improvement description (which truthfully records the Firebase → Supabase migration), `data/apps.json` (generated), and `supabase/config.toml` (Supabase CLI's own third-party-auth provider template).

## Test plan
- [x] `npm test` — 368 passing
- [x] `npm run lint` — 0 warnings
- [ ] `npm run validate:apps`
- [ ] Manual: `/join/<code>` still loads and registers a player

## Related
- PR #360 adds new `lib/firebase/sessionCodes.js` references in `AGENT_PROMPT_SHARED.md` — those will be fixed up on that branch so whichever PR lands second rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)