### PR TITLE
improve: word-scramble — multiplayer backend moderator/player flow

### DIFF
--- a/app/api/multiplayer/sessions/[code]/answers/route.js
+++ b/app/api/multiplayer/sessions/[code]/answers/route.js
@@ -1,0 +1,113 @@
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const CODE_RE = /^[A-HJ-NP-Z2-9]{4,10}$/;
+const ID_RE = /^[a-zA-Z0-9_-]{8,64}$/;
+
+function normalize(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+export async function POST(request, { params }) {
+  const resolvedParams = await params;
+  const code =
+    typeof resolvedParams?.code === 'string' ? resolvedParams.code.trim().toUpperCase() : '';
+  if (!CODE_RE.test(code)) {
+    return Response.json({ error: 'Invalid code' }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+  if (!supabase) {
+    return Response.json({ error: 'Multiplayer unavailable' }, { status: 503 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const playerId = typeof body.playerId === 'string' ? body.playerId.trim() : '';
+  const guess = typeof body.guess === 'string' ? body.guess : '';
+
+  if (!ID_RE.test(playerId)) {
+    return Response.json({ error: 'Invalid player ID' }, { status: 400 });
+  }
+
+  const { data: row, error: loadError } = await supabase
+    .from('multiplayer_sessions')
+    .select('status, game, players')
+    .eq('code', code)
+    .maybeSingle();
+
+  if (loadError) {
+    console.error('Failed to load session for answer submit', loadError);
+    return Response.json({ error: 'Failed to submit answer' }, { status: 500 });
+  }
+  if (!row) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const players = structuredClone(row.players || {});
+  const game = structuredClone(row.game || {});
+  const player = players[playerId];
+
+  if (!player) {
+    return Response.json({ error: 'Player not found' }, { status: 404 });
+  }
+
+  if (row.status !== 'playing' || game.roundState !== 'active') {
+    return Response.json({
+      ok: true,
+      accepted: false,
+      reason: 'round-inactive',
+      winnerId: game.roundWinnerId || null,
+      winnerName: game.roundWinnerName || null,
+    });
+  }
+
+  const correctAnswer = normalize(game.word);
+  if (!correctAnswer || normalize(guess) !== correctAnswer) {
+    return Response.json({ ok: true, accepted: false, reason: 'incorrect' });
+  }
+
+  if (game.roundWinnerId) {
+    return Response.json({
+      ok: true,
+      accepted: true,
+      alreadyAwarded: true,
+      winnerId: game.roundWinnerId,
+      winnerName: game.roundWinnerName || null,
+    });
+  }
+
+  player.score = Number(player.score || 0) + 1;
+  players[playerId] = player;
+
+  game.roundWinnerId = playerId;
+  game.roundWinnerName = player.name || 'Player';
+  game.roundWinnerAt = new Date().toISOString();
+  game.roundState = 'between';
+  game.solvedRounds = Number(game.solvedRounds || 0) + 1;
+  game.announcement = `${game.roundWinnerName} answered correctly first.`;
+
+  const { error: updateError } = await supabase
+    .from('multiplayer_sessions')
+    .update({ players, game })
+    .eq('code', code);
+
+  if (updateError) {
+    console.error('Failed to persist winner update', updateError);
+    return Response.json({ error: 'Failed to submit answer' }, { status: 500 });
+  }
+
+  return Response.json({
+    ok: true,
+    accepted: true,
+    winnerId: playerId,
+    winnerName: game.roundWinnerName,
+    alreadyAwarded: false,
+  });
+}

--- a/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/index.html
+++ b/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/index.html
@@ -1,0 +1,962 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="auto">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', '__GA_MEASUREMENT_ID__');
+  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Word Scramble Party - __MAIN_SITE_NAME__</title>
+  <meta name="voa-main-site-url" content="__MAIN_SITE_URL__" />
+  <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__" />
+  <meta name="voa-github-url" content="__GITHUB_URL__" />
+  <meta name="voa-social-x-url" content="__SOCIAL_X_URL__" />
+  <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__" />
+  <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__" />
+  <meta name="application-name" content="Word Scramble Party" />
+  <meta name="voa-app-id" content="2026/03/06/word-scramble" />
+  <script src="/apps/shared/app-shell.js" defer></script>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --text: #f9fafb;
+      --surface: #1e293b;
+      --card: #15213e;
+      --muted: #9ca3af;
+      --accent: #22d3ee;
+      --accent-2: #38bdf8;
+      --success: #22c55e;
+      --warning: #f59e0b;
+      --danger: #ef4444;
+      --border: #334155;
+    }
+
+    [data-theme='light'] {
+      --bg: #ffffff;
+      --text: #1f2937;
+      --surface: #f3f4f6;
+      --card: #ffffff;
+      --muted: #6b7280;
+      --accent: #0891b2;
+      --accent-2: #0369a1;
+      --success: #16a34a;
+      --warning: #d97706;
+      --danger: #dc2626;
+      --border: #d1d5db;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      min-height: 100vh;
+      font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 10% 20%, rgb(34 211 238 / 18%), transparent 45%),
+        radial-gradient(circle at 85% 0%, rgb(56 189 248 / 18%), transparent 40%),
+        var(--bg);
+      line-height: 1.4;
+    }
+
+    .app {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 1.25rem 1rem 1.5rem;
+      display: grid;
+      gap: 1rem;
+    }
+
+    .hero {
+      background: linear-gradient(135deg, rgb(15 23 42 / 92%), rgb(30 41 59 / 92%));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 1rem 1.25rem;
+      box-shadow: 0 18px 28px rgb(2 6 23 / 25%);
+    }
+
+    [data-theme='light'] .hero {
+      background: linear-gradient(135deg, rgb(240 249 255 / 95%), rgb(236 253 245 / 95%));
+      box-shadow: 0 14px 24px rgb(15 23 42 / 10%);
+    }
+
+    h1 {
+      font-size: clamp(1.5rem, 2.4vw, 2rem);
+      margin-bottom: 0.3rem;
+    }
+
+    .hero p {
+      color: var(--muted);
+      font-size: 0.98rem;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 1rem;
+      box-shadow: 0 10px 20px rgb(2 6 23 / 22%);
+    }
+
+    [data-theme='light'] .card {
+      box-shadow: 0 10px 20px rgb(15 23 42 / 8%);
+    }
+
+    .screen {
+      display: none;
+    }
+
+    .screen.active {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .row {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    label {
+      font-weight: 700;
+      font-size: 0.92rem;
+    }
+
+    input,
+    button {
+      font: inherit;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      min-height: 44px;
+    }
+
+    input {
+      background: var(--surface);
+      color: var(--text);
+      padding: 0.5rem 0.7rem;
+      width: min(100%, 320px);
+    }
+
+    .name-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 0.3rem 0.7rem;
+      font-weight: 700;
+      font-size: 0.87rem;
+    }
+
+    .pill button {
+      min-height: 24px;
+      width: 24px;
+      border-radius: 50%;
+      border: none;
+      background: var(--danger);
+      color: #fff;
+      cursor: pointer;
+    }
+
+    .btn {
+      cursor: pointer;
+      color: #fff;
+      font-weight: 700;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      border: none;
+      padding: 0.5rem 1rem;
+    }
+
+    .btn:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .btn-secondary {
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.65rem;
+    }
+
+    .stat {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 0.6rem;
+      text-align: center;
+    }
+
+    .stat b {
+      display: block;
+      font-size: 1.2rem;
+    }
+
+    .timer-urgent {
+      color: var(--danger);
+    }
+
+    .hint {
+      background: var(--surface);
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      padding: 0.7rem;
+      font-size: 0.95rem;
+    }
+
+    .scramble,
+    .answer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+      justify-content: center;
+    }
+
+    .tile {
+      width: 48px;
+      height: 56px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.35rem;
+      font-weight: 800;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      user-select: none;
+      text-transform: uppercase;
+    }
+
+    .tile.letter {
+      cursor: pointer;
+      color: #fff;
+      border: none;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+    }
+
+    .tile.letter.used {
+      opacity: 0.25;
+      pointer-events: none;
+    }
+
+    .tile.slot {
+      background: var(--surface);
+      border-style: dashed;
+    }
+
+    .tile.slot.filled {
+      border-style: solid;
+      cursor: pointer;
+      background: rgb(8 145 178 / 14%);
+    }
+
+    .tile.slot.highlight-next {
+      border-style: solid;
+      border-color: var(--warning);
+      border-width: 3px;
+      box-shadow: inset 0 0 0 1px var(--warning), 0 0 8px rgb(245 158 11 / 45%);
+    }
+
+    .message {
+      border-radius: 10px;
+      padding: 0.7rem 0.8rem;
+      font-weight: 700;
+      font-size: 0.95rem;
+      border: 1px solid transparent;
+    }
+
+    .message.info {
+      background: rgb(34 211 238 / 14%);
+      border-color: rgb(34 211 238 / 45%);
+    }
+
+    .message.success {
+      background: rgb(34 197 94 / 14%);
+      border-color: rgb(34 197 94 / 45%);
+    }
+
+    .message.warn {
+      background: rgb(245 158 11 / 14%);
+      border-color: rgb(245 158 11 / 45%);
+    }
+
+    .winner-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.5rem;
+    }
+
+    .score-list {
+      display: grid;
+      gap: 0.55rem;
+    }
+
+    .score-row {
+      display: grid;
+      grid-template-columns: 80px 1fr auto;
+      gap: 0.6rem;
+      align-items: center;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.55rem 0.7rem;
+    }
+
+    .rank {
+      font-weight: 800;
+    }
+
+    .score {
+      font-weight: 700;
+      color: var(--accent);
+    }
+
+    .muted {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 640px) {
+      .stats {
+        grid-template-columns: 1fr;
+      }
+
+      .app {
+        padding: 0.85rem;
+      }
+
+      .score-row {
+        grid-template-columns: 64px 1fr auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="app">
+    <section class="hero">
+      <h1>Word Scramble Party</h1>
+      <p>
+        Multiplayer icebreaker mode for live groups. Add players, run timed rounds, award each round
+        to the first correct responder, and finish with tie-aware placements.
+      </p>
+    </section>
+
+    <section id="setupScreen" class="card screen active" aria-label="Setup screen">
+      <h2>1) Setup Round</h2>
+      <p class="muted">Participant settings are saved to local storage for your next session.</p>
+      <div class="row">
+        <label for="participantInput">Participant Name</label>
+        <input id="participantInput" maxlength="24" placeholder="Add player" />
+        <button id="addParticipantBtn" class="btn" type="button">Add Participant</button>
+      </div>
+      <div id="nameList" class="name-list" aria-live="polite"></div>
+      <div class="row">
+        <label for="roundsInput">Number of Rounds</label>
+        <input id="roundsInput" type="number" min="1" max="30" value="6" />
+      </div>
+      <div class="row">
+        <button id="startBtn" class="btn" type="button">Start Game</button>
+      </div>
+      <p class="muted">Need at least two participants to start.</p>
+    </section>
+
+    <section id="playScreen" class="card screen" aria-label="Round play screen">
+      <h2>2) Live Round</h2>
+      <div class="stats">
+        <div class="stat">
+          <span>Round</span>
+          <b id="roundStat">1 / 6</b>
+        </div>
+        <div class="stat">
+          <span>Timer</span>
+          <b id="timerStat">30</b>
+        </div>
+        <div class="stat">
+          <span>Solved</span>
+          <b id="solvedStat">0</b>
+        </div>
+      </div>
+
+      <div id="roundMessage" class="message info">Moderator: choose winner after each solved round.</div>
+      <div id="hintBox" class="hint">Hint: <strong>Loading...</strong></div>
+      <div id="scramble" class="scramble" aria-label="Scrambled letters"></div>
+      <div id="answer" class="answer" aria-label="Answer slots"></div>
+
+      <div class="row">
+        <button id="clearBtn" class="btn btn-secondary" type="button">Clear Answer</button>
+        <button id="submitBtn" class="btn" type="button">Check Answer</button>
+        <button id="skipBtn" class="btn btn-secondary" type="button">Skip Round</button>
+      </div>
+
+      <div class="row">
+        <button id="openPanelBtn" class="btn btn-secondary" type="button">Open Answer Panel Window</button>
+      </div>
+
+      <div>
+        <h3>Award This Round</h3>
+        <p class="muted">Click the participant who answered first. This ends the current round.</p>
+        <div id="winnerGrid" class="winner-grid"></div>
+      </div>
+    </section>
+
+    <section id="scoreScreen" class="card screen" aria-label="Final scoreboard">
+      <h2>3) Final Scoreboard</h2>
+      <p class="muted">Placements use fair shared ranking for ties (1, 1, 3 style).</p>
+      <div id="scoreList" class="score-list"></div>
+      <div class="row">
+        <button id="playAgainBtn" class="btn" type="button">Play Again</button>
+        <button id="editSetupBtn" class="btn btn-secondary" type="button">Edit Participants</button>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const STORAGE_KEY = 'voa-word-scramble-party-config';
+
+    const WORDS = [
+      { word: 'apple', hint: 'A common fruit often in lunch boxes' },
+      { word: 'dance', hint: 'Move to rhythm and music' },
+      { word: 'guitar', hint: 'String instrument with six strings' },
+      { word: 'planet', hint: 'Earth is one of these' },
+      { word: 'bridge', hint: 'Structure used to cross water' },
+      { word: 'castle', hint: 'Historic fortress for royalty' },
+      { word: 'memory', hint: 'What this game challenges' },
+      { word: 'camera', hint: 'Device used to take photos' },
+      { word: 'rocket', hint: 'Vehicle that launches to space' },
+      { word: 'forest', hint: 'Large area full of trees' },
+      { word: 'puzzle', hint: 'A problem to solve for fun' },
+      { word: 'travel', hint: 'To go from place to place' },
+      { word: 'friend', hint: 'Someone you trust and enjoy' },
+      { word: 'silver', hint: 'Metal and also a medal color' },
+      { word: 'orange', hint: 'Color and citrus fruit' },
+      { word: 'school', hint: 'Place for classes and learning' },
+      { word: 'runner', hint: 'Someone moving quickly by foot' },
+      { word: 'market', hint: 'Place where goods are sold' },
+      { word: 'winter', hint: 'The coldest season' },
+      { word: 'bright', hint: 'Very full of light' }
+    ];
+
+    const setupScreen = document.getElementById('setupScreen');
+    const playScreen = document.getElementById('playScreen');
+    const scoreScreen = document.getElementById('scoreScreen');
+
+    const participantInput = document.getElementById('participantInput');
+    const roundsInput = document.getElementById('roundsInput');
+    const nameList = document.getElementById('nameList');
+    const startBtn = document.getElementById('startBtn');
+
+    const roundStat = document.getElementById('roundStat');
+    const timerStat = document.getElementById('timerStat');
+    const solvedStat = document.getElementById('solvedStat');
+    const roundMessage = document.getElementById('roundMessage');
+    const hintBox = document.getElementById('hintBox');
+    const scrambleEl = document.getElementById('scramble');
+    const answerEl = document.getElementById('answer');
+    const winnerGrid = document.getElementById('winnerGrid');
+
+    const scoreList = document.getElementById('scoreList');
+
+    let participants = [];
+    let roundsTotal = 6;
+    let currentRound = 1;
+    let solvedRounds = 0;
+    let timerLeft = 30;
+    let timerHandle = null;
+    let activeWord = null;
+    let scramble = [];
+    let answer = [];
+    let usedIndices = new Set();
+    let usedWords = new Set();
+    let roundClosed = false;
+    let answerPanelWindow = null;
+    let nextSlotIndex = 0;
+
+    function showScreen(name) {
+      setupScreen.classList.toggle('active', name === 'setup');
+      playScreen.classList.toggle('active', name === 'play');
+      scoreScreen.classList.toggle('active', name === 'score');
+    }
+
+    function persistSetup() {
+      const payload = {
+        names: participants.map((p) => p.name),
+        roundsTotal
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    }
+
+    function loadSetup() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        const data = JSON.parse(raw);
+        const names = Array.isArray(data.names) ? data.names : [];
+        participants = names
+          .filter((name) => typeof name === 'string' && name.trim().length > 0)
+          .slice(0, 12)
+          .map((name, index) => ({ id: index + 1, name: name.trim(), score: 0 }));
+        const parsedRounds = Number.parseInt(data.roundsTotal, 10);
+        roundsTotal = Number.isFinite(parsedRounds) ? Math.min(30, Math.max(1, parsedRounds)) : 6;
+        roundsInput.value = String(roundsTotal);
+      } catch (_error) {
+        participants = [];
+      }
+    }
+
+    function renderParticipants() {
+      nameList.innerHTML = '';
+      participants.forEach((participant, index) => {
+        const pill = document.createElement('div');
+        pill.className = 'pill';
+        pill.textContent = participant.name;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.setAttribute('aria-label', `Remove ${participant.name}`);
+        removeBtn.textContent = 'x';
+        removeBtn.addEventListener('click', () => {
+          participants.splice(index, 1);
+          participants = participants.map((item, idx) => ({ ...item, id: idx + 1 }));
+          renderParticipants();
+          persistSetup();
+          updateStartState();
+        });
+
+        pill.appendChild(removeBtn);
+        nameList.appendChild(pill);
+      });
+    }
+
+    function updateStartState() {
+      startBtn.disabled = participants.length < 2;
+    }
+
+    function addParticipant() {
+      const name = participantInput.value.trim();
+      if (!name) return;
+      if (participants.length >= 12) {
+        showRoundMessage('Participant limit reached (12).', 'warn');
+        return;
+      }
+      if (participants.some((item) => item.name.toLowerCase() === name.toLowerCase())) {
+        showRoundMessage('Duplicate participant names are not allowed.', 'warn');
+        return;
+      }
+      participants.push({ id: participants.length + 1, name, score: 0 });
+      participantInput.value = '';
+      renderParticipants();
+      updateStartState();
+      persistSetup();
+    }
+
+    function shuffleLetters(letters) {
+      const copy = [...letters];
+      for (let i = copy.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+      }
+      return copy;
+    }
+
+    function getWordForRound() {
+      const available = WORDS.filter((entry) => !usedWords.has(entry.word));
+      if (available.length === 0) {
+        usedWords.clear();
+        return getWordForRound();
+      }
+      const picked = available[Math.floor(Math.random() * available.length)];
+      usedWords.add(picked.word);
+      return picked;
+    }
+
+    function buildRound() {
+      activeWord = getWordForRound();
+      do {
+        scramble = shuffleLetters(activeWord.word.split(''));
+      } while (scramble.join('') === activeWord.word);
+
+      answer = [];
+      usedIndices = new Set();
+      timerLeft = 30;
+      roundClosed = false;
+
+      roundStat.textContent = `${currentRound} / ${roundsTotal}`;
+      solvedStat.textContent = String(solvedRounds);
+      hintBox.innerHTML = `Hint: <strong>${activeWord.hint}</strong>`;
+      showRoundMessage('Unscramble the word. Moderator awards each round winner.', 'info');
+      renderRoundTiles();
+      renderWinnerButtons();
+      startTimer();
+      updateAnswerPanel();
+    }
+
+    function renderRoundTiles() {
+      timerStat.textContent = String(timerLeft);
+      timerStat.classList.toggle('timer-urgent', timerLeft <= 7);
+
+      nextSlotIndex = answer.length;
+
+      scrambleEl.innerHTML = scramble
+        .map(
+          (letter, index) =>
+            `<button type="button" class="tile letter ${usedIndices.has(index) ? 'used' : ''}" data-index="${index}" aria-label="Letter ${letter}">${letter}</button>`
+        )
+        .join('');
+
+      answerEl.innerHTML = '';
+      for (let i = 0; i < activeWord.word.length; i += 1) {
+        const slotData = answer[i];
+        const slot = document.createElement('button');
+        slot.type = 'button';
+        const isNextSlot = i === nextSlotIndex;
+        slot.className = `tile slot${slotData ? ' filled' : ''}${isNextSlot && !roundClosed ? ' highlight-next' : ''}`;
+        slot.textContent = slotData ? slotData.letter : '';
+        slot.setAttribute('aria-label', slotData ? `Remove ${slotData.letter}` : 'Empty answer slot');
+        if (slotData) {
+          slot.addEventListener('click', () => removeLetter(i));
+        } else {
+          slot.disabled = true;
+        }
+        answerEl.appendChild(slot);
+      }
+
+      scrambleEl.querySelectorAll('button').forEach((button) => {
+        button.addEventListener('click', () => {
+          const idx = Number.parseInt(button.dataset.index, 10);
+          selectLetter(idx);
+        });
+      });
+    }
+
+    function renderWinnerButtons() {
+      winnerGrid.innerHTML = '';
+      participants.forEach((participant) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn';
+        button.textContent = `${participant.name} +1 (${participant.score})`;
+        button.addEventListener('click', () => awardRound(participant.id));
+        winnerGrid.appendChild(button);
+      });
+      const noPoint = document.createElement('button');
+      noPoint.type = 'button';
+      noPoint.className = 'btn btn-secondary';
+      noPoint.textContent = 'No Point This Round';
+      noPoint.addEventListener('click', () => finishRound(null));
+      winnerGrid.appendChild(noPoint);
+    }
+
+    function renderStartNextButton() {
+      winnerGrid.innerHTML = '';
+      if (currentRound >= roundsTotal) {
+        showFinalScoreboard();
+        return;
+      }
+      const startBtn = document.createElement('button');
+      startBtn.type = 'button';
+      startBtn.className = 'btn';
+      startBtn.textContent = 'Start Next Round';
+      startBtn.addEventListener('click', () => {
+        currentRound += 1;
+        buildRound();
+      });
+      winnerGrid.appendChild(startBtn);
+    }
+
+    function selectLetter(index) {
+      if (roundClosed || usedIndices.has(index) || answer.length >= activeWord.word.length) return;
+      usedIndices.add(index);
+      answer.push({ letter: scramble[index], sourceIndex: index });
+      renderRoundTiles();
+      updateAnswerPanel();
+    }
+
+    function removeLetter(index) {
+      if (roundClosed || !answer[index]) return;
+      usedIndices.delete(answer[index].sourceIndex);
+      answer.splice(index, 1);
+      renderRoundTiles();
+      updateAnswerPanel();
+    }
+
+    function clearAnswer() {
+      if (roundClosed) return;
+      answer = [];
+      usedIndices = new Set();
+      renderRoundTiles();
+      updateAnswerPanel();
+    }
+
+    function showRoundMessage(text, tone) {
+      roundMessage.className = `message ${tone}`;
+      roundMessage.textContent = text;
+    }
+
+    function submitAnswer() {
+      if (roundClosed) return;
+      if (answer.length !== activeWord.word.length) {
+        showRoundMessage('Fill every slot before checking the answer.', 'warn');
+        return;
+      }
+      const guess = answer.map((item) => item.letter).join('');
+      if (guess === activeWord.word) {
+        showRoundMessage('Correct answer. Moderator: choose who answered first.', 'success');
+      } else {
+        showRoundMessage('Not correct yet. Keep trying.', 'warn');
+      }
+      updateAnswerPanel();
+    }
+
+    function startTimer() {
+      stopTimer();
+      timerHandle = setInterval(() => {
+        timerLeft -= 1;
+        renderRoundTiles();
+        if (timerLeft <= 0) {
+          stopTimer();
+          showRoundMessage(`Time up. Answer was: ${activeWord.word.toUpperCase()}`, 'warn');
+          finishRound(null);
+        }
+      }, 1000);
+    }
+
+    function stopTimer() {
+      if (!timerHandle) return;
+      clearInterval(timerHandle);
+      timerHandle = null;
+    }
+
+    function awardRound(participantId) {
+      const winner = participants.find((participant) => participant.id === participantId);
+      if (!winner) return;
+      winner.score += 1;
+      solvedRounds += 1;
+      showRoundMessage(`${winner.name} gets this round!`, 'success');
+      finishRound(participantId);
+    }
+
+    function finishRound(_winnerId) {
+      if (roundClosed) return;
+      roundClosed = true;
+      stopTimer();
+      winnerGrid.querySelectorAll('button').forEach((button) => {
+        button.disabled = true;
+      });
+
+      setTimeout(() => {
+        renderStartNextButton();
+      }, 900);
+    }
+
+    function computePlacements(players) {
+      const sorted = [...players].sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.name.localeCompare(b.name);
+      });
+
+      let previousScore = null;
+      let currentRank = 0;
+      return sorted.map((player, index) => {
+        if (previousScore === null || player.score < previousScore) {
+          currentRank = index + 1;
+        }
+        previousScore = player.score;
+        return {
+          ...player,
+          rank: currentRank
+        };
+      });
+    }
+
+    function rankLabel(rank) {
+      if (rank === 1) return 'Gold';
+      if (rank === 2) return 'Silver';
+      if (rank === 3) return 'Bronze';
+      return `${rank}th`;
+    }
+
+    function showFinalScoreboard() {
+      stopTimer();
+      showScreen('score');
+      const placements = computePlacements(participants);
+      scoreList.innerHTML = '';
+
+      placements.forEach((entry) => {
+        const row = document.createElement('div');
+        row.className = 'score-row';
+
+        const rank = document.createElement('div');
+        rank.className = 'rank';
+        rank.textContent = `${entry.rank}. ${rankLabel(entry.rank)}`;
+
+        const name = document.createElement('div');
+        name.textContent = entry.name;
+
+        const score = document.createElement('div');
+        score.className = 'score';
+        score.textContent = `${entry.score} pts`;
+
+        row.appendChild(rank);
+        row.appendChild(name);
+        row.appendChild(score);
+        scoreList.appendChild(row);
+      });
+    }
+
+    function restartGame() {
+      participants = participants.map((participant) => ({ ...participant, score: 0 }));
+      currentRound = 1;
+      solvedRounds = 0;
+      usedWords = new Set();
+      showScreen('play');
+      buildRound();
+    }
+
+    function openAnswerPanel() {
+      answerPanelWindow = window.open('', 'voa-answer-panel', 'width=520,height=620');
+      if (!answerPanelWindow) {
+        showRoundMessage('Popup blocked. Allow popups for moderator panel.', 'warn');
+        return;
+      }
+      updateAnswerPanel();
+    }
+
+    function updateAnswerPanel() {
+      if (!answerPanelWindow || answerPanelWindow.closed || !activeWord) return;
+      const partialAnswer = answer.map((entry) => entry.letter).join('').toUpperCase();
+      answerPanelWindow.document.open();
+      answerPanelWindow.document.write(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Word Scramble Moderator Panel</title>
+  <style>
+    body { font-family: 'Trebuchet MS', 'Segoe UI', sans-serif; margin: 0; padding: 16px; background: #0f172a; color: #f8fafc; }
+    .card { background: #1e293b; border: 1px solid #334155; border-radius: 12px; padding: 12px; margin-bottom: 12px; }
+    h1 { margin: 0 0 10px; font-size: 1.2rem; }
+    h2 { margin: 0 0 6px; font-size: 0.95rem; color: #67e8f9; }
+    b { color: #22d3ee; }
+  </style>
+</head>
+<body>
+  <h1>Moderator Answer Panel</h1>
+  <div class="card"><h2>Round</h2><div><b>${currentRound}</b> / ${roundsTotal}</div></div>
+  <div class="card"><h2>Hint</h2><div>${activeWord.hint}</div></div>
+  <div class="card"><h2>Answer</h2><div><b>${activeWord.word.toUpperCase()}</b></div></div>
+  <div class="card"><h2>Current Guess</h2><div>${partialAnswer || '-'}</div></div>
+  <div class="card"><h2>Timer</h2><div>${timerLeft}s</div></div>
+</body>
+</html>`);
+      answerPanelWindow.document.close();
+    }
+
+    function startGame() {
+      roundsTotal = Number.parseInt(roundsInput.value, 10);
+      if (!Number.isFinite(roundsTotal) || roundsTotal < 1 || roundsTotal > 30) {
+        showRoundMessage('Rounds must be between 1 and 30.', 'warn');
+        return;
+      }
+      participants = participants.map((participant, index) => ({
+        id: index + 1,
+        name: participant.name,
+        score: 0
+      }));
+
+      persistSetup();
+      usedWords = new Set();
+      currentRound = 1;
+      solvedRounds = 0;
+      showScreen('play');
+      buildRound();
+    }
+
+    function setupKeyboardSupport() {
+      document.addEventListener('keydown', (event) => {
+        const tag = document.activeElement ? document.activeElement.tagName : '';
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+        if (!playScreen.classList.contains('active')) return;
+        if (event.key === 'Enter') {
+          submitAnswer();
+          return;
+        }
+        if (event.key === 'Backspace') {
+          if (answer.length > 0) {
+            removeLetter(answer.length - 1);
+          }
+          return;
+        }
+        if (event.key === 'Escape') {
+          clearAnswer();
+          return;
+        }
+        if (/^[a-zA-Z]$/.test(event.key)) {
+          const letter = event.key.toLowerCase();
+          const idx = scramble.findIndex((item, index) => item === letter && !usedIndices.has(index));
+          if (idx >= 0) {
+            selectLetter(idx);
+          }
+        }
+      });
+    }
+
+    document.getElementById('addParticipantBtn').addEventListener('click', addParticipant);
+    participantInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        addParticipant();
+      }
+    });
+
+    roundsInput.addEventListener('change', () => {
+      const value = Number.parseInt(roundsInput.value, 10);
+      if (Number.isFinite(value)) {
+        roundsTotal = Math.min(30, Math.max(1, value));
+        roundsInput.value = String(roundsTotal);
+        persistSetup();
+      }
+    });
+
+    startBtn.addEventListener('click', startGame);
+    document.getElementById('clearBtn').addEventListener('click', clearAnswer);
+    document.getElementById('submitBtn').addEventListener('click', submitAnswer);
+    document.getElementById('skipBtn').addEventListener('click', () => {
+      showRoundMessage(`Round skipped. Answer was ${activeWord.word.toUpperCase()}.`, 'warn');
+      finishRound(null);
+    });
+    document.getElementById('openPanelBtn').addEventListener('click', openAnswerPanel);
+    document.getElementById('playAgainBtn').addEventListener('click', restartGame);
+    document.getElementById('editSetupBtn').addEventListener('click', () => {
+      stopTimer();
+      showScreen('setup');
+    });
+
+    loadSetup();
+    renderParticipants();
+    updateStartState();
+    setupKeyboardSupport();
+  </script>
+</body>
+</html>

--- a/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/meta.json
+++ b/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/meta.json
@@ -29,16 +29,6 @@
       "implementedAt": "2026-04-18T17:01:51Z",
       "agentName": "GitHub Copilot",
       "llmModel": "Claude Haiku 4.5"
-    },
-    {
-      "issueNumber": 362,
-      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/362",
-      "runId": "run-20260419T220321Z-f36990",
-      "description": "Migrated Word Scramble to multiplayer backend sessions with moderator share-link lobby, player name join, realtime synchronized rounds/scores, and automatic first-correct score awarding.",
-      "requestor": "jeffholst",
-      "implementedAt": "2026-04-19T22:03:21Z",
-      "agentName": "Codex",
-      "llmModel": "GPT-5.4"
     }
   ],
   "generation": {

--- a/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/thumbnail.svg
+++ b/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/thumbnail.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22d3ee" />
+      <stop offset="100%" stop-color="#0284c7" />
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="5" result="blur" />
+      <feOffset in="blur" dx="0" dy="4" result="offsetBlur" />
+      <feFlood flood-color="#020617" flood-opacity="0.45" result="shadowColor" />
+      <feComposite in="shadowColor" in2="offsetBlur" operator="in" result="shadow" />
+      <feMerge>
+        <feMergeNode in="shadow" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect x="0" y="0" width="800" height="450" fill="url(#bg)" />
+
+  <rect x="26" y="18" width="748" height="62" rx="14" fill="#15213e" stroke="#334155" />
+  <text x="50" y="56" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="30" font-weight="700">
+    Word Scramble Party
+  </text>
+  <text x="748" y="56" text-anchor="end" fill="#67e8f9" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="20" font-weight="700">
+    Round 3/8
+  </text>
+
+  <rect x="40" y="100" width="510" height="310" rx="18" fill="#15213e" stroke="#334155" filter="url(#softShadow)" />
+
+  <rect x="62" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
+  <text x="76" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Timer</text>
+  <text x="76" y="172" fill="#f43f5e" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">11s</text>
+
+  <rect x="224" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
+  <text x="238" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Solved</text>
+  <text x="238" y="172" fill="#22d3ee" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">2</text>
+
+  <rect x="386" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
+  <text x="400" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Hint</text>
+  <text x="400" y="172" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16" font-weight="700">Color + Fruit</text>
+
+  <g filter="url(#softShadow)">
+    <rect x="86" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="150" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="214" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="278" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
+    <rect x="342" y="214" width="56" height="64" rx="10" fill="url(#tile)" opacity="0.38" />
+    <rect x="406" y="214" width="56" height="64" rx="10" fill="url(#tile)" opacity="0.38" />
+  </g>
+  <text x="114" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">O</text>
+  <text x="178" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">R</text>
+  <text x="242" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">A</text>
+  <text x="306" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">N</text>
+  <text x="370" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">G</text>
+  <text x="434" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">E</text>
+
+  <rect x="86" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="150" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="214" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="278" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="342" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <rect x="406" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="114" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">O</text>
+  <text x="178" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">R</text>
+  <text x="242" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">A</text>
+
+  <rect x="572" y="100" width="188" height="310" rx="18" fill="#15213e" stroke="#334155" filter="url(#softShadow)" />
+  <text x="666" y="128" text-anchor="middle" fill="#67e8f9" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="20" font-weight="700">
+    Scoreboard
+  </text>
+
+  <rect x="588" y="146" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="604" y="170" fill="#facc15" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="18" font-weight="700">1. Gold</text>
+  <text x="730" y="170" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Alex 2</text>
+  <text x="730" y="188" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Casey 2</text>
+
+  <rect x="588" y="208" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="604" y="238" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="18" font-weight="700">3. Bronze</text>
+  <text x="730" y="238" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Riley 1</text>
+
+  <rect x="588" y="270" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
+  <text x="666" y="302" text-anchor="middle" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="15">
+    Moderator Panel
+  </text>
+
+  <rect x="588" y="336" width="156" height="52" rx="10" fill="#0f172a" stroke="#22d3ee" />
+  <text x="666" y="366" text-anchor="middle" fill="#22d3ee" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16" font-weight="700">
+    Answer: ORANGE
+  </text>
+</svg>

--- a/apps/2026/03/06/word-scramble/index.html
+++ b/apps/2026/03/06/word-scramble/index.html
@@ -70,7 +70,7 @@
     }
 
     .app {
-      max-width: 920px;
+      max-width: 980px;
       margin: 0 auto;
       padding: 1.25rem 1rem 1.5rem;
       display: grid;
@@ -95,6 +95,11 @@
       margin-bottom: 0.3rem;
     }
 
+    h2 {
+      margin-bottom: 0.35rem;
+      font-size: 1.2rem;
+    }
+
     .hero p {
       color: var(--muted);
       font-size: 0.98rem;
@@ -114,11 +119,11 @@
 
     .screen {
       display: none;
+      gap: 1rem;
     }
 
     .screen.active {
       display: grid;
-      gap: 1rem;
     }
 
     .row {
@@ -126,6 +131,11 @@
       gap: 0.75rem;
       flex-wrap: wrap;
       align-items: center;
+    }
+
+    .col {
+      display: grid;
+      gap: 0.5rem;
     }
 
     label {
@@ -145,36 +155,7 @@
       background: var(--surface);
       color: var(--text);
       padding: 0.5rem 0.7rem;
-      width: min(100%, 320px);
-    }
-
-    .name-list {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-    }
-
-    .pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      background: var(--surface);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: 999px;
-      padding: 0.3rem 0.7rem;
-      font-weight: 700;
-      font-size: 0.87rem;
-    }
-
-    .pill button {
-      min-height: 24px;
-      width: 24px;
-      border-radius: 50%;
-      border: none;
-      background: var(--danger);
-      color: #fff;
-      cursor: pointer;
+      width: min(100%, 360px);
     }
 
     .btn {
@@ -197,9 +178,13 @@
       border: 1px solid var(--border);
     }
 
+    .btn-danger {
+      background: linear-gradient(135deg, #ef4444, #f97316);
+    }
+
     .stats {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: 0.65rem;
     }
 
@@ -273,13 +258,6 @@
       background: rgb(8 145 178 / 14%);
     }
 
-    .tile.slot.highlight-next {
-      border-style: solid;
-      border-color: var(--warning);
-      border-width: 3px;
-      box-shadow: inset 0 0 0 1px var(--warning), 0 0 8px rgb(245 158 11 / 45%);
-    }
-
     .message {
       border-radius: 10px;
       padding: 0.7rem 0.8rem;
@@ -303,10 +281,15 @@
       border-color: rgb(245 158 11 / 45%);
     }
 
-    .winner-grid {
+    .message.error {
+      background: rgb(239 68 68 / 14%);
+      border-color: rgb(239 68 68 / 45%);
+    }
+
+    .grid-2 {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 0.5rem;
+      grid-template-columns: 1.6fr 1fr;
+      gap: 0.8rem;
     }
 
     .score-list {
@@ -339,8 +322,39 @@
       font-size: 0.9rem;
     }
 
-    @media (max-width: 640px) {
+    .join-box {
+      border: 1px dashed var(--border);
+      border-radius: 12px;
+      padding: 0.7rem;
+      background: rgb(2 6 23 / 18%);
+      word-break: break-all;
+    }
+
+    [data-theme='light'] .join-box {
+      background: rgb(248 250 252 / 80%);
+    }
+
+    .role-badge {
+      display: inline-block;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      padding: 0.2rem 0.65rem;
+      font-size: 0.82rem;
+      font-weight: 700;
+      color: var(--muted);
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    @media (max-width: 760px) {
       .stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .grid-2 {
         grid-template-columns: 1fr;
       }
 
@@ -359,32 +373,66 @@
     <section class="hero">
       <h1>Word Scramble Party</h1>
       <p>
-        Multiplayer icebreaker mode for live groups. Add players, run timed rounds, award each round
-        to the first correct responder, and finish with tie-aware placements.
+        Multiplayer backend mode: moderator hosts a room, players join with a share link,
+        first correct answer wins the round automatically.
       </p>
     </section>
 
-    <section id="setupScreen" class="card screen active" aria-label="Setup screen">
-      <h2>1) Setup Round</h2>
-      <p class="muted">Participant settings are saved to local storage for your next session.</p>
-      <div class="row">
-        <label for="participantInput">Participant Name</label>
-        <input id="participantInput" maxlength="24" placeholder="Add player" />
-        <button id="addParticipantBtn" class="btn" type="button">Add Participant</button>
+    <section id="loadingScreen" class="card screen active" aria-label="Loading screen">
+      <h2>Connecting...</h2>
+      <p class="muted">Setting up multiplayer room.</p>
+    </section>
+
+    <section id="joinScreen" class="card screen" aria-label="Join screen">
+      <h2>Join Word Scramble</h2>
+      <p class="muted">Enter your name to join this game room.</p>
+      <div class="col">
+        <label for="playerNameInput">Your Name</label>
+        <input id="playerNameInput" maxlength="24" placeholder="Player name" />
       </div>
-      <div id="nameList" class="name-list" aria-live="polite"></div>
       <div class="row">
-        <label for="roundsInput">Number of Rounds</label>
-        <input id="roundsInput" type="number" min="1" max="30" value="6" />
+        <button id="joinBtn" class="btn" type="button">Join Game</button>
       </div>
+      <p id="joinMessage" class="message info">Waiting for your name.</p>
+    </section>
+
+    <section id="lobbyScreen" class="card screen" aria-label="Lobby screen">
       <div class="row">
-        <button id="startBtn" class="btn" type="button">Start Game</button>
+        <h2 style="margin: 0">Lobby</h2>
+        <span id="roleBadge" class="role-badge">Moderator</span>
       </div>
-      <p class="muted">Need at least two participants to start.</p>
+
+      <div id="moderatorLobbyTools">
+        <div class="join-box">
+          <div class="muted">Share this link with players:</div>
+          <strong id="joinUrlText">—</strong>
+          <div class="row" style="margin-top: 0.6rem">
+            <button id="copyJoinLinkBtn" class="btn btn-secondary" type="button">Copy Link</button>
+            <button id="shareJoinLinkBtn" class="btn btn-secondary" type="button">Share Link</button>
+          </div>
+        </div>
+        <div class="row">
+          <label for="roundsInput">Number of Rounds</label>
+          <input id="roundsInput" type="number" min="1" max="30" value="6" />
+          <button id="startBtn" class="btn" type="button">Start Game</button>
+        </div>
+      </div>
+
+      <div>
+        <h3>Players</h3>
+        <p class="muted">All connected players appear here in realtime.</p>
+        <div id="lobbyPlayers" class="score-list"></div>
+      </div>
+
+      <p id="lobbyMessage" class="message info">Moderator: wait for players, then start.</p>
     </section>
 
     <section id="playScreen" class="card screen" aria-label="Round play screen">
-      <h2>2) Live Round</h2>
+      <div class="row">
+        <h2 style="margin: 0">Live Round</h2>
+        <span id="playRoleBadge" class="role-badge">Player</span>
+      </div>
+
       <div class="stats">
         <div class="stat">
           <span>Round</span>
@@ -398,43 +446,62 @@
           <span>Solved</span>
           <b id="solvedStat">0</b>
         </div>
+        <div class="stat">
+          <span>Players</span>
+          <b id="playerCountStat">0</b>
+        </div>
       </div>
 
-      <div id="roundMessage" class="message info">Moderator: choose winner after each solved round.</div>
-      <div id="hintBox" class="hint">Hint: <strong>Loading...</strong></div>
-      <div id="scramble" class="scramble" aria-label="Scrambled letters"></div>
-      <div id="answer" class="answer" aria-label="Answer slots"></div>
+      <div id="roundMessage" class="message info">Waiting for moderator to start.</div>
+      <div id="hintBox" class="hint">Hint: <strong>Waiting for round...</strong></div>
 
-      <div class="row">
-        <button id="clearBtn" class="btn btn-secondary" type="button">Clear Answer</button>
-        <button id="submitBtn" class="btn" type="button">Check Answer</button>
-        <button id="skipBtn" class="btn btn-secondary" type="button">Skip Round</button>
+      <div class="grid-2">
+        <div class="card" style="padding: 0.7rem">
+          <h3 style="margin-bottom: 0.6rem">Scramble</h3>
+          <div id="scramble" class="scramble" aria-label="Scrambled letters"></div>
+          <div id="answer" class="answer" aria-label="Answer slots" style="margin-top: 0.65rem"></div>
+          <div class="row" style="margin-top: 0.65rem">
+            <button id="clearBtn" class="btn btn-secondary" type="button">Clear Answer</button>
+          </div>
+          <p class="muted" style="margin-top: 0.45rem">Answer auto-submits when all letters are correct.</p>
+        </div>
+
+        <div class="card" style="padding: 0.7rem">
+          <h3 style="margin-bottom: 0.55rem">Players & Scores</h3>
+          <div id="playPlayers" class="score-list"></div>
+        </div>
       </div>
 
-      <div class="row">
+      <div id="moderatorControls" class="row hidden">
         <button id="openPanelBtn" class="btn btn-secondary" type="button">Open Answer Panel Window</button>
-      </div>
-
-      <div>
-        <h3>Award This Round</h3>
-        <p class="muted">Click the participant who answered first. This ends the current round.</p>
-        <div id="winnerGrid" class="winner-grid"></div>
+        <button id="skipBtn" class="btn btn-secondary" type="button">Skip Round</button>
+        <button id="nextRoundBtn" class="btn" type="button">Start Next Round</button>
+        <button id="endGameBtn" class="btn btn-danger" type="button">End Game</button>
       </div>
     </section>
 
     <section id="scoreScreen" class="card screen" aria-label="Final scoreboard">
-      <h2>3) Final Scoreboard</h2>
+      <h2>Final Scoreboard</h2>
       <p class="muted">Placements use fair shared ranking for ties (1, 1, 3 style).</p>
       <div id="scoreList" class="score-list"></div>
-      <div class="row">
+      <div id="scoreModeratorControls" class="row hidden">
         <button id="playAgainBtn" class="btn" type="button">Play Again</button>
-        <button id="editSetupBtn" class="btn btn-secondary" type="button">Edit Participants</button>
       </div>
+    </section>
+
+    <section id="errorScreen" class="card screen" aria-label="Error screen">
+      <h2>Couldn’t connect</h2>
+      <p id="errorText" class="message error">Multiplayer backend is unavailable.</p>
     </section>
   </main>
 
-  <script>
-    const STORAGE_KEY = 'voa-word-scramble-party-config';
+  <script type="module">
+    const APP_NAME = 'Word Scramble Party';
+    const APP_ID = 'word-scramble';
+    const APP_PATH = '2026/03/06/word-scramble';
+    const SESSION_POLL_MS = 800;
+    const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    const STORAGE_PREFIX = '__STORAGE_PREFIX__';
 
     const WORDS = [
       { word: 'apple', hint: 'A common fruit often in lunch boxes' },
@@ -459,316 +526,248 @@
       { word: 'bright', hint: 'Very full of light' }
     ];
 
-    const setupScreen = document.getElementById('setupScreen');
-    const playScreen = document.getElementById('playScreen');
-    const scoreScreen = document.getElementById('scoreScreen');
+    const screens = {
+      loading: document.getElementById('loadingScreen'),
+      join: document.getElementById('joinScreen'),
+      lobby: document.getElementById('lobbyScreen'),
+      play: document.getElementById('playScreen'),
+      score: document.getElementById('scoreScreen'),
+      error: document.getElementById('errorScreen')
+    };
 
-    const participantInput = document.getElementById('participantInput');
+    const roleBadge = document.getElementById('roleBadge');
+    const playRoleBadge = document.getElementById('playRoleBadge');
     const roundsInput = document.getElementById('roundsInput');
-    const nameList = document.getElementById('nameList');
     const startBtn = document.getElementById('startBtn');
+    const lobbyPlayers = document.getElementById('lobbyPlayers');
+    const lobbyMessage = document.getElementById('lobbyMessage');
+    const joinUrlText = document.getElementById('joinUrlText');
+
+    const joinBtn = document.getElementById('joinBtn');
+    const playerNameInput = document.getElementById('playerNameInput');
+    const joinMessage = document.getElementById('joinMessage');
 
     const roundStat = document.getElementById('roundStat');
     const timerStat = document.getElementById('timerStat');
     const solvedStat = document.getElementById('solvedStat');
+    const playerCountStat = document.getElementById('playerCountStat');
     const roundMessage = document.getElementById('roundMessage');
     const hintBox = document.getElementById('hintBox');
     const scrambleEl = document.getElementById('scramble');
     const answerEl = document.getElementById('answer');
-    const winnerGrid = document.getElementById('winnerGrid');
+    const playPlayers = document.getElementById('playPlayers');
 
+    const moderatorControls = document.getElementById('moderatorControls');
+    const scoreModeratorControls = document.getElementById('scoreModeratorControls');
     const scoreList = document.getElementById('scoreList');
 
-    let participants = [];
-    let roundsTotal = 6;
-    let currentRound = 1;
-    let solvedRounds = 0;
-    let timerLeft = 30;
+    const errorText = document.getElementById('errorText');
+
+    let sessionCode = null;
+    let role = null;
+    let moderatorId = null;
+    let playerId = null;
+    let session = null;
+    let pollHandle = null;
     let timerHandle = null;
-    let activeWord = null;
-    let scramble = [];
-    let answer = [];
-    let usedIndices = new Set();
-    let usedWords = new Set();
-    let roundClosed = false;
+    let pendingAutoSubmit = false;
     let answerPanelWindow = null;
-    let nextSlotIndex = 0;
+
+    let localAnswer = [];
+    let localUsedIndices = new Set();
+
+    function localKey(key) {
+      return `${STORAGE_PREFIX}:word-scramble:${key}`;
+    }
 
     function showScreen(name) {
-      setupScreen.classList.toggle('active', name === 'setup');
-      playScreen.classList.toggle('active', name === 'play');
-      scoreScreen.classList.toggle('active', name === 'score');
-    }
-
-    function persistSetup() {
-      const payload = {
-        names: participants.map((p) => p.name),
-        roundsTotal
-      };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-    }
-
-    function loadSetup() {
-      try {
-        const raw = localStorage.getItem(STORAGE_KEY);
-        if (!raw) return;
-        const data = JSON.parse(raw);
-        const names = Array.isArray(data.names) ? data.names : [];
-        participants = names
-          .filter((name) => typeof name === 'string' && name.trim().length > 0)
-          .slice(0, 12)
-          .map((name, index) => ({ id: index + 1, name: name.trim(), score: 0 }));
-        const parsedRounds = Number.parseInt(data.roundsTotal, 10);
-        roundsTotal = Number.isFinite(parsedRounds) ? Math.min(30, Math.max(1, parsedRounds)) : 6;
-        roundsInput.value = String(roundsTotal);
-      } catch (_error) {
-        participants = [];
-      }
-    }
-
-    function renderParticipants() {
-      nameList.innerHTML = '';
-      participants.forEach((participant, index) => {
-        const pill = document.createElement('div');
-        pill.className = 'pill';
-        pill.textContent = participant.name;
-
-        const removeBtn = document.createElement('button');
-        removeBtn.type = 'button';
-        removeBtn.setAttribute('aria-label', `Remove ${participant.name}`);
-        removeBtn.textContent = 'x';
-        removeBtn.addEventListener('click', () => {
-          participants.splice(index, 1);
-          participants = participants.map((item, idx) => ({ ...item, id: idx + 1 }));
-          renderParticipants();
-          persistSetup();
-          updateStartState();
-        });
-
-        pill.appendChild(removeBtn);
-        nameList.appendChild(pill);
+      Object.entries(screens).forEach(([key, el]) => {
+        el.classList.toggle('active', key === name);
       });
     }
 
-    function updateStartState() {
-      startBtn.disabled = participants.length < 2;
+    function setError(message) {
+      errorText.textContent = message;
+      showScreen('error');
     }
 
-    function addParticipant() {
-      const name = participantInput.value.trim();
-      if (!name) return;
-      if (participants.length >= 12) {
-        showRoundMessage('Participant limit reached (12).', 'warn');
+    function normalize(value) {
+      return String(value || '')
+        .trim()
+        .toLowerCase();
+    }
+
+    function generateSessionCode(length = 6) {
+      let code = '';
+      for (let i = 0; i < length; i += 1) {
+        code += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+      }
+      return code;
+    }
+
+    function generateId(prefix = 'id') {
+      if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return `${prefix}-${crypto.randomUUID()}`;
+      }
+      return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    function hashParams() {
+      return new URLSearchParams(window.location.hash.replace(/^#/, ''));
+    }
+
+    function setHash(params) {
+      window.location.hash = params.toString();
+    }
+
+    async function isMultiplayerConfigured() {
+      const response = await fetch('/api/multiplayer/status', { cache: 'no-store' });
+      if (!response.ok) return false;
+      const payload = await response.json();
+      return Boolean(payload?.configured);
+    }
+
+    async function fetchSession(code) {
+      const response = await fetch(`/api/multiplayer/sessions/${code}`, { cache: 'no-store' });
+      if (response.status === 404) return null;
+      if (!response.ok) throw new Error('Failed to fetch session');
+      const payload = await response.json();
+      return payload?.session || null;
+    }
+
+    async function createSession(code, modId) {
+      const response = await fetch('/api/multiplayer/sessions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          code,
+          appId: APP_ID,
+          appName: APP_NAME,
+          appPath: APP_PATH,
+          moderatorId: modId,
+          settings: { roundsTotal: 6 },
+          status: 'lobby'
+        })
+      });
+      if (response.status === 409) return false;
+      if (!response.ok) throw new Error('Failed to create session');
+      return true;
+    }
+
+    function flattenPatch(prefix, value, out) {
+      if (value === null || value === undefined) {
+        out[prefix] = value;
         return;
       }
-      if (participants.some((item) => item.name.toLowerCase() === name.toLowerCase())) {
-        showRoundMessage('Duplicate participant names are not allowed.', 'warn');
+      const isObject = typeof value === 'object' && !Array.isArray(value);
+      if (!isObject) {
+        out[prefix] = value;
         return;
       }
-      participants.push({ id: participants.length + 1, name, score: 0 });
-      participantInput.value = '';
-      renderParticipants();
-      updateStartState();
-      persistSetup();
-    }
-
-    function shuffleLetters(letters) {
-      const copy = [...letters];
-      for (let i = copy.length - 1; i > 0; i -= 1) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [copy[i], copy[j]] = [copy[j], copy[i]];
+      const entries = Object.entries(value);
+      if (entries.length === 0) {
+        out[prefix] = {};
+        return;
       }
-      return copy;
+      entries.forEach(([key, child]) => {
+        flattenPatch(`${prefix}/${key}`, child, out);
+      });
     }
 
-    function getWordForRound() {
-      const available = WORDS.filter((entry) => !usedWords.has(entry.word));
-      if (available.length === 0) {
-        usedWords.clear();
-        return getWordForRound();
-      }
-      const picked = available[Math.floor(Math.random() * available.length)];
-      usedWords.add(picked.word);
-      return picked;
-    }
-
-    function buildRound() {
-      activeWord = getWordForRound();
-      do {
-        scramble = shuffleLetters(activeWord.word.split(''));
-      } while (scramble.join('') === activeWord.word);
-
-      answer = [];
-      usedIndices = new Set();
-      timerLeft = 30;
-      roundClosed = false;
-
-      roundStat.textContent = `${currentRound} / ${roundsTotal}`;
-      solvedStat.textContent = String(solvedRounds);
-      hintBox.innerHTML = `Hint: <strong>${activeWord.hint}</strong>`;
-      showRoundMessage('Unscramble the word. Moderator awards each round winner.', 'info');
-      renderRoundTiles();
-      renderWinnerButtons();
-      startTimer();
-      updateAnswerPanel();
-    }
-
-    function renderRoundTiles() {
-      timerStat.textContent = String(timerLeft);
-      timerStat.classList.toggle('timer-urgent', timerLeft <= 7);
-
-      nextSlotIndex = answer.length;
-
-      scrambleEl.innerHTML = scramble
-        .map(
-          (letter, index) =>
-            `<button type="button" class="tile letter ${usedIndices.has(index) ? 'used' : ''}" data-index="${index}" aria-label="Letter ${letter}">${letter}</button>`
-        )
-        .join('');
-
-      answerEl.innerHTML = '';
-      for (let i = 0; i < activeWord.word.length; i += 1) {
-        const slotData = answer[i];
-        const slot = document.createElement('button');
-        slot.type = 'button';
-        const isNextSlot = i === nextSlotIndex;
-        slot.className = `tile slot${slotData ? ' filled' : ''}${isNextSlot && !roundClosed ? ' highlight-next' : ''}`;
-        slot.textContent = slotData ? slotData.letter : '';
-        slot.setAttribute('aria-label', slotData ? `Remove ${slotData.letter}` : 'Empty answer slot');
-        if (slotData) {
-          slot.addEventListener('click', () => removeLetter(i));
+    async function patchSession({ status = null, patch = {} } = {}) {
+      if (!sessionCode || !moderatorId) return;
+      const normalizedPatch = {};
+      Object.entries(patch).forEach(([key, value]) => {
+        if (key.includes('/')) {
+          normalizedPatch[key] = value;
         } else {
-          slot.disabled = true;
+          flattenPatch(key, value, normalizedPatch);
         }
-        answerEl.appendChild(slot);
+      });
+
+      const response = await fetch(`/api/multiplayer/sessions/${sessionCode}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ moderatorId, status, patch: normalizedPatch })
+      });
+      if (!response.ok) {
+        throw new Error('Failed to update session');
       }
-
-      scrambleEl.querySelectorAll('button').forEach((button) => {
-        button.addEventListener('click', () => {
-          const idx = Number.parseInt(button.dataset.index, 10);
-          selectLetter(idx);
-        });
-      });
     }
 
-    function renderWinnerButtons() {
-      winnerGrid.innerHTML = '';
-      participants.forEach((participant) => {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'btn';
-        button.textContent = `${participant.name} +1 (${participant.score})`;
-        button.addEventListener('click', () => awardRound(participant.id));
-        winnerGrid.appendChild(button);
+    async function joinSession(code, name) {
+      const response = await fetch(`/api/multiplayer/sessions/${code}/players`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name })
       });
-      const noPoint = document.createElement('button');
-      noPoint.type = 'button';
-      noPoint.className = 'btn btn-secondary';
-      noPoint.textContent = 'No Point This Round';
-      noPoint.addEventListener('click', () => finishRound(null));
-      winnerGrid.appendChild(noPoint);
-    }
-
-    function renderStartNextButton() {
-      winnerGrid.innerHTML = '';
-      if (currentRound >= roundsTotal) {
-        showFinalScoreboard();
-        return;
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload?.error || 'Unable to join session');
       }
-      const startBtn = document.createElement('button');
-      startBtn.type = 'button';
-      startBtn.className = 'btn';
-      startBtn.textContent = 'Start Next Round';
-      startBtn.addEventListener('click', () => {
-        currentRound += 1;
-        buildRound();
+      return response.json();
+    }
+
+    async function submitCorrectAnswer(guess) {
+      if (!sessionCode || !playerId) return;
+      const response = await fetch(`/api/multiplayer/sessions/${sessionCode}/answers`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ playerId, guess })
       });
-      winnerGrid.appendChild(startBtn);
+      if (!response.ok) {
+        throw new Error('Failed to submit answer');
+      }
+      return response.json();
     }
 
-    function selectLetter(index) {
-      if (roundClosed || usedIndices.has(index) || answer.length >= activeWord.word.length) return;
-      usedIndices.add(index);
-      answer.push({ letter: scramble[index], sourceIndex: index });
-      renderRoundTiles();
-      updateAnswerPanel();
+    function playersArray() {
+      if (!session?.players) return [];
+      return Object.values(session.players).sort((a, b) => {
+        const scoreA = Number(a?.score || 0);
+        const scoreB = Number(b?.score || 0);
+        if (scoreB !== scoreA) return scoreB - scoreA;
+        return String(a?.name || '').localeCompare(String(b?.name || ''));
+      });
     }
 
-    function removeLetter(index) {
-      if (roundClosed || !answer[index]) return;
-      usedIndices.delete(answer[index].sourceIndex);
-      answer.splice(index, 1);
-      renderRoundTiles();
-      updateAnswerPanel();
+    function getRoundGame() {
+      return session?.game || null;
     }
 
-    function clearAnswer() {
-      if (roundClosed) return;
-      answer = [];
-      usedIndices = new Set();
-      renderRoundTiles();
-      updateAnswerPanel();
-    }
-
-    function showRoundMessage(text, tone) {
+    function setRoundMessage(text, tone = 'info') {
       roundMessage.className = `message ${tone}`;
       roundMessage.textContent = text;
     }
 
-    function submitAnswer() {
-      if (roundClosed) return;
-      if (answer.length !== activeWord.word.length) {
-        showRoundMessage('Fill every slot before checking the answer.', 'warn');
+    function renderLobbyPlayers() {
+      const players = playersArray();
+      lobbyPlayers.innerHTML = '';
+      if (!players.length) {
+        lobbyPlayers.innerHTML = '<p class="muted">No players connected yet.</p>';
         return;
       }
-      const guess = answer.map((item) => item.letter).join('');
-      if (guess === activeWord.word) {
-        showRoundMessage('Correct answer. Moderator: choose who answered first.', 'success');
-      } else {
-        showRoundMessage('Not correct yet. Keep trying.', 'warn');
-      }
-      updateAnswerPanel();
-    }
-
-    function startTimer() {
-      stopTimer();
-      timerHandle = setInterval(() => {
-        timerLeft -= 1;
-        renderRoundTiles();
-        if (timerLeft <= 0) {
-          stopTimer();
-          showRoundMessage(`Time up. Answer was: ${activeWord.word.toUpperCase()}`, 'warn');
-          finishRound(null);
-        }
-      }, 1000);
-    }
-
-    function stopTimer() {
-      if (!timerHandle) return;
-      clearInterval(timerHandle);
-      timerHandle = null;
-    }
-
-    function awardRound(participantId) {
-      const winner = participants.find((participant) => participant.id === participantId);
-      if (!winner) return;
-      winner.score += 1;
-      solvedRounds += 1;
-      showRoundMessage(`${winner.name} gets this round!`, 'success');
-      finishRound(participantId);
-    }
-
-    function finishRound(_winnerId) {
-      if (roundClosed) return;
-      roundClosed = true;
-      stopTimer();
-      winnerGrid.querySelectorAll('button').forEach((button) => {
-        button.disabled = true;
+      players.forEach((entry) => {
+        const row = document.createElement('div');
+        row.className = 'score-row';
+        row.innerHTML = `<div class="rank">•</div><div>${entry.name}</div><div class="score">${entry.score || 0}</div>`;
+        lobbyPlayers.appendChild(row);
       });
+    }
 
-      setTimeout(() => {
-        renderStartNextButton();
-      }, 900);
+    function renderPlayPlayers() {
+      const players = playersArray();
+      const winnerId = getRoundGame()?.roundWinnerId;
+      playPlayers.innerHTML = '';
+
+      players.forEach((entry, index) => {
+        const rank = index + 1;
+        const winnerLabel = winnerId && winnerId === entry.id ? ' 🏁' : '';
+        const row = document.createElement('div');
+        row.className = 'score-row';
+        row.innerHTML = `<div class="rank">${rank}</div><div>${entry.name}${winnerLabel}</div><div class="score">${entry.score || 0} pts</div>`;
+        playPlayers.appendChild(row);
+      });
     }
 
     function computePlacements(players) {
@@ -776,7 +775,6 @@
         if (b.score !== a.score) return b.score - a.score;
         return a.name.localeCompare(b.name);
       });
-
       let previousScore = null;
       let currentRank = 0;
       return sorted.map((player, index) => {
@@ -784,10 +782,7 @@
           currentRank = index + 1;
         }
         previousScore = player.score;
-        return {
-          ...player,
-          rank: currentRank
-        };
+        return { ...player, rank: currentRank };
       });
     }
 
@@ -798,55 +793,258 @@
       return `${rank}th`;
     }
 
-    function showFinalScoreboard() {
-      stopTimer();
-      showScreen('score');
-      const placements = computePlacements(participants);
+    function renderScoreboard() {
+      const placements = computePlacements(playersArray().map((entry) => ({
+        name: entry.name,
+        score: Number(entry.score || 0)
+      })));
       scoreList.innerHTML = '';
-
       placements.forEach((entry) => {
         const row = document.createElement('div');
         row.className = 'score-row';
-
-        const rank = document.createElement('div');
-        rank.className = 'rank';
-        rank.textContent = `${entry.rank}. ${rankLabel(entry.rank)}`;
-
-        const name = document.createElement('div');
-        name.textContent = entry.name;
-
-        const score = document.createElement('div');
-        score.className = 'score';
-        score.textContent = `${entry.score} pts`;
-
-        row.appendChild(rank);
-        row.appendChild(name);
-        row.appendChild(score);
+        row.innerHTML = `<div class="rank">${entry.rank}. ${rankLabel(entry.rank)}</div><div>${entry.name}</div><div class="score">${entry.score} pts</div>`;
         scoreList.appendChild(row);
       });
     }
 
-    function restartGame() {
-      participants = participants.map((participant) => ({ ...participant, score: 0 }));
-      currentRound = 1;
-      solvedRounds = 0;
-      usedWords = new Set();
-      showScreen('play');
-      buildRound();
+    function resetLocalAnswer() {
+      localAnswer = [];
+      localUsedIndices = new Set();
+      pendingAutoSubmit = false;
     }
 
-    function openAnswerPanel() {
-      answerPanelWindow = window.open('', 'voa-answer-panel', 'width=520,height=620');
-      if (!answerPanelWindow) {
-        showRoundMessage('Popup blocked. Allow popups for moderator panel.', 'warn');
+    function renderTiles() {
+      const game = getRoundGame();
+      const scramble = Array.isArray(game?.scramble) ? game.scramble : [];
+      const answerLength = game?.word ? game.word.length : 0;
+      const locked = !game || session?.status !== 'playing' || game.roundState !== 'active' || role !== 'player';
+
+      scrambleEl.innerHTML = scramble
+        .map((letter, index) => {
+          const used = localUsedIndices.has(index) ? ' used' : '';
+          return `<button type="button" class="tile letter${used}" data-index="${index}" aria-label="Letter ${letter}">${letter}</button>`;
+        })
+        .join('');
+
+      answerEl.innerHTML = '';
+      for (let i = 0; i < answerLength; i += 1) {
+        const slotData = localAnswer[i];
+        const slot = document.createElement('button');
+        slot.type = 'button';
+        slot.className = `tile slot${slotData ? ' filled' : ''}`;
+        slot.textContent = slotData ? slotData.letter : '';
+        slot.disabled = locked || !slotData;
+        if (!locked && slotData) {
+          slot.addEventListener('click', () => removeLetter(i));
+        }
+        answerEl.appendChild(slot);
+      }
+
+      scrambleEl.querySelectorAll('button').forEach((button) => {
+        button.disabled = locked;
+        if (!locked) {
+          button.addEventListener('click', () => {
+            const idx = Number.parseInt(button.dataset.index, 10);
+            selectLetter(idx);
+          });
+        }
+      });
+    }
+
+    async function tryAutoSubmit() {
+      const game = getRoundGame();
+      if (!game || role !== 'player' || pendingAutoSubmit || localAnswer.length !== game.word.length) return;
+      const guess = localAnswer.map((item) => item.letter).join('');
+      if (normalize(guess) !== normalize(game.word)) {
+        setRoundMessage('Not correct yet. Keep trying.', 'warn');
         return;
       }
-      updateAnswerPanel();
+      pendingAutoSubmit = true;
+      try {
+        const result = await submitCorrectAnswer(guess);
+        if (result?.alreadyAwarded) {
+          setRoundMessage(`${result.winnerName || 'Another player'} already solved first.`, 'warn');
+        } else if (result?.correct) {
+          setRoundMessage('Correct! Waiting for room sync...', 'success');
+        }
+      } catch {
+        setRoundMessage('Could not submit answer. Try again.', 'error');
+      } finally {
+        pendingAutoSubmit = false;
+      }
     }
 
-    function updateAnswerPanel() {
-      if (!answerPanelWindow || answerPanelWindow.closed || !activeWord) return;
-      const partialAnswer = answer.map((entry) => entry.letter).join('').toUpperCase();
+    function selectLetter(index) {
+      const game = getRoundGame();
+      const scramble = Array.isArray(game?.scramble) ? game.scramble : [];
+      if (!game || role !== 'player' || game.roundState !== 'active') return;
+      if (localUsedIndices.has(index) || localAnswer.length >= game.word.length) return;
+      localUsedIndices.add(index);
+      localAnswer.push({ letter: scramble[index], sourceIndex: index });
+      renderTiles();
+      tryAutoSubmit();
+    }
+
+    function removeLetter(index) {
+      const game = getRoundGame();
+      if (!game || role !== 'player' || game.roundState !== 'active') return;
+      const removed = localAnswer[index];
+      if (!removed) return;
+      localUsedIndices.delete(removed.sourceIndex);
+      localAnswer.splice(index, 1);
+      renderTiles();
+    }
+
+    function clearAnswer() {
+      const game = getRoundGame();
+      if (!game || role !== 'player' || game.roundState !== 'active') return;
+      resetLocalAnswer();
+      renderTiles();
+    }
+
+    function updateJoinBox() {
+      if (!sessionCode) return;
+      const url = `${window.location.origin}${window.location.pathname}#join=${sessionCode}`;
+      joinUrlText.textContent = url;
+    }
+
+    function saveModeratorRecord(code, id) {
+      try {
+        window.localStorage.setItem(localKey(`mod:${code}`), JSON.stringify({ moderatorId: id }));
+      } catch {
+        // ignore
+      }
+    }
+
+    function loadModeratorRecord(code) {
+      try {
+        const raw = window.localStorage.getItem(localKey(`mod:${code}`));
+        return raw ? JSON.parse(raw) : null;
+      } catch {
+        return null;
+      }
+    }
+
+    function getRandomWord(usedWordKeys = []) {
+      const used = new Set(Array.isArray(usedWordKeys) ? usedWordKeys : []);
+      const available = WORDS.filter((entry) => !used.has(entry.word));
+      const source = available.length ? available : WORDS;
+      const picked = source[Math.floor(Math.random() * source.length)];
+      return picked;
+    }
+
+    function shuffleLetters(word) {
+      const letters = word.split('');
+      for (let i = letters.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [letters[i], letters[j]] = [letters[j], letters[i]];
+      }
+      if (letters.join('') === word) {
+        letters.reverse();
+      }
+      return letters;
+    }
+
+    async function startRound(roundNumber, roundsTotal, usedWords = []) {
+      const picked = getRandomWord(usedWords);
+      const scramble = shuffleLetters(picked.word);
+      const now = Date.now();
+      const roundSeconds = 30;
+
+      await patchSession({
+        patch: {
+          settings: { roundsTotal },
+          game: {
+            roundNumber,
+            roundsTotal,
+            solvedRounds: Number(session?.game?.solvedRounds || 0),
+            roundState: 'active',
+            word: picked.word,
+            hint: picked.hint,
+            scramble,
+            roundWinnerId: null,
+            roundWinnerName: null,
+            roundWinnerAt: null,
+            announcement: 'Round is live. First correct answer wins automatically.',
+            usedWords: [...usedWords, picked.word],
+            roundStartedAt: new Date(now).toISOString(),
+            roundEndsAt: new Date(now + roundSeconds * 1000).toISOString()
+          }
+        },
+        status: 'playing'
+      });
+    }
+
+    async function moderatorStartGame() {
+      const roundsTotal = Math.min(30, Math.max(1, Number.parseInt(roundsInput.value, 10) || 6));
+      roundsInput.value = String(roundsTotal);
+      const players = playersArray();
+      if (players.length < 2) {
+        lobbyMessage.className = 'message warn';
+        lobbyMessage.textContent = 'Need at least two players before starting.';
+        return;
+      }
+      startBtn.disabled = true;
+      try {
+        await startRound(1, roundsTotal, []);
+      } catch {
+        lobbyMessage.className = 'message error';
+        lobbyMessage.textContent = 'Could not start game.';
+      } finally {
+        startBtn.disabled = false;
+      }
+    }
+
+    async function skipRound() {
+      const game = getRoundGame();
+      if (!game || role !== 'moderator' || game.roundState !== 'active') return;
+      await patchSession({
+        patch: {
+          game: {
+            ...game,
+            roundState: 'between',
+            announcement: `Round skipped. Answer was ${String(game.word || '').toUpperCase()}.`
+          }
+        }
+      });
+    }
+
+    async function startNextRound() {
+      const game = getRoundGame();
+      if (!game || role !== 'moderator') return;
+      const current = Number(game.roundNumber || 1);
+      const total = Number(game.roundsTotal || session?.settings?.roundsTotal || 6);
+      if (current >= total) {
+        await patchSession({ status: 'ended' });
+        return;
+      }
+      await startRound(current + 1, total, game.usedWords || []);
+    }
+
+    async function playAgain() {
+      if (role !== 'moderator') return;
+      const total = Number(session?.settings?.roundsTotal || 6);
+      const players = playersArray();
+      const nextPlayers = {};
+      players.forEach((entry) => {
+        nextPlayers[entry.id] = { ...entry, score: 0 };
+      });
+
+      await patchSession({
+        patch: { players: nextPlayers, game: null },
+        status: 'lobby'
+      });
+      await startRound(1, total, []);
+    }
+
+    async function endGameNow() {
+      if (role !== 'moderator') return;
+      await patchSession({ status: 'ended' });
+    }
+
+    function renderModeratorPanel() {
+      const game = getRoundGame();
+      if (!answerPanelWindow || answerPanelWindow.closed || !game) return;
       answerPanelWindow.document.open();
       answerPanelWindow.document.write(`<!DOCTYPE html>
 <html lang="en">
@@ -863,100 +1061,364 @@
 </head>
 <body>
   <h1>Moderator Answer Panel</h1>
-  <div class="card"><h2>Round</h2><div><b>${currentRound}</b> / ${roundsTotal}</div></div>
-  <div class="card"><h2>Hint</h2><div>${activeWord.hint}</div></div>
-  <div class="card"><h2>Answer</h2><div><b>${activeWord.word.toUpperCase()}</b></div></div>
-  <div class="card"><h2>Current Guess</h2><div>${partialAnswer || '-'}</div></div>
-  <div class="card"><h2>Timer</h2><div>${timerLeft}s</div></div>
+  <div class="card"><h2>Round</h2><div><b>${game.roundNumber || 1}</b> / ${game.roundsTotal || 1}</div></div>
+  <div class="card"><h2>Hint</h2><div>${game.hint || '-'}</div></div>
+  <div class="card"><h2>Answer</h2><div><b>${String(game.word || '').toUpperCase()}</b></div></div>
+  <div class="card"><h2>Winner</h2><div>${game.roundWinnerName || '-'}</div></div>
+  <div class="card"><h2>Status</h2><div>${game.announcement || '-'}</div></div>
 </body>
 </html>`);
       answerPanelWindow.document.close();
     }
 
-    function startGame() {
-      roundsTotal = Number.parseInt(roundsInput.value, 10);
-      if (!Number.isFinite(roundsTotal) || roundsTotal < 1 || roundsTotal > 30) {
-        showRoundMessage('Rounds must be between 1 and 30.', 'warn');
+    function openAnswerPanel() {
+      answerPanelWindow = window.open('', 'voa-answer-panel', 'width=520,height=620');
+      if (!answerPanelWindow) {
+        setRoundMessage('Popup blocked. Allow popups for moderator panel.', 'warn');
         return;
       }
-      participants = participants.map((participant, index) => ({
-        id: index + 1,
-        name: participant.name,
-        score: 0
-      }));
-
-      persistSetup();
-      usedWords = new Set();
-      currentRound = 1;
-      solvedRounds = 0;
-      showScreen('play');
-      buildRound();
+      renderModeratorPanel();
     }
 
-    function setupKeyboardSupport() {
-      document.addEventListener('keydown', (event) => {
-        const tag = document.activeElement ? document.activeElement.tagName : '';
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-        if (!playScreen.classList.contains('active')) return;
-        if (event.key === 'Enter') {
-          submitAnswer();
-          return;
+    function updateScreenBySession() {
+      const players = playersArray();
+      const game = getRoundGame();
+
+      roleBadge.textContent = role === 'moderator' ? 'Moderator' : 'Player';
+      playRoleBadge.textContent = role === 'moderator' ? 'Moderator' : 'Player';
+
+      if (!session) {
+        showScreen('loading');
+        return;
+      }
+
+      renderLobbyPlayers();
+      renderPlayPlayers();
+      playerCountStat.textContent = String(players.length);
+
+      if (session.status === 'lobby' || !game) {
+        updateJoinBox();
+        showScreen(role === 'moderator' ? 'lobby' : 'join');
+        lobbyMessage.className = 'message info';
+        lobbyMessage.textContent = 'Moderator: wait for players, then start.';
+        moderatorControls.classList.add('hidden');
+        scoreModeratorControls.classList.add('hidden');
+        return;
+      }
+
+      if (session.status === 'ended') {
+        showScreen('score');
+        renderScoreboard();
+        scoreModeratorControls.classList.toggle('hidden', role !== 'moderator');
+        return;
+      }
+
+      showScreen('play');
+      moderatorControls.classList.toggle('hidden', role !== 'moderator');
+
+      const roundNumber = Number(game.roundNumber || 1);
+      const roundsTotal = Number(game.roundsTotal || 1);
+      const solved = Number(game.solvedRounds || 0);
+      const winnerName = game.roundWinnerName;
+
+      roundStat.textContent = `${roundNumber} / ${roundsTotal}`;
+      solvedStat.textContent = String(solved);
+      hintBox.innerHTML = `Hint: <strong>${game.hint || 'Loading...'}</strong>`;
+
+      const now = Date.now();
+      const endsAt = Date.parse(game.roundEndsAt || '') || now;
+      const left = Math.max(0, Math.ceil((endsAt - now) / 1000));
+      timerStat.textContent = String(left);
+      timerStat.classList.toggle('timer-urgent', left <= 7);
+
+      if (game.roundState === 'active') {
+        if (winnerName) {
+          setRoundMessage(`${winnerName} answered correctly first.`, 'success');
+        } else {
+          setRoundMessage(game.announcement || 'Round is live.', 'info');
         }
-        if (event.key === 'Backspace') {
-          if (answer.length > 0) {
-            removeLetter(answer.length - 1);
+      } else {
+        setRoundMessage(game.announcement || 'Round complete.', winnerName ? 'success' : 'warn');
+      }
+
+      document.getElementById('nextRoundBtn').disabled = !(role === 'moderator' && game.roundState !== 'active');
+      document.getElementById('skipBtn').disabled = !(role === 'moderator' && game.roundState === 'active');
+      document.getElementById('openPanelBtn').disabled = role !== 'moderator';
+
+      renderTiles();
+      renderModeratorPanel();
+    }
+
+    function startPolling() {
+      if (pollHandle) {
+        clearInterval(pollHandle);
+      }
+      const tick = async () => {
+        if (!sessionCode) return;
+        try {
+          session = await fetchSession(sessionCode);
+          if (!session) {
+            setError('This game session no longer exists.');
+            return;
           }
-          return;
-        }
-        if (event.key === 'Escape') {
-          clearAnswer();
-          return;
-        }
-        if (/^[a-zA-Z]$/.test(event.key)) {
-          const letter = event.key.toLowerCase();
-          const idx = scramble.findIndex((item, index) => item === letter && !usedIndices.has(index));
-          if (idx >= 0) {
-            selectLetter(idx);
+
+          if (role === 'player' && playerId && !session.players?.[playerId]) {
+            setError('Your player record no longer exists. Rejoin from the host link.');
+            return;
           }
+
+          if (role === 'moderator') {
+            const game = getRoundGame();
+            const now = Date.now();
+            const endsAt = Date.parse(game?.roundEndsAt || '') || now;
+            const expired = now >= endsAt;
+            if (session.status === 'playing' && game?.roundState === 'active' && expired) {
+              await skipRound();
+            }
+          }
+
+          updateScreenBySession();
+        } catch {
+          setError('Connection lost while syncing multiplayer state.');
+        }
+      };
+
+      tick();
+      pollHandle = setInterval(tick, SESSION_POLL_MS);
+    }
+
+    function startTimerUiTick() {
+      if (timerHandle) {
+        clearInterval(timerHandle);
+      }
+      timerHandle = setInterval(() => {
+        if (screens.play.classList.contains('active')) {
+          updateScreenBySession();
+        }
+      }, 1000);
+    }
+
+    async function createModeratorSession() {
+      let created = false;
+      for (let attempt = 0; attempt < 8; attempt += 1) {
+        const code = generateSessionCode(6);
+        const id = generateId('mod');
+        // eslint-disable-next-line no-await-in-loop
+        const ok = await createSession(code, id);
+        if (!ok) {
+          continue;
+        }
+        sessionCode = code;
+        moderatorId = id;
+        role = 'moderator';
+        saveModeratorRecord(code, id);
+        const params = new URLSearchParams({ code, role: 'moderator' });
+        setHash(params);
+        created = true;
+        break;
+      }
+      if (!created) {
+        throw new Error('Could not create session');
+      }
+    }
+
+    async function reconnectModerator(code) {
+      const saved = loadModeratorRecord(code);
+      if (!saved?.moderatorId) {
+        await createModeratorSession();
+        return;
+      }
+      const existing = await fetchSession(code);
+      if (!existing || existing.moderatorId !== saved.moderatorId) {
+        await createModeratorSession();
+        return;
+      }
+      sessionCode = code;
+      moderatorId = saved.moderatorId;
+      role = 'moderator';
+    }
+
+    async function reconnectPlayer(code, pid) {
+      const existing = await fetchSession(code);
+      if (!existing || !existing.players?.[pid]) {
+        const params = new URLSearchParams({ join: code });
+        setHash(params);
+        showScreen('join');
+        role = 'player';
+        sessionCode = code;
+        playerId = null;
+        return;
+      }
+      role = 'player';
+      sessionCode = code;
+      playerId = pid;
+    }
+
+    async function bootstrap() {
+      showScreen('loading');
+      const configured = await isMultiplayerConfigured();
+      if (!configured) {
+        setError('Multiplayer backend is not configured on this deployment.');
+        return;
+      }
+
+      const params = hashParams();
+      const joinCode = params.get('join');
+      const code = params.get('code');
+      const hashRole = params.get('role');
+      const pid = params.get('pid');
+
+      if (hashRole === 'player' && code && pid) {
+        await reconnectPlayer(code, pid);
+        startPolling();
+        startTimerUiTick();
+        return;
+      }
+
+      if (joinCode) {
+        role = 'player';
+        sessionCode = joinCode.toUpperCase();
+        showScreen('join');
+        return;
+      }
+
+      if (hashRole === 'moderator' && code) {
+        await reconnectModerator(code.toUpperCase());
+      } else {
+        await createModeratorSession();
+      }
+
+      startPolling();
+      startTimerUiTick();
+    }
+
+    document.getElementById('copyJoinLinkBtn').addEventListener('click', async () => {
+      const url = joinUrlText.textContent || '';
+      if (!url || url === '—') return;
+      try {
+        await navigator.clipboard.writeText(url);
+        lobbyMessage.className = 'message success';
+        lobbyMessage.textContent = 'Join link copied.';
+      } catch {
+        lobbyMessage.className = 'message warn';
+        lobbyMessage.textContent = 'Could not copy link.';
+      }
+    });
+
+    const shareBtn = document.getElementById('shareJoinLinkBtn');
+    if (typeof navigator.share === 'function') {
+      shareBtn.addEventListener('click', async () => {
+        const url = joinUrlText.textContent || '';
+        if (!url || url === '—') return;
+        try {
+          await navigator.share({
+            title: `${APP_NAME} — join my game`,
+            text: `Join my ${APP_NAME} game (${sessionCode}):`,
+            url
+          });
+        } catch {
+          // ignored
         }
       });
+    } else {
+      shareBtn.classList.add('hidden');
     }
 
-    document.getElementById('addParticipantBtn').addEventListener('click', addParticipant);
-    participantInput.addEventListener('keydown', (event) => {
+    joinBtn.addEventListener('click', async () => {
+      const name = playerNameInput.value.trim();
+      if (!name) {
+        joinMessage.className = 'message warn';
+        joinMessage.textContent = 'Please enter your name.';
+        return;
+      }
+      joinBtn.disabled = true;
+      try {
+        const response = await joinSession(sessionCode, name);
+        playerId = response.playerId;
+        role = 'player';
+        const params = new URLSearchParams({
+          code: sessionCode,
+          role: 'player',
+          pid: playerId
+        });
+        setHash(params);
+        startPolling();
+        startTimerUiTick();
+      } catch (error) {
+        joinMessage.className = 'message error';
+        joinMessage.textContent = error.message || 'Unable to join game.';
+      } finally {
+        joinBtn.disabled = false;
+      }
+    });
+
+    playerNameInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
         event.preventDefault();
-        addParticipant();
+        joinBtn.click();
       }
     });
 
     roundsInput.addEventListener('change', () => {
       const value = Number.parseInt(roundsInput.value, 10);
       if (Number.isFinite(value)) {
-        roundsTotal = Math.min(30, Math.max(1, value));
-        roundsInput.value = String(roundsTotal);
-        persistSetup();
+        roundsInput.value = String(Math.min(30, Math.max(1, value)));
       }
     });
 
-    startBtn.addEventListener('click', startGame);
-    document.getElementById('clearBtn').addEventListener('click', clearAnswer);
-    document.getElementById('submitBtn').addEventListener('click', submitAnswer);
-    document.getElementById('skipBtn').addEventListener('click', () => {
-      showRoundMessage(`Round skipped. Answer was ${activeWord.word.toUpperCase()}.`, 'warn');
-      finishRound(null);
-    });
-    document.getElementById('openPanelBtn').addEventListener('click', openAnswerPanel);
-    document.getElementById('playAgainBtn').addEventListener('click', restartGame);
-    document.getElementById('editSetupBtn').addEventListener('click', () => {
-      stopTimer();
-      showScreen('setup');
+    startBtn.addEventListener('click', () => {
+      moderatorStartGame();
     });
 
-    loadSetup();
-    renderParticipants();
-    updateStartState();
-    setupKeyboardSupport();
+    document.getElementById('clearBtn').addEventListener('click', clearAnswer);
+    document.getElementById('openPanelBtn').addEventListener('click', openAnswerPanel);
+    document.getElementById('skipBtn').addEventListener('click', () => {
+      skipRound();
+    });
+    document.getElementById('nextRoundBtn').addEventListener('click', () => {
+      startNextRound();
+    });
+    document.getElementById('playAgainBtn').addEventListener('click', () => {
+      playAgain();
+    });
+    document.getElementById('endGameBtn').addEventListener('click', () => {
+      endGameNow();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (!screens.play.classList.contains('active')) return;
+      if (role !== 'player') return;
+      const tag = document.activeElement ? document.activeElement.tagName : '';
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+      if (event.key === 'Backspace') {
+        event.preventDefault();
+        if (localAnswer.length > 0) {
+          removeLetter(localAnswer.length - 1);
+        }
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        clearAnswer();
+        return;
+      }
+
+      if (/^[a-zA-Z]$/.test(event.key)) {
+        const game = getRoundGame();
+        const scramble = Array.isArray(game?.scramble) ? game.scramble : [];
+        const letter = event.key.toLowerCase();
+        const idx = scramble.findIndex((item, index) => item === letter && !localUsedIndices.has(index));
+        if (idx >= 0) {
+          selectLetter(idx);
+        }
+      }
+    });
+
+    bootstrap().catch(() => {
+      setError('Unable to initialize multiplayer room.');
+    });
   </script>
 </body>
 </html>

--- a/apps/2026/03/06/word-scramble/thumbnail.svg
+++ b/apps/2026/03/06/word-scramble/thumbnail.svg
@@ -1,95 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Word Scramble Party multiplayer lobby and live round">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0f172a" />
-      <stop offset="100%" stop-color="#1e293b" />
+    <linearGradient id="bg" x1="120" y1="40" x2="1080" y2="590" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B1732"/>
+      <stop offset="1" stop-color="#102A4F"/>
     </linearGradient>
-    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#22d3ee" />
-      <stop offset="100%" stop-color="#0284c7" />
+    <linearGradient id="card" x1="240" y1="120" x2="980" y2="520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#152946"/>
+      <stop offset="1" stop-color="#1B3558"/>
     </linearGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="5" result="blur" />
-      <feOffset in="blur" dx="0" dy="4" result="offsetBlur" />
-      <feFlood flood-color="#020617" flood-opacity="0.45" result="shadowColor" />
-      <feComposite in="shadowColor" in2="offsetBlur" operator="in" result="shadow" />
-      <feMerge>
-        <feMergeNode in="shadow" />
-        <feMergeNode in="SourceGraphic" />
-      </feMerge>
-    </filter>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#22D3EE"/>
+      <stop offset="1" stop-color="#38BDF8"/>
+    </linearGradient>
   </defs>
 
-  <rect x="0" y="0" width="800" height="450" fill="url(#bg)" />
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="160" cy="120" r="120" fill="#22D3EE" fill-opacity="0.14"/>
+  <circle cx="1060" cy="90" r="140" fill="#38BDF8" fill-opacity="0.12"/>
 
-  <rect x="26" y="18" width="748" height="62" rx="14" fill="#15213e" stroke="#334155" />
-  <text x="50" y="56" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="30" font-weight="700">
-    Word Scramble Party
-  </text>
-  <text x="748" y="56" text-anchor="end" fill="#67e8f9" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="20" font-weight="700">
-    Round 3/8
-  </text>
+  <rect x="118" y="82" width="964" height="466" rx="28" fill="url(#card)" stroke="#2E4A70" stroke-width="2"/>
 
-  <rect x="40" y="100" width="510" height="310" rx="18" fill="#15213e" stroke="#334155" filter="url(#softShadow)" />
+  <text x="164" y="152" fill="#F8FAFC" font-size="56" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">Word Scramble Party</text>
+  <text x="164" y="190" fill="#A5B4CF" font-size="24" font-family="Trebuchet MS, Segoe UI, sans-serif">Multiplayer host link + realtime first-correct scoring</text>
 
-  <rect x="62" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
-  <text x="76" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Timer</text>
-  <text x="76" y="172" fill="#f43f5e" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">11s</text>
+  <rect x="164" y="230" width="430" height="278" rx="18" fill="#0E223C" stroke="#2F4F75"/>
+  <text x="192" y="270" fill="#67E8F9" font-size="26" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">Lobby</text>
+  <text x="192" y="307" fill="#E2E8F0" font-size="20" font-family="Trebuchet MS, Segoe UI, sans-serif">Join URL: ...#join=AB3K9Q</text>
+  <rect x="192" y="330" width="182" height="46" rx="10" fill="url(#accent)"/>
+  <text x="224" y="360" fill="#042035" font-size="22" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">Start Game</text>
+  <text x="192" y="407" fill="#A5B4CF" font-size="20" font-family="Trebuchet MS, Segoe UI, sans-serif">Players: Alex, Kim, Sam</text>
+  <text x="192" y="439" fill="#A5B4CF" font-size="20" font-family="Trebuchet MS, Segoe UI, sans-serif">Rounds: 6</text>
 
-  <rect x="224" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
-  <text x="238" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Solved</text>
-  <text x="238" y="172" fill="#22d3ee" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">2</text>
+  <rect x="618" y="230" width="420" height="278" rx="18" fill="#0E223C" stroke="#2F4F75"/>
+  <text x="646" y="270" fill="#67E8F9" font-size="26" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">Live Round</text>
+  <text x="646" y="306" fill="#E2E8F0" font-size="20" font-family="Trebuchet MS, Segoe UI, sans-serif">Hint: Earth is one of these</text>
 
-  <rect x="386" y="122" width="145" height="62" rx="12" fill="#1e293b" stroke="#334155" />
-  <text x="400" y="148" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="14">Hint</text>
-  <text x="400" y="172" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16" font-weight="700">Color + Fruit</text>
+  <rect x="646" y="330" width="50" height="58" rx="10" fill="url(#accent)"/>
+  <rect x="703" y="330" width="50" height="58" rx="10" fill="url(#accent)"/>
+  <rect x="760" y="330" width="50" height="58" rx="10" fill="url(#accent)"/>
+  <rect x="817" y="330" width="50" height="58" rx="10" fill="url(#accent)"/>
+  <rect x="874" y="330" width="50" height="58" rx="10" fill="url(#accent)"/>
+  <rect x="931" y="330" width="50" height="58" rx="10" fill="url(#accent)"/>
 
-  <g filter="url(#softShadow)">
-    <rect x="86" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
-    <rect x="150" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
-    <rect x="214" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
-    <rect x="278" y="214" width="56" height="64" rx="10" fill="url(#tile)" />
-    <rect x="342" y="214" width="56" height="64" rx="10" fill="url(#tile)" opacity="0.38" />
-    <rect x="406" y="214" width="56" height="64" rx="10" fill="url(#tile)" opacity="0.38" />
-  </g>
-  <text x="114" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">O</text>
-  <text x="178" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">R</text>
-  <text x="242" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">A</text>
-  <text x="306" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">N</text>
-  <text x="370" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">G</text>
-  <text x="434" y="255" text-anchor="middle" fill="#ffffff" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="28" font-weight="700">E</text>
+  <text x="661" y="368" fill="#06223A" font-size="28" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">P</text>
+  <text x="718" y="368" fill="#06223A" font-size="28" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">A</text>
+  <text x="775" y="368" fill="#06223A" font-size="28" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">T</text>
+  <text x="832" y="368" fill="#06223A" font-size="28" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">N</text>
+  <text x="889" y="368" fill="#06223A" font-size="28" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">L</text>
+  <text x="946" y="368" fill="#06223A" font-size="28" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">E</text>
 
-  <rect x="86" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
-  <rect x="150" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
-  <rect x="214" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
-  <rect x="278" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
-  <rect x="342" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
-  <rect x="406" y="294" width="56" height="62" rx="10" fill="#1e293b" stroke="#334155" />
-  <text x="114" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">O</text>
-  <text x="178" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">R</text>
-  <text x="242" y="335" text-anchor="middle" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="26" font-weight="700">A</text>
-
-  <rect x="572" y="100" width="188" height="310" rx="18" fill="#15213e" stroke="#334155" filter="url(#softShadow)" />
-  <text x="666" y="128" text-anchor="middle" fill="#67e8f9" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="20" font-weight="700">
-    Scoreboard
-  </text>
-
-  <rect x="588" y="146" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
-  <text x="604" y="170" fill="#facc15" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="18" font-weight="700">1. Gold</text>
-  <text x="730" y="170" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Alex 2</text>
-  <text x="730" y="188" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Casey 2</text>
-
-  <rect x="588" y="208" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
-  <text x="604" y="238" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="18" font-weight="700">3. Bronze</text>
-  <text x="730" y="238" text-anchor="end" fill="#f8fafc" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16">Riley 1</text>
-
-  <rect x="588" y="270" width="156" height="52" rx="10" fill="#1e293b" stroke="#334155" />
-  <text x="666" y="302" text-anchor="middle" fill="#94a3b8" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="15">
-    Moderator Panel
-  </text>
-
-  <rect x="588" y="336" width="156" height="52" rx="10" fill="#0f172a" stroke="#22d3ee" />
-  <text x="666" y="366" text-anchor="middle" fill="#22d3ee" font-family="Trebuchet MS, Segoe UI, sans-serif" font-size="16" font-weight="700">
-    Answer: ORANGE
-  </text>
+  <text x="646" y="430" fill="#A7F3D0" font-size="22" font-family="Trebuchet MS, Segoe UI, sans-serif" font-weight="700">Alex answered correctly first!</text>
+  <text x="646" y="463" fill="#A5B4CF" font-size="20" font-family="Trebuchet MS, Segoe UI, sans-serif">Score auto-awarded +1</text>
 </svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -2921,6 +2921,16 @@
         "implementedAt": "2026-04-18T17:01:51Z",
         "agentName": "GitHub Copilot",
         "llmModel": "Claude Haiku 4.5"
+      },
+      {
+        "issueNumber": 362,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/362",
+        "runId": "run-20260419T220321Z-f36990",
+        "description": "Migrated Word Scramble to multiplayer backend sessions with moderator share-link lobby, player name join, realtime synchronized rounds/scores, and automatic first-correct score awarding.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-04-19T22:03:21Z",
+        "agentName": "Codex",
+        "llmModel": "GPT-5.4"
       }
     ],
     "allowImprovements": true,
@@ -2935,6 +2945,11 @@
         "runId": "run-20260418T165927Z-a7f2c9",
         "path": "backups/run-20260418T165927Z-a7f2c9/index.html",
         "url": "/apps/2026/03/06/word-scramble/backups/run-20260418T165927Z-a7f2c9/index.html"
+      },
+      {
+        "runId": "run-20260419T220321Z-f36990",
+        "path": "backups/run-20260419T220321Z-f36990/index.html",
+        "url": "/apps/2026/03/06/word-scramble/backups/run-20260419T220321Z-f36990/index.html"
       }
     ]
   },


### PR DESCRIPTION
Closes #362

## What changed
- Migrated Word Scramble to the multiplayer backend session flow.
- Moderator now gets a generated share link, lobby player roster, rounds setting, and Start Game control.
- Player links open a join-by-name flow and connect into the same live session.
- Moderator and player screens now show synced player names, round/timer state, and realtime winner/result announcements.
- Added automatic answer submission behavior: when a player fills all letters correctly, submission is sent automatically and the first correct player gets +1.
- Retained moderator controls in-session: Open Answer Panel Window, Skip Round, and Start Next Round.
- Added  endpoint to record player answer submissions and award first-correct scoring.

## Preserved behavior checks
- Existing shell/meta tags remain intact.
- Tie-aware final scoreboard remains in place.

## Required backup snapshot included
- 
- 
- 

## Validation
Passed:
- 
> valley-of-ai@0.2.0 generate:apps
> node scripts/generate-apps.mjs

🔍 Scanning for apps...
   Found 77 app(s)
   ✅ Team Taboo (2026/04/18/team-taboo)
   ✅ Alibi (2026/04/17/alibi)
   ✅ Mental Gymnastics (2026/04/16/mental-gymnastics)
   ✅ Missile Command Modern (2026/04/14/missile-command-modern)
   ✅ Benchmark Breakout Opus (2026/04/11/benchmark-breakout-opus)
   ✅ Benchmark Breakout Turbo (2026/04/10/benchmark-breakout-turbo)
   ✅ Benchmark Breakout (2026/04/10/benchmark-breakout)
   ✅ Asteroids Modern (2026/04/08/asteroids-modern)
   ✅ Plasma Chain Reaction (2026/04/04/plasma-chain-reaction)
   ✅ Emoji Quiz Party (2026/04/01/emoji-quiz-party)
   ✅ 2 Truths and a Lie (2026/03/31/two-truths-lie-game)
   ✅ Sokoban Warehouse (2026/03/26/sokoban-warehouse)
   ✅ Galaxian Blitz (2026/03/26/galaxian-blitz)
   ✅ Neon Slot Rush (2026/03/25/neon-slot-rush)
   ✅ Peg Solitaire (2026/03/25/peg-solitaire)
   ✅ Charades Chaos Deck (2026/03/24/charades-chaos-deck)
   ✅ Dungeon Puzzle Run (2026/03/23/dungeon-puzzle-run)
   ✅ Tic-Tac-Toe Strategy Lab (2026/03/23/tic-tac-toe-strategy-lab)
   ✅ Texas Lotto Generator (2026/03/21/texas-lotto-generator)
   ✅ Neighborhood Home Ranker (2026/03/21/neighborhood-home-ranker)
   ✅ Tetris Classic (2026/03/21/tetris-classic)
   ✅ Morse Code Radio (2026/03/21/morse-code-radio)
   ✅ Pattern Pulse Memory (2026/03/21/pattern-pulse-memory)
   ✅ Sudoku Sprint (2026/03/20/sudoku-sprint)
   ✅ Slide 2048 (2026/03/19/slide-2048)
   ✅ Orbit Memory Match (2026/03/19/orbit-memory-match)
   ✅ Cyber Hop (2026/03/18/cyber-hop)
   ✅ Hangman Word Game (2026/03/17/hangman-word-game)
   ✅ Focus Timer (2026/03/17/focus-timer)
   ✅ Mindful Breathing Tracker (2026/03/16/mindful-breathing-tracker)
   ✅ Focus Sprint Planner (2026/03/15/focus-sprint-planner)
   ✅ Hydration Nudge Tracker (2026/03/15/hydration-nudge-tracker)
   ✅ Decision Spinner (2026/03/14/decision-spinner)
   ✅ Password Entropy Lab (2026/03/14/password-entropy-lab)
   ✅ Interval Breathing Coach (2026/03/13/interval-breathing-coach)
   ✅ Bubble Tap (2026/03/13/bubble-tap)
   ✅ Meeting Cost Calculator (2026/03/12/meeting-cost-calculator)
   ✅ Timezone Overlap Finder (2026/03/12/timezone-overlap-finder)
   ✅ Constellation Explorer (2026/03/12/constellation-explorer)
   ✅ Sorting Race Visualizer (2026/03/12/sorting-race-visualizer)
   ✅ Lucky Decision Wheel (2026/03/11/lucky-decision-wheel)
   ✅ Habit Streak Garden (2026/03/10/habit-streak-garden)
   ✅ Neon Breakout (2026/03/10/neon-breakout)
   ✅ Pixel Painter (2026/03/10/pixel-painter)
   ✅ Gravity Dodge (2026/03/09/gravity-dodge)
   ✅ Typing Speed Sprint (2026/03/08/typing-speed-sprint)
   ✅ Daredevil Moto Jump (2026/03/08/daredevil-moto-jump)
   ✅ Mini Putt Gauntlet (2026/03/08/mini-putt-gauntlet)
   ✅ Eagle Eye Teacher (2026/03/08/eagle-eye-teacher)
   ✅ Logic Lights Out (2026/03/08/logic-lights-out)
   ✅ Space Invaders Clone (2026/03/08/space-invaders-clone)
   ✅ Workout Timer Pulse (2026/03/07/workout-timer-pulse)
   ✅ Road Rage (2026/03/07/road-rage)
   ✅ Fishing Frenzy (2026/03/07/fishing-frenzy)
   ✅ Design Dash (2026/03/07/design-dash)
   ✅ Realtor Tycoon (2026/03/07/realtor-tycoon)
   ✅ Lantern of Hollowmere (2026/03/07/zorkish-text-adventure)
   ✅ Halftime Hustle (2026/03/07/halftime-hustle)
   ✅ Pacman Classic (2026/03/07/pacman-classic)
   ✅ Debug Rush (2026/03/07/debug-rush)
   ✅ Blackjack (2026/03/07/blackjack)
   ✅ Archery Physics (2026/03/07/archery-physics)
   ✅ Disco Runner (2026/03/07/disco-runner)
   ✅ Flappy Bird (2026/03/07/flappy-bird)
   ✅ Contrast Lab (2026/03/07/contrast-lab)
   ✅ Word Weaver (2026/03/06/word-weaver)
   ✅ Memory Match (2026/03/06/memory-match)
   ✅ Sorting Algorithm Visualizer (2026/03/06/sorting-visualizer)
   ✅ Word Scramble Party (2026/03/06/word-scramble)
   ✅ Snake Game (2026/03/05/snake-game)
   ✅ Breathing Orb (2026/03/05/breathing-orb)
   ✅ Pomodoro Timer (2026/03/05/pomodoro-timer)
   ✅ Color Palette Generator (2026/03/05/color-palette-generator)

✨ Generated /Users/jeff/repos/jeff/valley-of-ai/data/apps.json with 73 app(s)
- 
> valley-of-ai@0.2.0 validate:apps
> node scripts/validate-apps.mjs

Validated 113 app index.html file(s): all passed.
Validated 111 app meta.json file(s): all passed.
Validated data/apps.json registry synchronization: passed.
Validated data/versus.json and versus-registry.json: passed.
Validated category synchronization across schema, issue template, and prompts: passed.
- 
> valley-of-ai@0.2.0 lint:fix
> eslint app components hooks lib scripts __tests__ --fix
- 
> valley-of-ai@0.2.0 format
> prettier --write "app/**/*.{js,jsx,ts,tsx}" "components/**/*.{js,jsx,ts,tsx}" "hooks/**/*.{js,jsx,ts,tsx}" "lib/**/*.{js,jsx,ts,tsx}" "scripts/**/*.{js,jsx,ts,tsx,mjs}" "__tests__/**/*.{js,jsx,ts,tsx}"

app/api/app-log/route.js 28ms (unchanged)
app/api/improvements/route.js 10ms (unchanged)
app/api/multiplayer/sessions/[code]/answers/route.js 6ms (unchanged)
app/api/multiplayer/sessions/[code]/players/route.js 4ms (unchanged)
app/api/multiplayer/sessions/[code]/route.js 8ms (unchanged)
app/api/multiplayer/sessions/route.js 3ms (unchanged)
app/api/multiplayer/status/route.js 1ms (unchanged)
app/api/scores/profanity.js 1ms (unchanged)
app/api/scores/route.js 7ms (unchanged)
app/api/stripe/checkout/route.js 4ms (unchanged)
app/api/stripe/webhook/route.js 4ms (unchanged)
app/api/suggestions/route.js 4ms (unchanged)
app/api/verify-payment/route.js 1ms (unchanged)
app/api/versus-votes/route.js 4ms (unchanged)
app/api/votes/route.js 4ms (unchanged)
app/improve/page.jsx 9ms (unchanged)
app/join/[code]/page.jsx 8ms (unchanged)
app/layout.jsx 1ms (unchanged)
app/leaderboard/page.jsx 4ms (unchanged)
app/logs/page.jsx 15ms (unchanged)
app/not-found.jsx 1ms (unchanged)
app/page.jsx 10ms (unchanged)
app/robots.js 1ms (unchanged)
app/showcase/[...id]/AppDetailClient.jsx 6ms (unchanged)
app/showcase/[...id]/page.jsx 4ms (unchanged)
app/sitemap.js 1ms (unchanged)
app/suggest/page.jsx 3ms (unchanged)
app/versus/[id]/page.jsx 2ms (unchanged)
app/versus/page.jsx 1ms (unchanged)
components/AppCard.jsx 2ms (unchanged)
components/AppLog.jsx 10ms (unchanged)
components/DonateModal.jsx 12ms (unchanged)
components/GalleryFilters.jsx 4ms (unchanged)
components/GalleryGrid.jsx 1ms (unchanged)
components/GalleryPagination.jsx 4ms (unchanged)
components/Header.jsx 2ms (unchanged)
components/LayoutShell.jsx 2ms (unchanged)
components/OptionsDrawer.jsx 3ms (unchanged)
components/PaymentSuccessModal.jsx 2ms (unchanged)
components/PterodactylSky.jsx 1ms (unchanged)
components/ShareButton.jsx 3ms (unchanged)
components/SubmissionSuccessModal.jsx 2ms (unchanged)
components/ThemeToggle.jsx 1ms (unchanged)
components/TipSection.jsx 2ms (unchanged)
components/TrendingRow.jsx 1ms (unchanged)
components/VersusCard.jsx 2ms (unchanged)
components/VersusComparisonTable.jsx 5ms (unchanged)
components/VersusEntryCard.jsx 2ms (unchanged)
components/VersusVoteBar.jsx 2ms (unchanged)
components/VersusVoteButton.jsx 1ms (unchanged)
components/VoteButtons.jsx 1ms (unchanged)
hooks/useFocusTrap.js 1ms (unchanged)
hooks/usePterodactyls.js 2ms (unchanged)
hooks/useVersusVotes.js 3ms (unchanged)
hooks/useVotes.js 4ms (unchanged)
lib/formatDuration.js 1ms (unchanged)
lib/markdown.js 0ms (unchanged)
lib/multiplayer/sessionCodes.js 1ms (unchanged)
lib/similarApps.js 1ms (unchanged)
lib/siteConfig.js 1ms (unchanged)
lib/supabaseAdmin.js 0ms (unchanged)
lib/trendingScore.js 1ms (unchanged)
lib/turnstile.js 1ms (unchanged)
scripts/agent.mjs 2ms (unchanged)
scripts/apps-registry.mjs 2ms (unchanged)
scripts/category-parsers.mjs 1ms (unchanged)
scripts/category-transforms.mjs 1ms (unchanged)
scripts/copy-logs-to-apps.mjs 3ms (unchanged)
scripts/generate-apps.mjs 1ms (unchanged)
scripts/generate-versus.mjs 2ms (unchanged)
scripts/issues/decide-issue.mjs 3ms (unchanged)
scripts/issues/lib/issue-github-client.mjs 3ms (unchanged)
scripts/issues/lib/issue-selection-heuristics.mjs 6ms (unchanged)
scripts/issues/retrieve-pending-issues.mjs 6ms (unchanged)
scripts/issues/select-app-improvement.mjs 5ms (unchanged)
scripts/issues/select-app-suggestion.mjs 10ms (unchanged)
scripts/logger.mjs 4ms (unchanged)
scripts/sync-categories.mjs 2ms (unchanged)
scripts/sync-public-content.mjs 2ms (unchanged)
scripts/validate-apps.mjs 8ms (unchanged)
scripts/validate-responsive.mjs 6ms (unchanged)
scripts/versus-registry.mjs 2ms (unchanged)
__tests__/api/app-log.test.js 2ms (unchanged)
__tests__/api/improvements.test.js 4ms (unchanged)
__tests__/api/scores-profanity.test.js 2ms (unchanged)
__tests__/api/scores.test.js 7ms (unchanged)
__tests__/api/stripe-checkout.test.js 2ms (unchanged)
__tests__/api/stripe-webhook.test.js 2ms (unchanged)
__tests__/api/suggestions.test.js 3ms (unchanged)
__tests__/api/verify-payment.test.js 2ms (unchanged)
__tests__/api/versus-votes.test.js 3ms (unchanged)
__tests__/api/votes.test.js 3ms (unchanged)
__tests__/components/AppLog.groupLogs.test.js 4ms (unchanged)
__tests__/components/ThemeToggle.test.js 1ms (unchanged)
__tests__/data/apps.test.js 1ms (unchanged)
__tests__/env.test.js 1ms (unchanged)
__tests__/lib/formatDuration.test.js 1ms (unchanged)
__tests__/lib/markdown.test.js 1ms (unchanged)
__tests__/lib/multiplayer/sessionCodes.test.js 1ms (unchanged)
__tests__/lib/similarApps.test.js 3ms (unchanged)
__tests__/lib/siteConfig.test.js 2ms (unchanged)
__tests__/lib/supabase.test.js 1ms (unchanged)
__tests__/lib/trendingScore.test.js 2ms (unchanged)
__tests__/scripts/generate-versus.test.js 3ms (unchanged)
__tests__/scripts/issues/decide-issue.test.js 4ms (unchanged)
__tests__/scripts/issues/lib/issue-selection-heuristics.test.js 11ms (unchanged)
__tests__/scripts/issues/retrieve-pending-issues.test.js 9ms (unchanged)
__tests__/scripts/sync-categories.test.js 3ms (unchanged)
__tests__/scripts/validate-apps.test.js 2ms (unchanged)
- 
> valley-of-ai@0.2.0 lint
> eslint app components hooks lib scripts __tests__ --max-warnings 0
- 
> valley-of-ai@0.2.0 test
> jest --passWithNoTests
- 
> valley-of-ai@0.2.0 validate:responsive:sample
> node scripts/validate-responsive.mjs --limit 5

Responsive validation passed for 5 app(s).
- 
> valley-of-ai@0.2.0 build
> npm run sync && next build


> valley-of-ai@0.2.0 sync
> node scripts/sync-public-content.mjs

◇ injected env (21) from .env // tip: ⌘ enable debugging { debug: true }
[sync] Copying runtime assets into public/...

✅ /Users/jeff/repos/jeff/valley-of-ai/apps → /Users/jeff/repos/jeff/valley-of-ai/public/apps
✅ /Users/jeff/repos/jeff/valley-of-ai/logs → /Users/jeff/repos/jeff/valley-of-ai/public/logs

[sync] Done.
▲ Next.js 16.2.3 (Turbopack)
- Environments: .env

  Creating an optimized production build ...
✓ Compiled successfully in 1308ms
  Running TypeScript ...
  Finished TypeScript in 37ms ...
  Collecting page data using 15 workers ...
  Generating static pages using 15 workers (0/94) ...
  Generating static pages using 15 workers (23/94) 
  Generating static pages using 15 workers (46/94) 
  Generating static pages using 15 workers (70/94) 
✓ Generating static pages using 15 workers (94/94) in 1076ms
  Finalizing page optimization ...

Route (app)                                   Revalidate  Expire
┌ ○ /
├ ○ /_not-found
├ ƒ /api/app-log
├ ƒ /api/improvements
├ ƒ /api/multiplayer/sessions
├ ƒ /api/multiplayer/sessions/[code]
├ ƒ /api/multiplayer/sessions/[code]/answers
├ ƒ /api/multiplayer/sessions/[code]/players
├ ƒ /api/multiplayer/status
├ ƒ /api/scores
├ ƒ /api/stripe/checkout
├ ƒ /api/stripe/webhook
├ ƒ /api/suggestions
├ ƒ /api/verify-payment
├ ƒ /api/versus-votes
├ ƒ /api/votes
├ ○ /improve
├ ƒ /join/[code]
├ ○ /leaderboard                                      1m      1y
├ ○ /logs
├ ○ /robots.txt
├ ● /showcase/[...id]
│ ├ /showcase/2026/04/18/team-taboo
│ ├ /showcase/2026/04/17/alibi
│ ├ /showcase/2026/04/16/mental-gymnastics
│ └ [+70 more paths]
├ ○ /sitemap.xml
├ ○ /suggest
├ ○ /versus
└ ƒ /versus/[id]


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand
