### PR TITLE
improve: two-truths-lie-game — backend multiplayer moderator/player flow

### DIFF
--- a/app/api/multiplayer/sessions/[code]/players/[playerId]/route.js
+++ b/app/api/multiplayer/sessions/[code]/players/[playerId]/route.js
@@ -1,0 +1,124 @@
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const CODE_RE = /^[A-HJ-NP-Z2-9]{4,10}$/;
+const ID_RE = /^[a-zA-Z0-9_-]{8,64}$/;
+
+function asString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function PATCH(request, { params }) {
+  const resolvedParams = await params;
+  const code =
+    typeof resolvedParams?.code === 'string' ? resolvedParams.code.trim().toUpperCase() : '';
+  const playerId =
+    typeof resolvedParams?.playerId === 'string' ? resolvedParams.playerId.trim() : '';
+
+  if (!CODE_RE.test(code)) {
+    return Response.json({ error: 'Invalid code' }, { status: 400 });
+  }
+  if (!ID_RE.test(playerId)) {
+    return Response.json({ error: 'Invalid player ID' }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+  if (!supabase) {
+    return Response.json({ error: 'Multiplayer unavailable' }, { status: 503 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const action = asString(body.action);
+  if (!action) {
+    return Response.json({ error: 'Missing action' }, { status: 400 });
+  }
+
+  const { data: row, error: loadError } = await supabase
+    .from('multiplayer_sessions')
+    .select('players, game')
+    .eq('code', code)
+    .maybeSingle();
+
+  if (loadError) {
+    console.error('Failed to load session for player update', loadError);
+    return Response.json({ error: 'Failed to update player' }, { status: 500 });
+  }
+  if (!row) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const players = structuredClone(row.players || {});
+  const game = structuredClone(row.game || {});
+  const player = players[playerId];
+
+  if (!player) {
+    return Response.json({ error: 'Player not found' }, { status: 404 });
+  }
+
+  if (action === 'submitStatements') {
+    const statements = Array.isArray(body.statements) ? body.statements : [];
+    const lieIndex = Number(body.lieIndex);
+
+    if (statements.length !== 3) {
+      return Response.json({ error: 'Expected exactly 3 statements' }, { status: 400 });
+    }
+    const cleaned = statements.map((entry) => asString(entry));
+    if (cleaned.some((entry) => !entry || entry.length > 180)) {
+      return Response.json({ error: 'Statements must each be 1-180 characters' }, { status: 400 });
+    }
+    if (!Number.isInteger(lieIndex) || lieIndex < 0 || lieIndex > 2) {
+      return Response.json({ error: 'Invalid lie index' }, { status: 400 });
+    }
+
+    player.submission = {
+      statements: cleaned,
+      lieIndex,
+      ready: true,
+      submittedAt: new Date().toISOString(),
+    };
+    players[playerId] = player;
+  } else if (action === 'vote') {
+    const roundId = asString(body.roundId);
+    const statementIndex = Number(body.statementIndex);
+
+    if (!roundId) {
+      return Response.json({ error: 'Missing round ID' }, { status: 400 });
+    }
+    if (!Number.isInteger(statementIndex) || statementIndex < 0 || statementIndex > 2) {
+      return Response.json({ error: 'Invalid vote selection' }, { status: 400 });
+    }
+
+    if (game.phase !== 'vote' || game.currentRoundId !== roundId) {
+      return Response.json({ ok: true, accepted: false, reason: 'round-inactive' });
+    }
+    if (game.currentSpeakerId === playerId) {
+      return Response.json({ ok: true, accepted: false, reason: 'speaker-cannot-vote' });
+    }
+
+    player.vote = {
+      roundId,
+      statementIndex,
+      votedAt: new Date().toISOString(),
+    };
+    players[playerId] = player;
+  } else {
+    return Response.json({ error: 'Unsupported action' }, { status: 400 });
+  }
+
+  const { error: updateError } = await supabase
+    .from('multiplayer_sessions')
+    .update({ players, game })
+    .eq('code', code);
+
+  if (updateError) {
+    console.error('Failed to persist player update', updateError);
+    return Response.json({ error: 'Failed to update player' }, { status: 500 });
+  }
+
+  return Response.json({ ok: true });
+}

--- a/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/index.html
+++ b/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/index.html
@@ -1,0 +1,1680 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>2 Truths and a Lie - __MAIN_SITE_NAME__</title>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '__GA_MEASUREMENT_ID__');
+    </script>
+
+    <meta name="voa-main-site-url" content="__MAIN_SITE_URL__" />
+    <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__" />
+    <meta name="voa-github-url" content="__GITHUB_URL__" />
+    <meta name="voa-social-x-url" content="__SOCIAL_X_URL__" />
+    <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__" />
+    <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__" />
+    <meta name="application-name" content="2 Truths and a Lie" />
+    <meta name="voa-app-id" content="2026/03/31/two-truths-lie-game" />
+    <script src="/apps/shared/app-shell.js" defer></script>
+
+    <style>
+      /* ── Theme variables ── */
+      :root {
+        --bg: #0f172a;
+        --text: #f9fafb;
+        --surface: #1e293b;
+      }
+      [data-theme='light'] {
+        --bg: #ffffff;
+        --text: #1f2937;
+        --surface: #f3f4f6;
+      }
+
+      /* ── App-specific palette ── */
+      :root {
+        --accent: #8b5cf6;
+        --accent-bright: #a78bfa;
+        --accent-dark: #6d28d9;
+        --success: #10b981;
+        --danger: #ef4444;
+        --warning: #f59e0b;
+        --card: #1e293b;
+        --card-border: #334155;
+        --text-muted: #94a3b8;
+      }
+      [data-theme='light'] {
+        --card: #f3f4f6;
+        --card-border: #d1d5db;
+        --text-muted: #6b7280;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+        min-height: 100dvh;
+      }
+
+      /* ── Viewport wrapper — accounts for 64px header + 56px footer ── */
+      #app {
+        position: fixed;
+        top: 64px;
+        bottom: 56px;
+        left: 0;
+        right: 0;
+        overflow-y: auto;
+        padding: 16px;
+      }
+
+      /* ── Screens ── */
+      .screen {
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+        max-width: 640px;
+        margin: 0 auto;
+        padding-bottom: 16px;
+      }
+      .screen.active {
+        display: flex;
+        animation: fadeIn 0.2s ease;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(8px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      h1 {
+        font-size: clamp(1.4rem, 4vw, 2rem);
+        font-weight: 700;
+        color: var(--accent-bright);
+        text-align: center;
+      }
+      h2 {
+        font-size: clamp(1.1rem, 3vw, 1.5rem);
+        font-weight: 600;
+        text-align: center;
+      }
+      h3 {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--text-muted);
+        text-align: center;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+      }
+
+      /* ── Buttons ── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 12px 24px;
+        border-radius: 10px;
+        border: none;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.15s ease;
+        min-height: 48px;
+        min-width: 44px;
+      }
+      .btn:active {
+        transform: scale(0.97);
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: white;
+      }
+      .btn-primary:hover {
+        background: var(--accent-dark);
+      }
+      .btn-success {
+        background: var(--success);
+        color: white;
+      }
+      .btn-success:hover {
+        filter: brightness(0.9);
+      }
+      .btn-danger {
+        background: var(--danger);
+        color: white;
+      }
+      .btn-danger:hover {
+        filter: brightness(0.9);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--text-muted);
+        border: 1.5px solid var(--card-border);
+      }
+      .btn-ghost:hover {
+        background: var(--surface);
+        color: var(--text);
+      }
+      .btn-lg {
+        font-size: 1.15rem;
+        padding: 14px 32px;
+      }
+      .btn-sm {
+        font-size: 0.875rem;
+        padding: 8px 14px;
+        min-height: 38px;
+      }
+      .btn:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+        transform: none;
+      }
+      .full-width {
+        width: 100%;
+      }
+
+      /* ── Cards ── */
+      .card {
+        background: var(--card);
+        border: 1.5px solid var(--card-border);
+        border-radius: 12px;
+        padding: 16px;
+        width: 100%;
+      }
+
+      /* ── Input ── */
+      .input {
+        width: 100%;
+        padding: 12px 14px;
+        background: var(--bg);
+        border: 1.5px solid var(--card-border);
+        border-radius: 8px;
+        color: var(--text);
+        font-size: 1rem;
+        outline: none;
+        transition: border-color 0.15s;
+      }
+      .input:focus {
+        border-color: var(--accent);
+      }
+
+      .row {
+        display: flex;
+        gap: 8px;
+        width: 100%;
+        align-items: center;
+      }
+      .row .input {
+        flex: 1;
+      }
+
+      /* ── Player chips ── */
+      .player-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        width: 100%;
+      }
+      .player-chip {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--surface);
+        border: 1.5px solid var(--card-border);
+        border-radius: 20px;
+        padding: 6px 12px;
+        font-size: 0.9rem;
+      }
+      .player-chip button {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        cursor: pointer;
+        font-size: 1rem;
+        line-height: 1;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 24px;
+        min-width: 24px;
+        border-radius: 50%;
+      }
+      .player-chip button:hover {
+        color: var(--danger);
+      }
+
+      /* ── Round badge ── */
+      .round-badge {
+        background: var(--surface);
+        border: 1.5px solid var(--card-border);
+        border-radius: 20px;
+        padding: 4px 14px;
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      /* ── Timer ring ── */
+      .timer-ring {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .timer-ring svg {
+        transform: rotate(-90deg);
+      }
+      .timer-number {
+        position: absolute;
+        font-size: clamp(2.5rem, 10vw, 4rem);
+        font-weight: 700;
+        color: var(--accent-bright);
+      }
+      #timerCircle {
+        transition: stroke-dashoffset 1s linear;
+        stroke-linecap: round;
+      }
+
+      /* ── Spinner wheel ── */
+      .wheel-container {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+      }
+      .wheel-wrapper {
+        position: relative;
+        display: inline-block;
+      }
+      #spinCanvas {
+        display: block;
+        border-radius: 50%;
+        max-width: 100%;
+      }
+      .wheel-pointer {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0;
+        height: 0;
+        border-top: 14px solid transparent;
+        border-bottom: 14px solid transparent;
+        border-right: 28px solid var(--accent-bright);
+        filter: drop-shadow(0 0 4px var(--accent));
+      }
+
+      /* ── Speaker name ── */
+      .winner-name {
+        font-size: clamp(1.8rem, 6vw, 2.8rem);
+        font-weight: 700;
+        color: var(--accent-bright);
+        text-align: center;
+        text-shadow: 0 0 20px rgba(139, 92, 246, 0.5);
+      }
+
+      @keyframes spinResult {
+        0%,
+        100% {
+          transform: scale(1);
+        }
+        50% {
+          transform: scale(1.05);
+        }
+      }
+      .spin-result {
+        animation: spinResult 0.4s ease;
+      }
+
+      /* ── Guess grid ── */
+      .guess-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        width: 100%;
+      }
+      .guess-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        background: var(--card);
+        border: 1.5px solid var(--card-border);
+        border-radius: 10px;
+        padding: 10px 14px;
+      }
+      .guess-row.correct {
+        border-color: var(--success);
+        background: rgba(16, 185, 129, 0.1);
+      }
+      .guess-row.wrong {
+        border-color: var(--danger);
+        background: rgba(239, 68, 68, 0.08);
+      }
+      .guess-name {
+        flex: 1;
+        font-weight: 600;
+        font-size: 1rem;
+      }
+      .guess-btns {
+        display: flex;
+        gap: 6px;
+      }
+      .guess-btn {
+        width: 52px;
+        height: 52px;
+        border-radius: 10px;
+        border: 2px solid var(--card-border);
+        background: var(--bg);
+        color: var(--text-muted);
+        font-size: 1.1rem;
+        font-weight: 700;
+        cursor: pointer;
+        transition: all 0.15s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
+      .guess-btn:hover {
+        border-color: var(--accent);
+        color: var(--accent-bright);
+        background: rgba(139, 92, 246, 0.12);
+        transform: scale(1.05);
+      }
+      .guess-btn.selected {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: white;
+        box-shadow: 0 0 12px rgba(139, 92, 246, 0.5);
+        transform: scale(1.1);
+      }
+      .guess-btn.selected::after {
+        content: '✓';
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        background: var(--success);
+        color: white;
+        border-radius: 50%;
+        width: 16px;
+        height: 16px;
+        font-size: 9px;
+        font-weight: 900;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+      }
+      .guess-row.has-guess {
+        border-color: var(--accent-dark);
+        background: rgba(139, 92, 246, 0.06);
+      }
+      /* Winners banner */
+      .winners-banner {
+        width: 100%;
+        background: linear-gradient(135deg, rgba(16,185,129,0.15), rgba(16,185,129,0.05));
+        border: 2px solid var(--success);
+        border-radius: 14px;
+        padding: 16px;
+        text-align: center;
+      }
+      .winners-banner h2 {
+        color: var(--success);
+        margin-bottom: 10px;
+        filter: drop-shadow(0 0 6px rgba(16,185,129,0.4));
+      }
+      .winners-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        justify-content: center;
+      }
+      .winner-chip {
+        background: var(--success);
+        color: white;
+        border-radius: 20px;
+        padding: 6px 14px;
+        font-weight: 700;
+        font-size: 1rem;
+      }
+      .no-winners-banner {
+        width: 100%;
+        background: rgba(148, 163, 184, 0.08);
+        border: 2px solid var(--card-border);
+        border-radius: 14px;
+        padding: 14px;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 1rem;
+      }
+      .guess-icon {
+        font-size: 1.2rem;
+        min-width: 24px;
+        text-align: center;
+      }
+
+      /* ── Scoreboard table ── */
+      .score-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .score-table th,
+      .score-table td {
+        padding: 10px 14px;
+        text-align: left;
+        border-bottom: 1px solid var(--card-border);
+      }
+      .score-table th {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-muted);
+      }
+      .score-table tr:last-child td {
+        border-bottom: none;
+      }
+      .score-rank {
+        font-size: 1.2rem;
+        min-width: 30px;
+      }
+      .score-points {
+        font-weight: 700;
+        font-size: 1.1rem;
+        color: var(--accent-bright);
+      }
+
+      /* ── Instructions ── */
+      .instructions {
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        width: 100%;
+      }
+      .instructions li {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+        background: var(--surface);
+        border-radius: 10px;
+        padding: 12px 14px;
+        font-size: 0.95rem;
+        line-height: 1.45;
+      }
+      .instructions li .num {
+        background: var(--accent);
+        color: white;
+        border-radius: 50%;
+        width: 24px;
+        height: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.8rem;
+        font-weight: 700;
+        flex-shrink: 0;
+        margin-top: 1px;
+      }
+
+      /* ── Utility ── */
+      .text-center {
+        text-align: center;
+      }
+      .text-muted {
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+      .flex-row {
+        display: flex;
+        gap: 10px;
+        width: 100%;
+      }
+      .flex-row .btn {
+        flex: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <!-- ── SCREEN: Setup ── -->
+      <div id="screenSetup" class="screen active">
+        <h1>2 Truths and a Lie</h1>
+        <p class="text-muted text-center">Add everyone who's playing, then start.</p>
+
+        <div class="card">
+          <div class="row">
+            <input
+              id="nameInput"
+              class="input"
+              type="text"
+              placeholder="Enter player name…"
+              maxlength="30"
+              autocomplete="off"
+            />
+            <button class="btn btn-primary" onclick="addPlayer()">Add</button>
+          </div>
+        </div>
+
+        <div id="playerList" class="player-list"></div>
+        <div style="display: flex; align-items: center; gap: 10px; width: 100%">
+          <p id="playerCountMsg" class="text-muted" style="display: none; flex: 1; margin: 0"></p>
+          <button
+            id="removeAllBtn"
+            class="btn btn-ghost btn-sm"
+            style="display: none; color: var(--danger)"
+            onclick="removeAllPlayers()"
+          >
+            Remove All
+          </button>
+        </div>
+
+        <button id="startBtn" class="btn btn-primary btn-lg full-width" onclick="startGame()" disabled>
+          Start Game
+        </button>
+      </div>
+
+      <!-- ── SCREEN: Think Time (round 1 only) ── -->
+      <div id="screenThink" class="screen">
+        <h1>Think Time!</h1>
+        <h2>Everyone: write your 3 statements</h2>
+
+        <div class="timer-ring">
+          <svg width="180" height="180" viewBox="0 0 180 180">
+            <circle cx="90" cy="90" r="80" fill="none" stroke="var(--card-border)" stroke-width="10" />
+            <circle
+              id="timerCircle"
+              cx="90"
+              cy="90"
+              r="80"
+              fill="none"
+              stroke-width="10"
+              stroke-dasharray="502.65"
+              stroke-dashoffset="0"
+            />
+          </svg>
+          <span class="timer-number" id="timerNum">60</span>
+        </div>
+
+        <ul class="instructions">
+          <li><span class="num">1</span>Write 2 TRUE statements about yourself</li>
+          <li><span class="num">2</span>Write 1 LIE — make it believable!</li>
+          <li>
+            <span class="num">3</span>When time's up, the host spins to pick the first speaker
+          </li>
+        </ul>
+
+        <button class="btn btn-ghost full-width" onclick="skipTimer()">Skip Timer →</button>
+      </div>
+
+      <!-- ── SCREEN: Spinner ── -->
+      <div id="screenSpin" class="screen">
+        <div class="round-badge" id="roundBadgeSpin"></div>
+        <h2 id="spinTitle">Who goes next?</h2>
+
+        <div class="wheel-container">
+          <div class="wheel-wrapper" id="wheelWrapper">
+            <canvas id="spinCanvas" width="280" height="280"></canvas>
+            <div class="wheel-pointer" id="wheelPointer"></div>
+          </div>
+        </div>
+
+        <button id="spinBtn" class="btn btn-primary btn-lg" onclick="spinWheel()">🎡 Spin!</button>
+        <div id="spinResult" class="winner-name" style="display: none"></div>
+        <button
+          id="goTurnBtn"
+          class="btn btn-success btn-lg full-width"
+          style="display: none"
+          onclick="goToTurn()"
+        >
+          It's their turn →
+        </button>
+        <button
+          class="btn btn-ghost btn-sm"
+          style="margin-top: 8px; opacity: 0.7"
+          onclick="endRoundEarly()"
+        >
+          End Game
+        </button>
+      </div>
+
+      <!-- ── SCREEN: Turn (record guesses) ── -->
+      <div id="screenTurn" class="screen">
+        <div class="round-badge" id="roundBadgeTurn"></div>
+        <h3>Now speaking…</h3>
+        <div class="winner-name" id="turnSpeakerName"></div>
+
+        <!-- Phase 1: host enters the 3 statements -->
+        <div id="statementCapture" class="card">
+          <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 10px">
+            Ask <strong id="turnSpeakerName2"></strong> to share their 3 statements, then type them
+            in below.
+          </p>
+          <div style="display: flex; flex-direction: column; gap: 10px">
+            <div style="display: flex; gap: 10px; align-items: center">
+              <span
+                style="
+                  background: var(--accent);
+                  color: white;
+                  border-radius: 50%;
+                  width: 28px;
+                  height: 28px;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-weight: 700;
+                  flex-shrink: 0;
+                "
+                >1</span
+              >
+              <input
+                id="stmt1"
+                class="input"
+                type="text"
+                placeholder="Statement 1…"
+                maxlength="140"
+                autocomplete="off"
+              />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center">
+              <span
+                style="
+                  background: var(--accent);
+                  color: white;
+                  border-radius: 50%;
+                  width: 28px;
+                  height: 28px;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-weight: 700;
+                  flex-shrink: 0;
+                "
+                >2</span
+              >
+              <input
+                id="stmt2"
+                class="input"
+                type="text"
+                placeholder="Statement 2…"
+                maxlength="140"
+                autocomplete="off"
+              />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center">
+              <span
+                style="
+                  background: var(--accent);
+                  color: white;
+                  border-radius: 50%;
+                  width: 28px;
+                  height: 28px;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-weight: 700;
+                  flex-shrink: 0;
+                "
+                >3</span
+              >
+              <input
+                id="stmt3"
+                class="input"
+                type="text"
+                placeholder="Statement 3…"
+                maxlength="140"
+                autocomplete="off"
+              />
+            </div>
+          </div>
+          <button
+            id="showStatementsBtn"
+            class="btn btn-primary full-width"
+            style="margin-top: 14px"
+            onclick="submitStatements()"
+            disabled
+          >
+            Show Statements on Screen →
+          </button>
+        </div>
+
+        <!-- Phase 2: statements displayed + guess recording (shown after submitStatements) -->
+        <div id="statementsDisplay" style="display: none; width: 100%">
+          <div class="card">
+            <h3 style="margin-bottom: 10px">Statements</h3>
+            <div style="display: flex; flex-direction: column; gap: 8px">
+              <div class="guess-row" style="border-color: var(--accent-dark)">
+                <span
+                  style="
+                    background: var(--accent);
+                    color: white;
+                    border-radius: 50%;
+                    width: 28px;
+                    height: 28px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-weight: 700;
+                    flex-shrink: 0;
+                  "
+                  >1</span
+                >
+                <span id="stmtDisplay1" class="guess-name" style="font-weight: 400"></span>
+              </div>
+              <div class="guess-row" style="border-color: var(--accent-dark)">
+                <span
+                  style="
+                    background: var(--accent);
+                    color: white;
+                    border-radius: 50%;
+                    width: 28px;
+                    height: 28px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-weight: 700;
+                    flex-shrink: 0;
+                  "
+                  >2</span
+                >
+                <span id="stmtDisplay2" class="guess-name" style="font-weight: 400"></span>
+              </div>
+              <div class="guess-row" style="border-color: var(--accent-dark)">
+                <span
+                  style="
+                    background: var(--accent);
+                    color: white;
+                    border-radius: 50%;
+                    width: 28px;
+                    height: 28px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-weight: 700;
+                    flex-shrink: 0;
+                  "
+                  >3</span
+                >
+                <span id="stmtDisplay3" class="guess-name" style="font-weight: 400"></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top: 0">
+            <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 10px">
+              Each player: which number is the lie?
+            </p>
+            <div class="guess-grid" id="guessGrid"></div>
+          </div>
+
+          <div class="card" style="margin-top: 0">
+            <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px">
+              Which statement was the LIE?
+            </p>
+            <div class="flex-row" id="lieButtons">
+              <button class="btn btn-ghost" onclick="selectLie(1)">Statement 1</button>
+              <button class="btn btn-ghost" onclick="selectLie(2)">Statement 2</button>
+              <button class="btn btn-ghost" onclick="selectLie(3)">Statement 3</button>
+            </div>
+            <p
+              id="lieSelectedMsg"
+              style="display: none; margin-top: 8px; font-size: 0.9rem; color: var(--success); font-weight: 600"
+            ></p>
+          </div>
+
+          <button
+            id="revealBtn"
+            class="btn btn-success btn-lg full-width"
+            onclick="revealLie()"
+            disabled
+          >
+            Show the Winners!
+          </button>
+        </div>
+      </div>
+
+      <!-- ── SCREEN: Reveal ── -->
+      <div id="screenReveal" class="screen">
+        <div class="round-badge" id="roundBadgeReveal"></div>
+        <h2>The Lie was Statement <span id="lieNumDisplay"></span>!</h2>
+        <p class="text-center" id="revealSpeakerNote" style="color: var(--text-muted)"></p>
+
+        <div id="revealStatements" class="card" style="display: none; width: 100%">
+          <div style="display: flex; flex-direction: column; gap: 8px" id="revealStmtList"></div>
+        </div>
+
+        <div id="winnersBanner"></div>
+
+        <div class="guess-grid" id="revealGrid"></div>
+
+        <button id="nextTurnBtn" class="btn btn-primary btn-lg full-width" onclick="nextTurn()"></button>
+      </div>
+
+      <!-- ── SCREEN: Round End Scoreboard ── -->
+      <div id="screenRoundEnd" class="screen">
+        <h1>Round <span id="roundEndNum"></span> Complete!</h1>
+        <div class="card">
+          <table class="score-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>Player</th>
+                <th>Points</th>
+              </tr>
+            </thead>
+            <tbody id="roundEndScores"></tbody>
+          </table>
+        </div>
+        <div class="flex-row">
+          <button class="btn btn-ghost" onclick="returnToSetup()">End Game</button>
+          <button class="btn btn-primary" onclick="nextRound()">Next Round →</button>
+        </div>
+      </div>
+
+      <!-- ── SCREEN: Final Scores ── -->
+      <div id="screenFinal" class="screen">
+        <h1>🏆 Final Scores</h1>
+        <div class="card">
+          <table class="score-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>Player</th>
+                <th>Points</th>
+              </tr>
+            </thead>
+            <tbody id="finalScores"></tbody>
+          </table>
+        </div>
+        <button class="btn btn-primary btn-lg full-width" onclick="resetGame()">Play Again</button>
+      </div>
+    </div>
+
+    <script>
+      /**
+       * 2 Truths and a Lie — Game Controller
+       *
+       * Flow:
+       *   Setup → Think Time (round 1) → Spinner → Turn → Reveal
+       *   → (repeat Spinner/Turn/Reveal for each speaker)
+       *   → Round End Scoreboard → (next round or Final Scores)
+       *
+       * Scoring: 1 point per correct guess. The speaker earns no points.
+       */
+
+      // ── Persistence ────────────────────────────────────────────────────────
+      /** localStorage key for persisting player names across sessions. */
+      const SAVED_NAMES_KEY = 'voa-2tl-saved-names';
+
+      // ── State ──────────────────────────────────────────────────────────────
+      /** @type {{ name: string, points: number }[]} */
+      let players = [];
+
+      let round = 1;
+
+      /** Names of players yet to speak this round. */
+      let speakerQueue = [];
+
+      /** Name of the player currently speaking. */
+      let currentSpeaker = null;
+
+      /** Which statement number (1, 2, or 3) is the lie for this turn. */
+      let currentLie = null;
+
+      /** Map of guesser name → guessed statement number. */
+      let guesses = {};
+
+      /** The 3 statements entered by the host for the current speaker. */
+      let currentStatements = ['', '', ''];
+
+      let timerInterval = null;
+      let timerSecs = 60;
+
+      /** Whether the wheel is currently animating. */
+      let spinning = false;
+
+      /** Current wheel rotation in radians. */
+      let spinAngle = 0;
+
+      // ── Screen management ──────────────────────────────────────────────────
+
+      /**
+       * Activate a screen by ID and hide all others.
+       * @param {string} id - The ID of the screen element to show.
+       */
+      function showScreen(id) {
+        document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+        document.getElementById(id).classList.add('active');
+      }
+
+      // ── Setup screen ───────────────────────────────────────────────────────
+
+      const nameInput = document.getElementById('nameInput');
+      nameInput.addEventListener('keydown', e => {
+        if (e.key === 'Enter') addPlayer();
+      });
+
+      /**
+       * Load previously-saved player names from localStorage into the players list.
+       * Only names persist across sessions; scores always start at zero.
+       */
+      function loadSavedNames() {
+        try {
+          const raw = localStorage.getItem(SAVED_NAMES_KEY);
+          if (!raw) return;
+          const names = JSON.parse(raw);
+          if (!Array.isArray(names)) return;
+          players = names
+            .filter(n => typeof n === 'string' && n.trim())
+            .map(name => ({ name: name.trim(), points: 0 }));
+        } catch {
+          // Ignore corrupted storage; start with an empty list.
+        }
+      }
+
+      /**
+       * Persist the current player names to localStorage so they can be recalled
+       * on the next visit.
+       */
+      function saveNames() {
+        try {
+          localStorage.setItem(SAVED_NAMES_KEY, JSON.stringify(players.map(p => p.name)));
+        } catch {
+          // localStorage unavailable (private mode, quota) — silently skip.
+        }
+      }
+
+      loadSavedNames();
+      renderPlayerList();
+
+      /**
+       * Add the name from the input field to the player list.
+       * Ignores empty strings and duplicate names (case-insensitive).
+       */
+      function addPlayer() {
+        const name = nameInput.value.trim();
+        if (!name) return;
+        if (players.find(p => p.name.toLowerCase() === name.toLowerCase())) {
+          nameInput.select();
+          return;
+        }
+        players.push({ name, points: 0 });
+        nameInput.value = '';
+        nameInput.focus();
+        saveNames();
+        renderPlayerList();
+      }
+
+      /**
+       * Remove a player by name from the list.
+       * @param {string} name - Exact player name to remove.
+       */
+      function removePlayer(name) {
+        players = players.filter(p => p.name !== name);
+        saveNames();
+        renderPlayerList();
+      }
+
+      /**
+       * Re-render the player chips and update the start button state.
+       * Requires at least 2 players to enable the start button.
+       */
+      function renderPlayerList() {
+        const list = document.getElementById('playerList');
+        const msg = document.getElementById('playerCountMsg');
+        const btn = document.getElementById('startBtn');
+
+        list.innerHTML = players
+          .map(
+            p =>
+              `<div class="player-chip">
+              <span>${escHtml(p.name)}</span>
+              <button data-remove="${escHtml(p.name)}">✕</button>
+            </div>`,
+          )
+          .join('');
+
+        // Attach remove listeners (avoids inline onclick quoting issues)
+        list.querySelectorAll('[data-remove]').forEach(btn => {
+          btn.addEventListener('click', () => removePlayer(btn.dataset.remove));
+        });
+
+        const n = players.length;
+        const removeAllBtn = document.getElementById('removeAllBtn');
+        if (n > 0) {
+          msg.style.display = 'block';
+          msg.textContent = n === 1 ? '1 player added — need at least 2' : `${n} players`;
+          removeAllBtn.style.display = 'inline-flex';
+        } else {
+          msg.style.display = 'none';
+          removeAllBtn.style.display = 'none';
+        }
+        btn.disabled = n < 2;
+      }
+
+      /**
+       * Escape HTML special characters to safely insert user input into innerHTML.
+       * @param {string} s - Raw string.
+       * @returns {string} HTML-escaped string.
+       */
+      function escHtml(s) {
+        return s
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      /**
+       * Convert a player name to a DOM-safe ID fragment (alphanumeric + underscore).
+       * @param {string} name
+       * @returns {string}
+       */
+      function idSafe(name) {
+        return name.replace(/[^a-zA-Z0-9]/g, '_');
+      }
+
+      // ── Game start ─────────────────────────────────────────────────────────
+
+      /**
+       * Reset scores and begin a new game from round 1.
+       * Shows the think-time screen (60-second countdown) for round 1.
+       */
+      function startGame() {
+        round = 1;
+        players.forEach(p => (p.points = 0));
+        buildSpeakerQueue();
+        showScreen('screenThink');
+        startTimer();
+      }
+
+      /**
+       * Fill the speaker queue with all player names in their current order.
+       */
+      function buildSpeakerQueue() {
+        speakerQueue = players.map(p => p.name);
+      }
+
+      // ── Think-time timer ───────────────────────────────────────────────────
+
+      const TIMER_CIRCUMFERENCE = 2 * Math.PI * 80; // r=80 matches the SVG
+
+      /**
+       * Start the 60-second countdown and update the ring + number each second.
+       * Automatically transitions to the spinner when time expires.
+       */
+      function startTimer() {
+        timerSecs = 60;
+        updateTimerDisplay(60);
+        clearInterval(timerInterval);
+        timerInterval = setInterval(() => {
+          timerSecs--;
+          updateTimerDisplay(timerSecs);
+          if (timerSecs <= 0) {
+            clearInterval(timerInterval);
+            showSpinner();
+          }
+        }, 1000);
+      }
+
+      /**
+       * Update the SVG ring progress and numeric label.
+       * Ring turns yellow below 20s and red below 10s.
+       * @param {number} secs - Seconds remaining.
+       */
+      function updateTimerDisplay(secs) {
+        document.getElementById('timerNum').textContent = secs;
+        const offset = TIMER_CIRCUMFERENCE * (1 - secs / 60);
+        const circle = document.getElementById('timerCircle');
+        circle.style.strokeDashoffset = offset;
+        circle.style.stroke =
+          secs <= 10 ? 'var(--danger)' : secs <= 20 ? 'var(--warning)' : 'var(--accent)';
+      }
+
+      /**
+       * Skip the think-time countdown and go directly to the spinner.
+       */
+      function skipTimer() {
+        clearInterval(timerInterval);
+        showSpinner();
+      }
+
+      // ── Spinner wheel ──────────────────────────────────────────────────────
+
+      /** Segment fill colors for the wheel, cycled for any player count. */
+      const WHEEL_COLORS = [
+        '#7c3aed',
+        '#2563eb',
+        '#059669',
+        '#d97706',
+        '#dc2626',
+        '#0891b2',
+        '#65a30d',
+        '#ea580c',
+        '#9333ea',
+        '#0f766e',
+      ];
+
+      /**
+       * Show the spinner screen, reset result area, and draw the wheel.
+       */
+      function showSpinner() {
+        document.getElementById('roundBadgeSpin').textContent = `Round ${round}`;
+        document.getElementById('spinTitle').textContent =
+          speakerQueue.length < players.length ? 'Who goes next?' : 'Who goes first?';
+        document.getElementById('spinResult').style.display = 'none';
+        document.getElementById('goTurnBtn').style.display = 'none';
+        document.getElementById('spinBtn').disabled = false;
+        showScreen('screenSpin');
+        drawWheel(spinAngle);
+        positionPointer();
+      }
+
+      /**
+       * Position the arrow pointer flush against the right edge of the wheel canvas.
+       */
+      function positionPointer() {
+        const canvas = document.getElementById('spinCanvas');
+        const r = canvas.width / 2;
+        const pointer = document.getElementById('wheelPointer');
+        pointer.style.left = `calc(50% + ${r - 12}px)`;
+      }
+
+      /**
+       * Draw the spinner wheel at a given rotation angle.
+       * Each segment gets a label truncated to 12 characters.
+       * @param {number} angle - Wheel rotation in radians.
+       */
+      function drawWheel(angle) {
+        const canvas = document.getElementById('spinCanvas');
+        const ctx = canvas.getContext('2d');
+        const cx = canvas.width / 2;
+        const cy = canvas.height / 2;
+        const r = cx - 6;
+        const names = speakerQueue;
+        const n = names.length;
+        const slice = (2 * Math.PI) / n;
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        for (let i = 0; i < n; i++) {
+          const start = angle + i * slice;
+          const end = start + slice;
+
+          // Segment fill
+          ctx.beginPath();
+          ctx.moveTo(cx, cy);
+          ctx.arc(cx, cy, r, start, end);
+          ctx.closePath();
+          ctx.fillStyle = WHEEL_COLORS[i % WHEEL_COLORS.length];
+          ctx.fill();
+          ctx.strokeStyle = 'rgba(0,0,0,0.25)';
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+
+          // Segment label — rotated to read along the slice midpoint
+          ctx.save();
+          ctx.translate(cx, cy);
+          ctx.rotate(start + slice / 2);
+          ctx.textAlign = 'right';
+          ctx.fillStyle = 'white';
+          const fs = Math.min(16, Math.max(9, 220 / n));
+          ctx.font = `600 ${fs}px system-ui, sans-serif`;
+          ctx.shadowColor = 'rgba(0,0,0,0.6)';
+          ctx.shadowBlur = 4;
+          const label = names[i].length > 12 ? names[i].slice(0, 11) + '…' : names[i];
+          ctx.fillText(label, r - 8, 5);
+          ctx.restore();
+        }
+
+        // Center hub
+        ctx.beginPath();
+        ctx.arc(cx, cy, 18, 0, 2 * Math.PI);
+        ctx.fillStyle = '#1e293b';
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+
+      /**
+       * Animate the wheel with cubic ease-out over ~3.5s.
+       * Randomly selects a winner from the remaining speakerQueue.
+       * After landing, displays the winner's name and reveals the "go to turn" button.
+       */
+      function spinWheel() {
+        if (spinning || speakerQueue.length === 0) return;
+        spinning = true;
+        document.getElementById('spinBtn').disabled = true;
+        document.getElementById('spinResult').style.display = 'none';
+        document.getElementById('goTurnBtn').style.display = 'none';
+
+        const names = speakerQueue;
+        const n = names.length;
+        const slice = (2 * Math.PI) / n;
+
+        // Pick a random target segment
+        const winnerIdx = Math.floor(Math.random() * n);
+        // Use an integer number of extra rotations so the correction math is exact.
+        const extraRotations = 3 + Math.floor(Math.random() * 4); // 3, 4, 5, or 6
+        const targetSegmentCenter = winnerIdx * slice + slice / 2;
+        // Compute how much we need to rotate from the current position so that
+        // segment winnerIdx's center lands at angle 0 (where the pointer is).
+        // We want: (spinAngle + delta + targetSegmentCenter) ≡ 0 (mod 2π)
+        // → delta = -spinAngle - targetSegmentCenter + k*2π for the smallest positive k
+        const correction =
+          ((2 * Math.PI - ((spinAngle + targetSegmentCenter) % (2 * Math.PI))) %
+            (2 * Math.PI)) +
+          extraRotations * 2 * Math.PI;
+        const spinTarget = spinAngle + correction;
+
+        const duration = 3500;
+        const startTime = performance.now();
+        const startAngle = spinAngle;
+
+        /**
+         * Animation frame: advances the wheel with cubic ease-out.
+         * @param {number} now - Current timestamp from requestAnimationFrame.
+         */
+        function frame(now) {
+          const t = Math.min((now - startTime) / duration, 1);
+          const ease = 1 - Math.pow(1 - t, 3);
+          spinAngle = startAngle + (spinTarget - startAngle) * ease;
+          drawWheel(spinAngle);
+
+          if (t < 1) {
+            requestAnimationFrame(frame);
+          } else {
+            spinning = false;
+            spinAngle = spinTarget;
+            currentSpeaker = names[winnerIdx];
+            showSpinResult(currentSpeaker);
+          }
+        }
+
+        requestAnimationFrame(frame);
+      }
+
+      /**
+       * Display the spin result with a bounce animation and show the turn button.
+       * @param {string} name - The selected player's name.
+       */
+      function showSpinResult(name) {
+        const el = document.getElementById('spinResult');
+        el.textContent = `🎉 ${name}!`;
+        el.style.display = 'block';
+        el.classList.remove('spin-result');
+        void el.offsetWidth; // trigger reflow to restart animation
+        el.classList.add('spin-result');
+        document.getElementById('goTurnBtn').style.display = 'flex';
+      }
+
+      // ── Turn screen ────────────────────────────────────────────────────────
+
+      /**
+       * Transition to the turn screen for the current speaker.
+       * Shows the statement-capture phase first; guess grid is hidden until statements are submitted.
+       */
+      function goToTurn() {
+        guesses = {};
+        currentLie = null;
+        currentStatements = ['', '', ''];
+        document.getElementById('roundBadgeTurn').textContent = `Round ${round}`;
+        document.getElementById('turnSpeakerName').textContent = currentSpeaker;
+        document.getElementById('turnSpeakerName2').textContent = currentSpeaker;
+
+        // Reset statement inputs
+        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
+          const el = document.getElementById(id);
+          el.value = '';
+          el.disabled = false;
+        });
+        document.getElementById('showStatementsBtn').disabled = true;
+        document.getElementById('statementCapture').style.display = 'block';
+        document.getElementById('statementsDisplay').style.display = 'none';
+
+        resetLieButtons();
+        showScreen('screenTurn');
+
+        // Enable submit button when all 3 statements are non-empty
+        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
+          document.getElementById(id).addEventListener('input', checkStatementsReady);
+        });
+      }
+
+      /**
+       * Enable the "Show Statements" button only when all 3 inputs have content.
+       */
+      function checkStatementsReady() {
+        const all = ['stmt1', 'stmt2', 'stmt3'].every(
+          id => document.getElementById(id).value.trim().length > 0,
+        );
+        document.getElementById('showStatementsBtn').disabled = !all;
+      }
+
+      /**
+       * Lock the statement inputs, display them numbered on screen, and reveal the guess grid.
+       */
+      function submitStatements() {
+        currentStatements = ['stmt1', 'stmt2', 'stmt3'].map(id =>
+          document.getElementById(id).value.trim(),
+        );
+
+        // Lock inputs
+        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
+          document.getElementById(id).disabled = true;
+        });
+
+        // Display numbered statements
+        ['stmtDisplay1', 'stmtDisplay2', 'stmtDisplay3'].forEach((id, i) => {
+          document.getElementById(id).textContent = currentStatements[i];
+        });
+
+        // Switch phases
+        document.getElementById('statementCapture').style.display = 'none';
+        document.getElementById('statementsDisplay').style.display = 'block';
+
+        buildGuessGrid();
+        document.getElementById('revealBtn').disabled = true;
+      }
+
+      /**
+       * Build the guess entry grid: one row per non-speaker player.
+       * Each row has three numbered buttons (1, 2, 3) to record a guess.
+       * Uses data-* attributes + addEventListener to avoid inline onclick quoting issues.
+       */
+      function buildGuessGrid() {
+        const grid = document.getElementById('guessGrid');
+        const guessers = players.filter(p => p.name !== currentSpeaker);
+        grid.innerHTML = guessers
+          .map(
+            p =>
+              `<div class="guess-row" id="gr-${idSafe(p.name)}">
+              <span class="guess-name">${escHtml(p.name)}</span>
+              <div class="guess-btns">
+                ${[1, 2, 3]
+                  .map(
+                    n =>
+                      `<button class="guess-btn" id="gb-${idSafe(p.name)}-${n}"
+                        data-player="${escHtml(p.name)}" data-num="${n}">${n}</button>`,
+                  )
+                  .join('')}
+              </div>
+              <span class="guess-icon" id="gi-${idSafe(p.name)}"></span>
+            </div>`,
+          )
+          .join('');
+
+        // Attach click listeners after building HTML — avoids inline onclick quoting bugs
+        grid.querySelectorAll('.guess-btn').forEach(btn => {
+          btn.addEventListener('click', () => {
+            recordGuess(btn.dataset.player, parseInt(btn.dataset.num, 10));
+          });
+        });
+      }
+
+      /**
+       * Record a player's guess and highlight their selected button.
+       * Checks whether the reveal button should be enabled.
+       * @param {string} name - The guesser's name.
+       * @param {number} num - The guessed statement number (1, 2, or 3).
+       */
+      function recordGuess(name, num) {
+        guesses[name] = num;
+        [1, 2, 3].forEach(n => {
+          const btn = document.getElementById(`gb-${idSafe(name)}-${n}`);
+          if (btn) btn.classList.toggle('selected', n === num);
+        });
+        // Highlight the whole row once a guess has been made
+        const row = document.getElementById(`gr-${idSafe(name)}`);
+        if (row) row.classList.add('has-guess');
+        checkRevealReady();
+      }
+
+      /**
+       * Enable the reveal button once the lie statement has been selected.
+       * Players who haven't recorded a guess are counted as wrong on reveal.
+       */
+      function checkRevealReady() {
+        document.getElementById('revealBtn').disabled = currentLie === null;
+      }
+
+      /**
+       * Mark a statement as the lie and highlight the corresponding button.
+       * @param {number} num - The lie statement number (1, 2, or 3).
+       */
+      function selectLie(num) {
+        currentLie = num;
+        const btns = document.getElementById('lieButtons').querySelectorAll('.btn');
+        btns.forEach((btn, i) => {
+          btn.classList.toggle('btn-danger', i + 1 === num);
+          btn.classList.toggle('btn-ghost', i + 1 !== num);
+        });
+        document.getElementById('lieSelectedMsg').style.display = 'block';
+        document.getElementById('lieSelectedMsg').textContent = `Statement ${num} is the lie.`;
+        checkRevealReady();
+      }
+
+      /**
+       * Reset all lie-selection buttons to their default ghost state.
+       */
+      function resetLieButtons() {
+        document.getElementById('lieButtons').querySelectorAll('.btn').forEach(btn => {
+          btn.classList.remove('btn-danger');
+          btn.classList.add('btn-ghost');
+        });
+        document.getElementById('lieSelectedMsg').style.display = 'none';
+      }
+
+      // ── Reveal screen ──────────────────────────────────────────────────────
+
+      /**
+       * Reveal the lie, award points to correct guessers, and show the reveal screen.
+       * Removes the current speaker from the queue after this turn.
+       */
+      function revealLie() {
+        document.getElementById('roundBadgeReveal').textContent = `Round ${round}`;
+        document.getElementById('lieNumDisplay').textContent = currentLie;
+        document.getElementById('revealSpeakerNote').textContent =
+          `${currentSpeaker}'s lie was statement ${currentLie}`;
+
+        // Show the 3 statements on the reveal screen if they were captured
+        const revealStmts = document.getElementById('revealStatements');
+        const revealList = document.getElementById('revealStmtList');
+        if (currentStatements.some(s => s.length > 0)) {
+          revealList.innerHTML = currentStatements
+            .map((s, i) => {
+              const isLie = i + 1 === currentLie;
+              return `<div class="guess-row ${isLie ? 'wrong' : 'correct'}">
+                <span style="background:${isLie ? 'var(--danger)' : 'var(--success)'};color:white;border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;font-weight:700;flex-shrink:0">${i + 1}</span>
+                <span style="flex:1;font-size:0.95rem">${escHtml(s)}</span>
+                <span>${isLie ? '🤥' : '✓'}</span>
+              </div>`;
+            })
+            .join('');
+          revealStmts.style.display = 'block';
+        } else {
+          revealStmts.style.display = 'none';
+        }
+
+        const guessers = players.filter(p => p.name !== currentSpeaker);
+        let correct = 0;
+        const winners = [];
+
+        document.getElementById('revealGrid').innerHTML = guessers
+          .map(p => {
+            const isCorrect = guesses[p.name] === currentLie;
+            if (isCorrect) {
+              p.points++;
+              correct++;
+              winners.push(p.name);
+            }
+            const guessLabel =
+              guesses[p.name] !== undefined ? `guessed #${guesses[p.name]}` : 'no guess';
+            return `<div class="guess-row ${isCorrect ? 'correct' : 'wrong'}">
+            <span class="guess-name">${escHtml(p.name)}</span>
+            <span style="color:var(--text-muted);font-size:0.9rem">${guessLabel}</span>
+            <span class="guess-icon">${isCorrect ? '✅' : '❌'}</span>
+          </div>`;
+          })
+          .join('');
+
+        // Winners banner
+        const banner = document.getElementById('winnersBanner');
+        if (winners.length > 0) {
+          banner.innerHTML = `<div class="winners-banner">
+            <h2>🏆 Winner${winners.length > 1 ? 's' : ''}!</h2>
+            <div class="winners-list">
+              ${winners.map(n => `<span class="winner-chip">${escHtml(n)}</span>`).join('')}
+            </div>
+          </div>`;
+        } else {
+          banner.innerHTML = `<div class="no-winners-banner">😅 Nobody guessed the lie!</div>`;
+        }
+
+        // Remove speaker from the queue
+        speakerQueue = speakerQueue.filter(n => n !== currentSpeaker);
+
+        document.getElementById('nextTurnBtn').textContent =
+          speakerQueue.length > 0 ? 'Next Speaker →' : 'Round Complete →';
+
+        showScreen('screenReveal');
+      }
+
+      /**
+       * Advance from the reveal screen.
+       * Spins again if speakers remain; otherwise shows the round-end scoreboard.
+       */
+      function nextTurn() {
+        if (speakerQueue.length > 0) {
+          showSpinner();
+        } else {
+          showRoundEnd();
+        }
+      }
+
+      // ── Round end ──────────────────────────────────────────────────────────
+
+      /**
+       * Show the end-of-round scoreboard with current cumulative scores.
+       */
+      function showRoundEnd() {
+        document.getElementById('roundEndNum').textContent = round;
+        renderScoreTable('roundEndScores');
+        showScreen('screenRoundEnd');
+      }
+
+      /**
+       * Start the next round. Rebuilds the speaker queue; no think timer after round 1.
+       */
+      function nextRound() {
+        round++;
+        buildSpeakerQueue();
+        showSpinner();
+      }
+
+      /**
+       * End the current round early from the spinner screen.
+       * Clears the remaining speaker queue and shows the round-end scoreboard.
+       */
+      function endRoundEarly() {
+        speakerQueue = [];
+        showRoundEnd();
+      }
+
+      /**
+       * Return to the setup screen with player names preserved but scores reset.
+       */
+      function returnToSetup() {
+        round = 1;
+        spinAngle = 0;
+        currentStatements = ['', '', ''];
+        players.forEach(p => (p.points = 0));
+        renderPlayerList();
+        showScreen('screenSetup');
+      }
+
+      /**
+       * Remove all players from the list.
+       */
+      function removeAllPlayers() {
+        players = [];
+        saveNames();
+        renderPlayerList();
+      }
+
+      /**
+       * Skip to the final scores screen immediately.
+       */
+      function endGame() {
+        renderScoreTable('finalScores');
+        showScreen('screenFinal');
+      }
+
+      // ── Final scores ───────────────────────────────────────────────────────
+
+      /**
+       * Render players sorted by score descending into a score table body.
+       * @param {string} tbodyId - ID of the <tbody> element to populate.
+       */
+      function renderScoreTable(tbodyId) {
+        const sorted = [...players].sort((a, b) => b.points - a.points);
+        const medalByRank = {
+          1: '🥇',
+          2: '🥈',
+          3: '🥉',
+        };
+        let lastPoints = null;
+        let lastRank = 0;
+        document.getElementById(tbodyId).innerHTML = sorted
+          .map(
+            (p, i) => {
+              const rank = p.points === lastPoints ? lastRank : i + 1;
+              lastPoints = p.points;
+              lastRank = rank;
+
+              return `<tr>
+            <td class="score-rank">${medalByRank[rank] || rank}</td>
+            <td>${escHtml(p.name)}</td>
+            <td class="score-points">${p.points}</td>
+          </tr>`;
+            },
+          )
+          .join('');
+      }
+
+      /**
+       * Reset the entire game: clear players and scores, return to setup screen.
+       */
+      function resetGame() {
+        players = [];
+        round = 1;
+        spinAngle = 0;
+        currentStatements = ['', '', ''];
+        saveNames();
+        renderPlayerList();
+        showScreen('screenSetup');
+      }
+    </script>
+  </body>
+</html>

--- a/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/meta.json
+++ b/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/meta.json
@@ -1,0 +1,84 @@
+{
+  "id": "two-truths-lie-game",
+  "name": "2 Truths and a Lie",
+  "shortDescription": "Host a live 2 Truths and a Lie party game — spin to pick speakers, record guesses, reveal the lie, and track scores across rounds.",
+  "thumbnail": "thumbnail.svg",
+  "createdAt": "2026-03-31T01:54:53Z",
+  "category": "Icebreakers",
+  "status": "active",
+  "tags": ["party", "game", "social", "spinner", "multiplayer", "zoom", "icebreaker", "responsive"],
+  "homepagePath": "index.html",
+  "inputMode": "responsive",
+  "generation": {
+    "agentName": "Claude Code",
+    "llmModel": "claude-sonnet-4-6",
+    "startTime": "2026-03-31T01:54:53Z",
+    "endTime": "2026-03-31T02:02:26Z",
+    "totalTokensIn": 5200,
+    "totalTokensOut": 12400,
+    "runId": "run-20260331T015453Z-a7f3c2",
+    "notes": "Built from community suggestion #243. 6-screen host-driven flow: Setup → Think Timer (round 1 only) → Spinner wheel → Turn/Guess recording → Reveal → Round-end Scoreboard. Dark purple theme optimised for Zoom screen-sharing."
+  },
+  "improvements": [
+    {
+      "issueNumber": 247,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/247",
+      "runId": "run-20260331T024754Z-b3c9e1",
+      "appliedAt": "2026-03-31T02:47:54Z",
+      "summary": "Enlarged guess buttons (52x52) with glow, scale, and checkmark badge when selected; whole row highlights purple on selection. Replaced generic points card on reveal screen with a prominent winners banner listing correct guessers by name as green chips."
+    },
+    {
+      "issueNumber": 245,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/245",
+      "runId": "run-20260331T022221Z-d4e8f1",
+      "appliedAt": "2026-03-31T02:22:21Z",
+      "summary": "Fixed spinner wheel alignment (integer rotations + corrected modulo formula), added host statement capture on turn screen with numbered display, updated reveal screen to show statements with lie highlighted, redrew thumbnail with geometrically perfect circular wheel using SVG arc paths and clipPath."
+    },
+    {
+      "issueNumber": 249,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/249",
+      "runId": "run-20260331T112654Z-e7f521",
+      "description": "Renamed Reveal the Lie button to Show the Winners, added End Game button on spinner screen to finish round early and show scoreboard.",
+      "requestor": "Jeff Holst",
+      "implementedAt": "2026-03-31T11:26:54Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-opus-4-6"
+    },
+    {
+      "issueNumber": 251,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/251",
+      "runId": "run-20260331T114206Z-c31c68",
+      "description": "Moved End Game button on spinner screen to reduce accidental clicks, changed End Game on Round Complete to return to setup with player names preserved, added Remove All button on setup screen.",
+      "requestor": "Jeff Holst",
+      "implementedAt": "2026-03-31T11:42:06Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-opus-4-6"
+    },
+    {
+      "issueNumber": 253,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/253",
+      "runId": "run-20260331T195547Z-a7a8dd",
+      "description": "Updated scoreboard ranking so tied players share the same medal and subsequent ranks are skipped (competition ranking).",
+      "requestor": "Jeff Holst",
+      "implementedAt": "2026-03-31T19:55:47Z",
+      "agentName": "Codex",
+      "llmModel": "gpt-5"
+    },
+    {
+      "issueNumber": 350,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/350",
+      "runId": "run-20260418T161449Z-b2be10",
+      "description": "Persist setup-screen player names to localStorage so they are recalled on the next visit. Names are saved after add, remove, remove-all, and reset; scores always start at zero.",
+      "requestor": "jeffholst",
+      "implementedAt": "2026-04-18T16:14:49Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-opus-4-7"
+    }
+  ],
+  "suggestion": {
+    "issueNumber": 243,
+    "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/243",
+    "prompt": "Build a browser-based \"2 Truths and a Lie\" game for a Zoom screen-share host. Start with a setup screen where the host enters participant names. Then show instructions and a 60-second countdown for everyone to think of 3 statements (2 true, 1 false). After the first round timer ends, show a wheel containing all participant names and a button to spin and randomly choose the next speaker. For each turn, show a scoreboard where the host records which statement (1, 2, or 3) each participant guessed was the lie. After reveal, mark everyone who guessed correctly as round winners. Support multiple rounds; only the first round uses the 60-second timer. Make it simple, responsive, and easy to run live on a shared screen.",
+    "requestor": "Jeff Holst"
+  }
+}

--- a/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/thumbnail.svg
+++ b/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/thumbnail.svg
@@ -1,0 +1,213 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <defs>
+    <!-- Background gradient -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e1040"/>
+    </linearGradient>
+    <!-- Title gradient -->
+    <linearGradient id="titleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#818cf8"/>
+    </linearGradient>
+    <!-- Card surface gradient -->
+    <linearGradient id="cardGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1e293b"/>
+      <stop offset="100%" stop-color="#172033"/>
+    </linearGradient>
+    <!-- Glow filter for title -->
+    <filter id="titleGlow" x="-20%" y="-50%" width="140%" height="200%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Drop shadow for wheel -->
+    <filter id="wheelShadow" x="-15%" y="-15%" width="130%" height="130%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="8" result="blur"/>
+      <feOffset dx="0" dy="4" result="shadow"/>
+      <feFlood flood-color="#8b5cf6" flood-opacity="0.4" result="color"/>
+      <feComposite in="color" in2="shadow" operator="in" result="coloredShadow"/>
+      <feMerge>
+        <feMergeNode in="coloredShadow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Card shadow -->
+    <filter id="cardShadow" x="-5%" y="-5%" width="110%" height="120%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"/>
+      <feOffset dx="0" dy="3"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Clip to enforce perfectly circular wheel boundary -->
+    <clipPath id="wheelClip">
+      <circle cx="230" cy="250" r="135"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background -->
+  <rect x="0" y="0" width="800" height="450" fill="url(#bgGrad)"/>
+
+  <!-- Subtle grid texture -->
+  <g opacity="0.06">
+    <line x1="0" y1="75" x2="800" y2="75" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="0" y1="150" x2="800" y2="150" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="0" y1="225" x2="800" y2="225" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="0" y1="300" x2="800" y2="300" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="0" y1="375" x2="800" y2="375" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="100" y1="0" x2="100" y2="450" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="200" y1="0" x2="200" y2="450" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="300" y1="0" x2="300" y2="450" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="400" y1="0" x2="400" y2="450" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="500" y1="0" x2="500" y2="450" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="600" y1="0" x2="600" y2="450" stroke="#a78bfa" stroke-width="1"/>
+    <line x1="700" y1="0" x2="700" y2="450" stroke="#a78bfa" stroke-width="1"/>
+  </g>
+
+  <!-- Edge glow frame -->
+  <rect x="0" y="0" width="800" height="450" fill="none" stroke="#8b5cf6" stroke-width="3" opacity="0.5"/>
+  <rect x="4" y="4" width="792" height="442" fill="none" stroke="#a78bfa" stroke-width="1" opacity="0.2"/>
+
+  <!-- ── Spinner wheel ── -->
+  <!-- Glow halo behind wheel -->
+  <circle cx="230" cy="250" r="145" fill="#8b5cf6" opacity="0.07"/>
+
+  <!--
+    8 equal segments, 45deg each, clockwise from top.
+    All arcs use rx=135 ry=135 (perfect circle), large-arc-flag=0, sweep=1 (CW).
+    Segment endpoints computed from cx=230 cy=250 r=135:
+      P0 (  0deg top):    (230,   115)
+      P1 ( 45deg):        (325.5, 154.5)
+      P2 ( 90deg right):  (365,   250)
+      P3 (135deg):        (325.5, 345.5)
+      P4 (180deg bottom): (230,   385)
+      P5 (225deg):        (134.5, 345.5)
+      P6 (270deg left):   (95,    250)
+      P7 (315deg):        (134.5, 154.5)
+  -->
+  <g filter="url(#wheelShadow)" clip-path="url(#wheelClip)">
+    <!-- Seg 0: purple  0-45deg -->
+    <path d="M230,250 L230,115 A135,135 0 0,1 325.5,154.5 Z" fill="#7c3aed"/>
+    <!-- Seg 1: blue   45-90deg -->
+    <path d="M230,250 L325.5,154.5 A135,135 0 0,1 365,250 Z" fill="#2563eb"/>
+    <!-- Seg 2: green  90-135deg -->
+    <path d="M230,250 L365,250 A135,135 0 0,1 325.5,345.5 Z" fill="#059669"/>
+    <!-- Seg 3: orange 135-180deg -->
+    <path d="M230,250 L325.5,345.5 A135,135 0 0,1 230,385 Z" fill="#d97706"/>
+    <!-- Seg 4: red    180-225deg -->
+    <path d="M230,250 L230,385 A135,135 0 0,1 134.5,345.5 Z" fill="#dc2626"/>
+    <!-- Seg 5: teal   225-270deg -->
+    <path d="M230,250 L134.5,345.5 A135,135 0 0,1 95,250 Z" fill="#0891b2"/>
+    <!-- Seg 6: lime   270-315deg -->
+    <path d="M230,250 L95,250 A135,135 0 0,1 134.5,154.5 Z" fill="#65a30d"/>
+    <!-- Seg 7: violet 315-360deg -->
+    <path d="M230,250 L134.5,154.5 A135,135 0 0,1 230,115 Z" fill="#9333ea"/>
+  </g>
+
+  <!-- Spoke lines (inside the clip) -->
+  <g clip-path="url(#wheelClip)" stroke="rgba(0,0,0,0.3)" stroke-width="1.5">
+    <line x1="230" y1="250" x2="230" y2="115"/>
+    <line x1="230" y1="250" x2="325.5" y2="154.5"/>
+    <line x1="230" y1="250" x2="365" y2="250"/>
+    <line x1="230" y1="250" x2="325.5" y2="345.5"/>
+    <line x1="230" y1="250" x2="230" y2="385"/>
+    <line x1="230" y1="250" x2="134.5" y2="345.5"/>
+    <line x1="230" y1="250" x2="95" y2="250"/>
+    <line x1="230" y1="250" x2="134.5" y2="154.5"/>
+  </g>
+
+  <!-- Outer ring border -->
+  <circle cx="230" cy="250" r="135" fill="none" stroke="rgba(0,0,0,0.4)" stroke-width="2"/>
+
+  <!--
+    Segment labels at 65% radius (r=88) at each segment midpoint angle.
+    Midpoint angles (clockwise from top): 22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5
+    Label positions:
+      22.5:  (264, 169)   67.5:  (311, 216)   112.5: (311, 284)   157.5: (264, 331)
+      202.5: (196, 331)   247.5: (149, 284)   292.5: (149, 216)   337.5: (196, 169)
+  -->
+  <g font-family="system-ui,sans-serif" font-size="12" font-weight="600" fill="white" text-anchor="middle" dominant-baseline="central">
+    <text x="264" y="169" transform="rotate(22.5,264,169)">Alex</text>
+    <text x="311" y="216" transform="rotate(67.5,311,216)">Sam</text>
+    <text x="311" y="284" transform="rotate(112.5,311,284)">Jordan</text>
+    <text x="264" y="331" transform="rotate(157.5,264,331)">Taylor</text>
+    <text x="196" y="331" transform="rotate(202.5,196,331)">Morgan</text>
+    <text x="149" y="284" transform="rotate(247.5,149,284)">Casey</text>
+    <text x="149" y="216" transform="rotate(292.5,149,216)">Riley</text>
+    <text x="196" y="169" transform="rotate(337.5,196,169)">Jamie</text>
+  </g>
+
+  <!-- Center hub -->
+  <circle cx="230" cy="250" r="20" fill="#1e293b"/>
+  <circle cx="230" cy="250" r="20" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="2"/>
+
+  <!-- Pointer arrow pointing left, tip at wheel right edge -->
+  <polygon points="375,250 362,238 362,262" fill="#a78bfa" filter="url(#titleGlow)"/>
+
+  <!-- Spin result label -->
+  <text x="230" y="425" fill="#a78bfa" font-size="15" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">🎉 Sam!</text>
+
+  <!-- ── Right panel: Guess recording ── -->
+  <rect x="420" y="100" width="355" height="330" rx="14" fill="url(#cardGrad)" stroke="#334155" stroke-width="1.5" filter="url(#cardShadow)"/>
+
+  <!-- Panel header -->
+  <text x="597" y="133" fill="#94a3b8" font-size="11" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" letter-spacing="0.08em">NOW SPEAKING</text>
+  <text x="597" y="162" fill="#a78bfa" font-size="22" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">Sam</text>
+  <text x="597" y="180" fill="#64748b" font-size="11" font-family="system-ui,sans-serif" text-anchor="middle">Round 2</text>
+
+  <!-- Divider -->
+  <line x1="436" y1="190" x2="758" y2="190" stroke="#334155" stroke-width="1"/>
+
+  <!-- Statements section label -->
+  <text x="436" y="208" fill="#94a3b8" font-size="10" font-weight="700" font-family="system-ui,sans-serif" letter-spacing="0.07em">STATEMENTS</text>
+
+  <!-- Statement 1 -->
+  <rect x="434" y="213" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
+  <circle cx="452" cy="230" r="10" fill="#8b5cf6"/>
+  <text x="452" y="230" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">1</text>
+  <text x="468" y="230" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I once swam with sharks</text>
+
+  <!-- Statement 2 -->
+  <rect x="434" y="251" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
+  <circle cx="452" cy="268" r="10" fill="#8b5cf6"/>
+  <text x="452" y="268" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">2</text>
+  <text x="468" y="268" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I speak four languages</text>
+
+  <!-- Statement 3 -->
+  <rect x="434" y="289" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
+  <circle cx="452" cy="306" r="10" fill="#8b5cf6"/>
+  <text x="452" y="306" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">3</text>
+  <text x="468" y="306" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I've climbed Mt. Rainier</text>
+
+  <!-- Divider -->
+  <line x1="436" y1="332" x2="758" y2="332" stroke="#334155" stroke-width="1"/>
+  <text x="436" y="348" fill="#94a3b8" font-size="10" font-weight="700" font-family="system-ui,sans-serif" letter-spacing="0.07em">PLAYER GUESSES</text>
+
+  <!-- Guess row: Alex → 2 -->
+  <rect x="434" y="354" width="322" height="34" rx="7" fill="#172033" stroke="#334155" stroke-width="1.2"/>
+  <text x="450" y="371" fill="#f9fafb" font-size="12" font-weight="600" font-family="system-ui,sans-serif" dominant-baseline="central">Alex</text>
+  <rect x="683" y="359" width="28" height="24" rx="5" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="697" y="371" fill="white" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">2</text>
+  <rect x="715" y="359" width="28" height="24" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
+  <text x="729" y="371" fill="#94a3b8" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">3</text>
+  <rect x="747" y="359" width="28" height="24" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
+  <text x="761" y="371" fill="#94a3b8" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">1</text>
+
+  <!-- ── Title ── -->
+  <text x="400" y="55" fill="url(#titleGrad)" font-size="36" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">2 Truths and a Lie</text>
+  <text x="400" y="80" fill="#64748b" font-size="14" font-family="system-ui,sans-serif" text-anchor="middle">party game for Zoom</text>
+
+  <!-- Corner accents -->
+  <line x1="0" y1="0" x2="40" y2="0" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="0" y1="0" x2="0" y2="40" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="800" y1="0" x2="760" y2="0" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="800" y1="0" x2="800" y2="40" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="0" y1="450" x2="40" y2="450" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="0" y1="450" x2="0" y2="410" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="800" y1="450" x2="760" y2="450" stroke="#8b5cf6" stroke-width="3"/>
+  <line x1="800" y1="450" x2="800" y2="410" stroke="#8b5cf6" stroke-width="3"/>
+</svg>

--- a/apps/2026/03/31/two-truths-lie-game/index.html
+++ b/apps/2026/03/31/two-truths-lie-game/index.html
@@ -27,7 +27,6 @@
     <script src="/apps/shared/app-shell.js" defer></script>
 
     <style>
-      /* ── Theme variables ── */
       :root {
         --bg: #0f172a;
         --text: #f9fafb;
@@ -39,7 +38,6 @@
         --surface: #f3f4f6;
       }
 
-      /* ── App-specific palette ── */
       :root {
         --accent: #8b5cf6;
         --accent-bright: #a78bfa;
@@ -70,7 +68,6 @@
         min-height: 100dvh;
       }
 
-      /* ── Viewport wrapper — accounts for 64px header + 56px footer ── */
       #app {
         position: fixed;
         top: 64px;
@@ -81,30 +78,17 @@
         padding: 16px;
       }
 
-      /* ── Screens ── */
       .screen {
         display: none;
         flex-direction: column;
         align-items: center;
         gap: 16px;
-        max-width: 640px;
+        max-width: 760px;
         margin: 0 auto;
         padding-bottom: 16px;
       }
       .screen.active {
         display: flex;
-        animation: fadeIn 0.2s ease;
-      }
-
-      @keyframes fadeIn {
-        from {
-          opacity: 0;
-          transform: translateY(8px);
-        }
-        to {
-          opacity: 1;
-          transform: translateY(0);
-        }
       }
 
       h1 {
@@ -118,16 +102,15 @@
         font-weight: 600;
         text-align: center;
       }
-      h3 {
-        font-size: 0.85rem;
-        font-weight: 600;
-        color: var(--text-muted);
-        text-align: center;
-        text-transform: uppercase;
-        letter-spacing: 0.07em;
+
+      .card {
+        background: var(--card);
+        border: 1.5px solid var(--card-border);
+        border-radius: 12px;
+        padding: 16px;
+        width: 100%;
       }
 
-      /* ── Buttons ── */
       .btn {
         display: inline-flex;
         align-items: center;
@@ -141,174 +124,159 @@
         cursor: pointer;
         transition: all 0.15s ease;
         min-height: 48px;
-        min-width: 44px;
       }
       .btn:active {
-        transform: scale(0.97);
+        transform: scale(0.98);
       }
       .btn-primary {
         background: var(--accent);
-        color: white;
+        color: #fff;
       }
       .btn-primary:hover {
         background: var(--accent-dark);
       }
       .btn-success {
         background: var(--success);
-        color: white;
-      }
-      .btn-success:hover {
-        filter: brightness(0.9);
+        color: #fff;
       }
       .btn-danger {
         background: var(--danger);
-        color: white;
-      }
-      .btn-danger:hover {
-        filter: brightness(0.9);
+        color: #fff;
       }
       .btn-ghost {
         background: transparent;
         color: var(--text-muted);
         border: 1.5px solid var(--card-border);
       }
-      .btn-ghost:hover {
-        background: var(--surface);
-        color: var(--text);
-      }
-      .btn-lg {
-        font-size: 1.15rem;
-        padding: 14px 32px;
-      }
       .btn-sm {
-        font-size: 0.875rem;
-        padding: 8px 14px;
-        min-height: 38px;
+        min-height: 36px;
+        padding: 8px 12px;
+        font-size: 0.85rem;
       }
       .btn:disabled {
         opacity: 0.45;
         cursor: not-allowed;
         transform: none;
       }
-      .full-width {
-        width: 100%;
-      }
 
-      /* ── Cards ── */
-      .card {
-        background: var(--card);
-        border: 1.5px solid var(--card-border);
-        border-radius: 12px;
-        padding: 16px;
+      .input,
+      .textarea,
+      .select {
         width: 100%;
-      }
-
-      /* ── Input ── */
-      .input {
-        width: 100%;
-        padding: 12px 14px;
+        padding: 11px 12px;
         background: var(--bg);
         border: 1.5px solid var(--card-border);
         border-radius: 8px;
         color: var(--text);
         font-size: 1rem;
-        outline: none;
-        transition: border-color 0.15s;
       }
-      .input:focus {
-        border-color: var(--accent);
+      .textarea {
+        min-height: 72px;
+        resize: vertical;
+      }
+
+      .muted {
+        color: var(--text-muted);
+        font-size: 0.92rem;
+      }
+
+      .full {
+        width: 100%;
       }
 
       .row {
         display: flex;
-        gap: 8px;
-        width: 100%;
+        gap: 10px;
         align-items: center;
+        width: 100%;
       }
-      .row .input {
-        flex: 1;
-      }
-
-      /* ── Player chips ── */
-      .player-list {
-        display: flex;
+      .row.wrap {
         flex-wrap: wrap;
+      }
+
+      .pill {
+        border: 1.5px solid var(--card-border);
+        border-radius: 999px;
+        padding: 5px 10px;
+        font-size: 0.82rem;
+        color: var(--text-muted);
+        background: var(--surface);
+      }
+
+      .players {
+        display: flex;
+        flex-direction: column;
         gap: 8px;
-        width: 100%;
       }
-      .player-chip {
-        display: flex;
+      .player-row {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        gap: 10px;
         align-items: center;
-        gap: 6px;
         background: var(--surface);
         border: 1.5px solid var(--card-border);
-        border-radius: 20px;
-        padding: 6px 12px;
-        font-size: 0.9rem;
+        border-radius: 10px;
+        padding: 10px 12px;
       }
-      .player-chip button {
-        background: none;
-        border: none;
-        color: var(--text-muted);
-        cursor: pointer;
-        font-size: 1rem;
-        line-height: 1;
-        padding: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 24px;
-        min-width: 24px;
-        border-radius: 50%;
+      .status-ready {
+        color: var(--success);
+        font-weight: 600;
       }
-      .player-chip button:hover {
-        color: var(--danger);
+      .status-waiting {
+        color: var(--warning);
+        font-weight: 600;
       }
 
-      /* ── Round badge ── */
-      .round-badge {
+      .statement-list,
+      .vote-list,
+      .result-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .statement-item,
+      .vote-row,
+      .result-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
         background: var(--surface);
         border: 1.5px solid var(--card-border);
-        border-radius: 20px;
-        padding: 4px 14px;
-        font-size: 0.85rem;
-        color: var(--text-muted);
+        border-radius: 10px;
+        padding: 10px 12px;
       }
 
-      /* ── Timer ring ── */
-      .timer-ring {
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+      .vote-buttons {
+        display: grid;
+        gap: 8px;
+        grid-template-columns: repeat(3, 1fr);
       }
-      .timer-ring svg {
-        transform: rotate(-90deg);
-      }
-      .timer-number {
-        position: absolute;
-        font-size: clamp(2.5rem, 10vw, 4rem);
+      .vote-btn {
+        min-height: 52px;
+        border-radius: 10px;
+        border: 1.5px solid var(--card-border);
+        background: var(--bg);
+        color: var(--text);
+        font-size: 1.1rem;
         font-weight: 700;
-        color: var(--accent-bright);
+        cursor: pointer;
       }
-      #timerCircle {
-        transition: stroke-dashoffset 1s linear;
-        stroke-linecap: round;
+      .vote-btn.active {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+      .vote-btn:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
       }
 
-      /* ── Spinner wheel ── */
-      .wheel-container {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-      }
-      .wheel-wrapper {
+      .wheel-wrap {
         position: relative;
         display: inline-block;
       }
       #spinCanvas {
-        display: block;
         border-radius: 50%;
         max-width: 100%;
       }
@@ -324,904 +292,455 @@
         filter: drop-shadow(0 0 4px var(--accent));
       }
 
-      /* ── Speaker name ── */
-      .winner-name {
-        font-size: clamp(1.8rem, 6vw, 2.8rem);
+      .big-name {
+        text-align: center;
+        font-size: clamp(1.6rem, 6vw, 2.7rem);
         font-weight: 700;
         color: var(--accent-bright);
-        text-align: center;
-        text-shadow: 0 0 20px rgba(139, 92, 246, 0.5);
       }
 
-      @keyframes spinResult {
-        0%,
-        100% {
-          transform: scale(1);
-        }
-        50% {
-          transform: scale(1.05);
-        }
-      }
-      .spin-result {
-        animation: spinResult 0.4s ease;
-      }
-
-      /* ── Guess grid ── */
-      .guess-grid {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-        width: 100%;
-      }
-      .guess-row {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        background: var(--card);
-        border: 1.5px solid var(--card-border);
-        border-radius: 10px;
-        padding: 10px 14px;
-      }
-      .guess-row.correct {
+      .result-good {
         border-color: var(--success);
         background: rgba(16, 185, 129, 0.1);
       }
-      .guess-row.wrong {
+      .result-bad {
         border-color: var(--danger);
-        background: rgba(239, 68, 68, 0.08);
-      }
-      .guess-name {
-        flex: 1;
-        font-weight: 600;
-        font-size: 1rem;
-      }
-      .guess-btns {
-        display: flex;
-        gap: 6px;
-      }
-      .guess-btn {
-        width: 52px;
-        height: 52px;
-        border-radius: 10px;
-        border: 2px solid var(--card-border);
-        background: var(--bg);
-        color: var(--text-muted);
-        font-size: 1.1rem;
-        font-weight: 700;
-        cursor: pointer;
-        transition: all 0.15s;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        position: relative;
-      }
-      .guess-btn:hover {
-        border-color: var(--accent);
-        color: var(--accent-bright);
-        background: rgba(139, 92, 246, 0.12);
-        transform: scale(1.05);
-      }
-      .guess-btn.selected {
-        background: var(--accent);
-        border-color: var(--accent);
-        color: white;
-        box-shadow: 0 0 12px rgba(139, 92, 246, 0.5);
-        transform: scale(1.1);
-      }
-      .guess-btn.selected::after {
-        content: '✓';
-        position: absolute;
-        top: -6px;
-        right: -6px;
-        background: var(--success);
-        color: white;
-        border-radius: 50%;
-        width: 16px;
-        height: 16px;
-        font-size: 9px;
-        font-weight: 900;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        line-height: 1;
-      }
-      .guess-row.has-guess {
-        border-color: var(--accent-dark);
-        background: rgba(139, 92, 246, 0.06);
-      }
-      /* Winners banner */
-      .winners-banner {
-        width: 100%;
-        background: linear-gradient(135deg, rgba(16,185,129,0.15), rgba(16,185,129,0.05));
-        border: 2px solid var(--success);
-        border-radius: 14px;
-        padding: 16px;
-        text-align: center;
-      }
-      .winners-banner h2 {
-        color: var(--success);
-        margin-bottom: 10px;
-        filter: drop-shadow(0 0 6px rgba(16,185,129,0.4));
-      }
-      .winners-list {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-        justify-content: center;
-      }
-      .winner-chip {
-        background: var(--success);
-        color: white;
-        border-radius: 20px;
-        padding: 6px 14px;
-        font-weight: 700;
-        font-size: 1rem;
-      }
-      .no-winners-banner {
-        width: 100%;
-        background: rgba(148, 163, 184, 0.08);
-        border: 2px solid var(--card-border);
-        border-radius: 14px;
-        padding: 14px;
-        text-align: center;
-        color: var(--text-muted);
-        font-size: 1rem;
-      }
-      .guess-icon {
-        font-size: 1.2rem;
-        min-width: 24px;
-        text-align: center;
+        background: rgba(239, 68, 68, 0.1);
       }
 
-      /* ── Scoreboard table ── */
-      .score-table {
-        width: 100%;
-        border-collapse: collapse;
-      }
-      .score-table th,
-      .score-table td {
-        padding: 10px 14px;
-        text-align: left;
-        border-bottom: 1px solid var(--card-border);
-      }
-      .score-table th {
-        font-size: 0.8rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: var(--text-muted);
-      }
-      .score-table tr:last-child td {
-        border-bottom: none;
-      }
-      .score-rank {
-        font-size: 1.2rem;
-        min-width: 30px;
-      }
-      .score-points {
-        font-weight: 700;
-        font-size: 1.1rem;
-        color: var(--accent-bright);
+      .hidden {
+        display: none !important;
       }
 
-      /* ── Instructions ── */
-      .instructions {
-        list-style: none;
-        display: flex;
-        flex-direction: column;
-        gap: 10px;
-        width: 100%;
-      }
-      .instructions li {
-        display: flex;
-        gap: 12px;
-        align-items: flex-start;
-        background: var(--surface);
-        border-radius: 10px;
-        padding: 12px 14px;
-        font-size: 0.95rem;
-        line-height: 1.45;
-      }
-      .instructions li .num {
-        background: var(--accent);
-        color: white;
-        border-radius: 50%;
-        width: 24px;
-        height: 24px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.8rem;
-        font-weight: 700;
-        flex-shrink: 0;
-        margin-top: 1px;
-      }
-
-      /* ── Utility ── */
-      .text-center {
-        text-align: center;
-      }
-      .text-muted {
-        color: var(--text-muted);
-        font-size: 0.9rem;
-      }
-      .flex-row {
-        display: flex;
-        gap: 10px;
-        width: 100%;
-      }
-      .flex-row .btn {
-        flex: 1;
+      @media (max-width: 640px) {
+        .player-row {
+          grid-template-columns: 1fr;
+        }
+        .vote-buttons {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
       }
     </style>
   </head>
   <body>
     <div id="app">
-      <!-- ── SCREEN: Setup ── -->
-      <div id="screenSetup" class="screen active">
+      <div id="screenLoading" class="screen active">
         <h1>2 Truths and a Lie</h1>
-        <p class="text-muted text-center">Add everyone who's playing, then start.</p>
+        <p class="muted">Connecting to multiplayer room...</p>
+      </div>
 
+      <div id="screenError" class="screen">
+        <h1>Connection Error</h1>
+        <div class="card"><p id="errorText" class="muted"></p></div>
+      </div>
+
+      <div id="screenJoin" class="screen">
+        <h1>Join 2 Truths and a Lie</h1>
         <div class="card">
-          <div class="row">
-            <input
-              id="nameInput"
-              class="input"
-              type="text"
-              placeholder="Enter player name…"
-              maxlength="30"
-              autocomplete="off"
-            />
-            <button class="btn btn-primary" onclick="addPlayer()">Add</button>
+          <p class="muted" style="margin-bottom: 8px">Code: <strong id="joinCodeLabel"></strong></p>
+          <div class="row wrap" style="margin-bottom: 8px">
+            <input id="joinNameInput" class="input" maxlength="30" placeholder="Your name" />
           </div>
-        </div>
-
-        <div id="playerList" class="player-list"></div>
-        <div style="display: flex; align-items: center; gap: 10px; width: 100%">
-          <p id="playerCountMsg" class="text-muted" style="display: none; flex: 1; margin: 0"></p>
-          <button
-            id="removeAllBtn"
-            class="btn btn-ghost btn-sm"
-            style="display: none; color: var(--danger)"
-            onclick="removeAllPlayers()"
+          <p class="muted" style="margin-bottom: 6px">Enter two truths and one lie.</p>
+          <div class="statement-list" style="margin-bottom: 10px">
+            <textarea id="joinStatement1" class="textarea" maxlength="180" placeholder="Statement 1"></textarea>
+            <textarea id="joinStatement2" class="textarea" maxlength="180" placeholder="Statement 2"></textarea>
+            <textarea id="joinStatement3" class="textarea" maxlength="180" placeholder="Statement 3"></textarea>
+          </div>
+          <label class="muted" for="joinLieSelect" style="display: block; margin-bottom: 6px"
+            >Which statement is the lie?</label
           >
-            Remove All
-          </button>
+          <select id="joinLieSelect" class="select" style="margin-bottom: 12px">
+            <option value="0">Statement 1</option>
+            <option value="1">Statement 2</option>
+            <option value="2">Statement 3</option>
+          </select>
+          <button id="joinSubmitBtn" class="btn btn-primary full">Submit and Join</button>
+          <p id="joinMessage" class="muted" style="margin-top: 8px"></p>
         </div>
-
-        <button id="startBtn" class="btn btn-primary btn-lg full-width" onclick="startGame()" disabled>
-          Start Game
-        </button>
       </div>
 
-      <!-- ── SCREEN: Think Time (round 1 only) ── -->
-      <div id="screenThink" class="screen">
-        <h1>Think Time!</h1>
-        <h2>Everyone: write your 3 statements</h2>
-
-        <div class="timer-ring">
-          <svg width="180" height="180" viewBox="0 0 180 180">
-            <circle cx="90" cy="90" r="80" fill="none" stroke="var(--card-border)" stroke-width="10" />
-            <circle
-              id="timerCircle"
-              cx="90"
-              cy="90"
-              r="80"
-              fill="none"
-              stroke-width="10"
-              stroke-dasharray="502.65"
-              stroke-dashoffset="0"
-            />
-          </svg>
-          <span class="timer-number" id="timerNum">60</span>
+      <div id="screenModerator" class="screen">
+        <h1>2 Truths and a Lie</h1>
+        <div class="row wrap">
+          <span class="pill">Moderator</span>
+          <span class="pill" id="modCodePill">Code: ----</span>
+          <span class="pill" id="modPhasePill">Lobby</span>
         </div>
 
-        <ul class="instructions">
-          <li><span class="num">1</span>Write 2 TRUE statements about yourself</li>
-          <li><span class="num">2</span>Write 1 LIE — make it believable!</li>
-          <li>
-            <span class="num">3</span>When time's up, the host spins to pick the first speaker
-          </li>
-        </ul>
-
-        <button class="btn btn-ghost full-width" onclick="skipTimer()">Skip Timer →</button>
-      </div>
-
-      <!-- ── SCREEN: Spinner ── -->
-      <div id="screenSpin" class="screen">
-        <div class="round-badge" id="roundBadgeSpin"></div>
-        <h2 id="spinTitle">Who goes next?</h2>
-
-        <div class="wheel-container">
-          <div class="wheel-wrapper" id="wheelWrapper">
-            <canvas id="spinCanvas" width="280" height="280"></canvas>
-            <div class="wheel-pointer" id="wheelPointer"></div>
+        <div id="modLobbyPanel" class="card full">
+          <h2>Lobby</h2>
+          <p class="muted" style="margin: 6px 0 10px">Share this link with players.</p>
+          <div class="row wrap" style="margin-bottom: 10px">
+            <input id="joinLinkInput" class="input" readonly />
+            <button id="copyJoinLinkBtn" class="btn btn-ghost btn-sm">Copy Link</button>
           </div>
-        </div>
-
-        <button id="spinBtn" class="btn btn-primary btn-lg" onclick="spinWheel()">🎡 Spin!</button>
-        <div id="spinResult" class="winner-name" style="display: none"></div>
-        <button
-          id="goTurnBtn"
-          class="btn btn-success btn-lg full-width"
-          style="display: none"
-          onclick="goToTurn()"
-        >
-          It's their turn →
-        </button>
-        <button
-          class="btn btn-ghost btn-sm"
-          style="margin-top: 8px; opacity: 0.7"
-          onclick="endRoundEarly()"
-        >
-          End Game
-        </button>
-      </div>
-
-      <!-- ── SCREEN: Turn (record guesses) ── -->
-      <div id="screenTurn" class="screen">
-        <div class="round-badge" id="roundBadgeTurn"></div>
-        <h3>Now speaking…</h3>
-        <div class="winner-name" id="turnSpeakerName"></div>
-
-        <!-- Phase 1: host enters the 3 statements -->
-        <div id="statementCapture" class="card">
-          <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 10px">
-            Ask <strong id="turnSpeakerName2"></strong> to share their 3 statements, then type them
-            in below.
+          <p id="modLobbyMessage" class="muted" style="margin-bottom: 8px">
+            Players appear here as they submit their two truths and a lie.
           </p>
-          <div style="display: flex; flex-direction: column; gap: 10px">
-            <div style="display: flex; gap: 10px; align-items: center">
-              <span
-                style="
-                  background: var(--accent);
-                  color: white;
-                  border-radius: 50%;
-                  width: 28px;
-                  height: 28px;
-                  display: flex;
-                  align-items: center;
-                  justify-content: center;
-                  font-weight: 700;
-                  flex-shrink: 0;
-                "
-                >1</span
-              >
-              <input
-                id="stmt1"
-                class="input"
-                type="text"
-                placeholder="Statement 1…"
-                maxlength="140"
-                autocomplete="off"
-              />
-            </div>
-            <div style="display: flex; gap: 10px; align-items: center">
-              <span
-                style="
-                  background: var(--accent);
-                  color: white;
-                  border-radius: 50%;
-                  width: 28px;
-                  height: 28px;
-                  display: flex;
-                  align-items: center;
-                  justify-content: center;
-                  font-weight: 700;
-                  flex-shrink: 0;
-                "
-                >2</span
-              >
-              <input
-                id="stmt2"
-                class="input"
-                type="text"
-                placeholder="Statement 2…"
-                maxlength="140"
-                autocomplete="off"
-              />
-            </div>
-            <div style="display: flex; gap: 10px; align-items: center">
-              <span
-                style="
-                  background: var(--accent);
-                  color: white;
-                  border-radius: 50%;
-                  width: 28px;
-                  height: 28px;
-                  display: flex;
-                  align-items: center;
-                  justify-content: center;
-                  font-weight: 700;
-                  flex-shrink: 0;
-                "
-                >3</span
-              >
-              <input
-                id="stmt3"
-                class="input"
-                type="text"
-                placeholder="Statement 3…"
-                maxlength="140"
-                autocomplete="off"
-              />
-            </div>
-          </div>
-          <button
-            id="showStatementsBtn"
-            class="btn btn-primary full-width"
-            style="margin-top: 14px"
-            onclick="submitStatements()"
-            disabled
-          >
-            Show Statements on Screen →
+          <div id="modLobbyPlayers" class="players"></div>
+          <button id="modStartGameBtn" class="btn btn-success full" style="margin-top: 12px" disabled>
+            Start Game
           </button>
         </div>
 
-        <!-- Phase 2: statements displayed + guess recording (shown after submitStatements) -->
-        <div id="statementsDisplay" style="display: none; width: 100%">
-          <div class="card">
-            <h3 style="margin-bottom: 10px">Statements</h3>
-            <div style="display: flex; flex-direction: column; gap: 8px">
-              <div class="guess-row" style="border-color: var(--accent-dark)">
-                <span
-                  style="
-                    background: var(--accent);
-                    color: white;
-                    border-radius: 50%;
-                    width: 28px;
-                    height: 28px;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    font-weight: 700;
-                    flex-shrink: 0;
-                  "
-                  >1</span
-                >
-                <span id="stmtDisplay1" class="guess-name" style="font-weight: 400"></span>
-              </div>
-              <div class="guess-row" style="border-color: var(--accent-dark)">
-                <span
-                  style="
-                    background: var(--accent);
-                    color: white;
-                    border-radius: 50%;
-                    width: 28px;
-                    height: 28px;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    font-weight: 700;
-                    flex-shrink: 0;
-                  "
-                  >2</span
-                >
-                <span id="stmtDisplay2" class="guess-name" style="font-weight: 400"></span>
-              </div>
-              <div class="guess-row" style="border-color: var(--accent-dark)">
-                <span
-                  style="
-                    background: var(--accent);
-                    color: white;
-                    border-radius: 50%;
-                    width: 28px;
-                    height: 28px;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    font-weight: 700;
-                    flex-shrink: 0;
-                  "
-                  >3</span
-                >
-                <span id="stmtDisplay3" class="guess-name" style="font-weight: 400"></span>
-              </div>
-            </div>
+        <div id="modSpinPanel" class="card full hidden">
+          <h2>Pick the next speaker</h2>
+          <div class="wheel-wrap" style="margin: 10px auto; width: 280px">
+            <canvas id="spinCanvas" width="280" height="280"></canvas>
+            <div id="wheelPointer" class="wheel-pointer"></div>
           </div>
-
-          <div class="card" style="margin-top: 0">
-            <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 10px">
-              Each player: which number is the lie?
-            </p>
-            <div class="guess-grid" id="guessGrid"></div>
+          <div id="modSelectedSpeaker" class="big-name" style="display: none"></div>
+          <div class="row wrap" style="margin-top: 12px">
+            <button id="modSpinBtn" class="btn btn-primary">Spin Wheel</button>
+            <button id="modStartRoundBtn" class="btn btn-success" disabled>Start Round</button>
           </div>
+        </div>
 
-          <div class="card" style="margin-top: 0">
-            <p style="font-size: 0.9rem; color: var(--text-muted); margin-bottom: 8px">
-              Which statement was the LIE?
-            </p>
-            <div class="flex-row" id="lieButtons">
-              <button class="btn btn-ghost" onclick="selectLie(1)">Statement 1</button>
-              <button class="btn btn-ghost" onclick="selectLie(2)">Statement 2</button>
-              <button class="btn btn-ghost" onclick="selectLie(3)">Statement 3</button>
-            </div>
-            <p
-              id="lieSelectedMsg"
-              style="display: none; margin-top: 8px; font-size: 0.9rem; color: var(--success); font-weight: 600"
-            ></p>
-          </div>
-
-          <button
-            id="revealBtn"
-            class="btn btn-success btn-lg full-width"
-            onclick="revealLie()"
-            disabled
-          >
-            Show the Winners!
+        <div id="modVotePanel" class="card full hidden">
+          <h2 id="modVoteTitle">Vote on the lie</h2>
+          <p class="muted" id="modVoteHint" style="margin: 6px 0 10px"></p>
+          <div id="modStatements" class="statement-list"></div>
+          <div id="modVoteProgress" class="muted" style="margin-top: 10px"></div>
+          <button id="modShowResultsBtn" class="btn btn-primary full" style="margin-top: 12px" disabled>
+            Show Results
           </button>
         </div>
-      </div>
 
-      <!-- ── SCREEN: Reveal ── -->
-      <div id="screenReveal" class="screen">
-        <div class="round-badge" id="roundBadgeReveal"></div>
-        <h2>The Lie was Statement <span id="lieNumDisplay"></span>!</h2>
-        <p class="text-center" id="revealSpeakerNote" style="color: var(--text-muted)"></p>
-
-        <div id="revealStatements" class="card" style="display: none; width: 100%">
-          <div style="display: flex; flex-direction: column; gap: 8px" id="revealStmtList"></div>
+        <div id="modResultsPanel" class="card full hidden">
+          <h2>Round Results</h2>
+          <p id="modResultSummary" class="muted" style="margin: 6px 0 10px"></p>
+          <div id="modResultsRows" class="result-list"></div>
+          <button id="modContinueBtn" class="btn btn-success full" style="margin-top: 12px">
+            Continue
+          </button>
         </div>
 
-        <div id="winnersBanner"></div>
-
-        <div class="guess-grid" id="revealGrid"></div>
-
-        <button id="nextTurnBtn" class="btn btn-primary btn-lg full-width" onclick="nextTurn()"></button>
-      </div>
-
-      <!-- ── SCREEN: Round End Scoreboard ── -->
-      <div id="screenRoundEnd" class="screen">
-        <h1>Round <span id="roundEndNum"></span> Complete!</h1>
-        <div class="card">
-          <table class="score-table">
-            <thead>
-              <tr>
-                <th></th>
-                <th>Player</th>
-                <th>Points</th>
-              </tr>
-            </thead>
-            <tbody id="roundEndScores"></tbody>
-          </table>
-        </div>
-        <div class="flex-row">
-          <button class="btn btn-ghost" onclick="returnToSetup()">End Game</button>
-          <button class="btn btn-primary" onclick="nextRound()">Next Round →</button>
+        <div class="card full">
+          <h2>Players</h2>
+          <div id="modRosterPlayers" class="players"></div>
         </div>
       </div>
 
-      <!-- ── SCREEN: Final Scores ── -->
-      <div id="screenFinal" class="screen">
-        <h1>🏆 Final Scores</h1>
-        <div class="card">
-          <table class="score-table">
-            <thead>
-              <tr>
-                <th></th>
-                <th>Player</th>
-                <th>Points</th>
-              </tr>
-            </thead>
-            <tbody id="finalScores"></tbody>
-          </table>
+      <div id="screenPlayer" class="screen">
+        <h1>2 Truths and a Lie</h1>
+        <div class="row wrap">
+          <span class="pill">Player</span>
+          <span class="pill" id="playerNamePill">Joined</span>
+          <span class="pill" id="playerPhasePill">Waiting</span>
         </div>
-        <button class="btn btn-primary btn-lg full-width" onclick="resetGame()">Play Again</button>
+
+        <div id="playerWaitingPanel" class="card full">
+          <h2 id="playerWaitingTitle">Waiting for moderator</h2>
+          <p id="playerWaitingText" class="muted" style="margin-top: 6px"></p>
+        </div>
+
+        <div id="playerVotePanel" class="card full hidden">
+          <h2 id="playerVoteTitle">Which statement is the lie?</h2>
+          <div id="playerStatements" class="statement-list" style="margin-top: 8px"></div>
+          <p id="playerVoteMessage" class="muted" style="margin: 10px 0 8px"></p>
+          <div class="vote-buttons">
+            <button class="vote-btn" data-vote-index="0">1</button>
+            <button class="vote-btn" data-vote-index="1">2</button>
+            <button class="vote-btn" data-vote-index="2">3</button>
+          </div>
+        </div>
+
+        <div id="playerResultsPanel" class="card full hidden">
+          <h2>Results Board</h2>
+          <p id="playerResultSummary" class="muted" style="margin: 6px 0 10px"></p>
+          <div id="playerResultsRows" class="result-list"></div>
+        </div>
       </div>
     </div>
 
     <script>
-      /**
-       * 2 Truths and a Lie — Game Controller
-       *
-       * Flow:
-       *   Setup → Think Time (round 1) → Spinner → Turn → Reveal
-       *   → (repeat Spinner/Turn/Reveal for each speaker)
-       *   → Round End Scoreboard → (next round or Final Scores)
-       *
-       * Scoring: 1 point per correct guess. The speaker earns no points.
-       */
+      const APP_ID = 'two-truths-lie-game';
+      const APP_NAME = '2 Truths and a Lie';
+      const APP_PATH = '/apps/2026/03/31/two-truths-lie-game';
+      const STORAGE_PREFIX = 'voa-mp-2tl';
+      const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+      const SESSION_POLL_MS = 1800;
+      const WHEEL_COLORS = ['#7c3aed', '#2563eb', '#059669', '#d97706', '#dc2626', '#0891b2'];
 
-      // ── Persistence ────────────────────────────────────────────────────────
-      /** localStorage key for persisting player names across sessions. */
-      const SAVED_NAMES_KEY = 'voa-2tl-saved-names';
+      const screens = {
+        loading: document.getElementById('screenLoading'),
+        error: document.getElementById('screenError'),
+        join: document.getElementById('screenJoin'),
+        moderator: document.getElementById('screenModerator'),
+        player: document.getElementById('screenPlayer'),
+      };
 
-      // ── State ──────────────────────────────────────────────────────────────
-      /** @type {{ name: string, points: number }[]} */
-      let players = [];
-
-      let round = 1;
-
-      /** Names of players yet to speak this round. */
-      let speakerQueue = [];
-
-      /** Name of the player currently speaking. */
-      let currentSpeaker = null;
-
-      /** Which statement number (1, 2, or 3) is the lie for this turn. */
-      let currentLie = null;
-
-      /** Map of guesser name → guessed statement number. */
-      let guesses = {};
-
-      /** The 3 statements entered by the host for the current speaker. */
-      let currentStatements = ['', '', ''];
-
-      let timerInterval = null;
-      let timerSecs = 60;
-
-      /** Whether the wheel is currently animating. */
+      let sessionCode = null;
+      let session = null;
+      let role = null;
+      let moderatorId = null;
+      let playerId = null;
+      let pollHandle = null;
       let spinning = false;
-
-      /** Current wheel rotation in radians. */
       let spinAngle = 0;
+      let selectedSpeakerId = null;
 
-      // ── Screen management ──────────────────────────────────────────────────
-
-      /**
-       * Activate a screen by ID and hide all others.
-       * @param {string} id - The ID of the screen element to show.
-       */
-      function showScreen(id) {
-        document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
-        document.getElementById(id).classList.add('active');
+      function showScreen(name) {
+        Object.entries(screens).forEach(([key, el]) => {
+          el.classList.toggle('active', key === name);
+        });
       }
 
-      // ── Setup screen ───────────────────────────────────────────────────────
+      function setError(message) {
+        document.getElementById('errorText').textContent = message;
+        showScreen('error');
+      }
 
-      const nameInput = document.getElementById('nameInput');
-      nameInput.addEventListener('keydown', e => {
-        if (e.key === 'Enter') addPlayer();
-      });
+      function hashParams() {
+        return new URLSearchParams(window.location.hash.replace(/^#/, ''));
+      }
 
-      /**
-       * Load previously-saved player names from localStorage into the players list.
-       * Only names persist across sessions; scores always start at zero.
-       */
-      function loadSavedNames() {
+      function setHash(params) {
+        window.location.hash = params.toString();
+      }
+
+      function localKey(key) {
+        return `${STORAGE_PREFIX}:${key}`;
+      }
+
+      function saveModeratorRecord(code, id) {
         try {
-          const raw = localStorage.getItem(SAVED_NAMES_KEY);
-          if (!raw) return;
-          const names = JSON.parse(raw);
-          if (!Array.isArray(names)) return;
-          players = names
-            .filter(n => typeof n === 'string' && n.trim())
-            .map(name => ({ name: name.trim(), points: 0 }));
+          window.localStorage.setItem(localKey(`mod:${code}`), JSON.stringify({ moderatorId: id }));
         } catch {
-          // Ignore corrupted storage; start with an empty list.
+          // no-op
         }
       }
 
-      /**
-       * Persist the current player names to localStorage so they can be recalled
-       * on the next visit.
-       */
-      function saveNames() {
+      function loadModeratorRecord(code) {
         try {
-          localStorage.setItem(SAVED_NAMES_KEY, JSON.stringify(players.map(p => p.name)));
+          const raw = window.localStorage.getItem(localKey(`mod:${code}`));
+          return raw ? JSON.parse(raw) : null;
         } catch {
-          // localStorage unavailable (private mode, quota) — silently skip.
+          return null;
         }
       }
 
-      loadSavedNames();
-      renderPlayerList();
+      function savePlayerName(name) {
+        try {
+          window.localStorage.setItem(localKey('playerName'), name);
+        } catch {
+          // no-op
+        }
+      }
 
-      /**
-       * Add the name from the input field to the player list.
-       * Ignores empty strings and duplicate names (case-insensitive).
-       */
-      function addPlayer() {
-        const name = nameInput.value.trim();
-        if (!name) return;
-        if (players.find(p => p.name.toLowerCase() === name.toLowerCase())) {
-          nameInput.select();
+      function loadPlayerName() {
+        try {
+          return window.localStorage.getItem(localKey('playerName')) || '';
+        } catch {
+          return '';
+        }
+      }
+
+      function generateSessionCode(length = 6) {
+        let code = '';
+        for (let i = 0; i < length; i += 1) {
+          code += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+        }
+        return code;
+      }
+
+      function generateId(prefix = 'id') {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+          return `${prefix}-${crypto.randomUUID()}`;
+        }
+        return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      }
+
+      async function isMultiplayerConfigured() {
+        const response = await fetch('/api/multiplayer/status', { cache: 'no-store' });
+        if (!response.ok) return false;
+        const payload = await response.json();
+        return Boolean(payload?.configured);
+      }
+
+      async function fetchSession(code) {
+        const response = await fetch(`/api/multiplayer/sessions/${code}`, { cache: 'no-store' });
+        if (response.status === 404) return null;
+        if (!response.ok) throw new Error('Failed to fetch session');
+        const payload = await response.json();
+        return payload?.session || null;
+      }
+
+      async function createSession(code, modId) {
+        const response = await fetch('/api/multiplayer/sessions', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            code,
+            appId: APP_ID,
+            appName: APP_NAME,
+            appPath: APP_PATH,
+            moderatorId: modId,
+            settings: {},
+          }),
+        });
+        if (response.status === 409) return false;
+        if (!response.ok) throw new Error('Failed to create session');
+        return true;
+      }
+
+      function flattenPatch(prefix, value, out) {
+        if (value === null || value === undefined) {
+          out[prefix] = value;
           return;
         }
-        players.push({ name, points: 0 });
-        nameInput.value = '';
-        nameInput.focus();
-        saveNames();
-        renderPlayerList();
+        const isObject = typeof value === 'object' && !Array.isArray(value);
+        if (!isObject) {
+          out[prefix] = value;
+          return;
+        }
+        const entries = Object.entries(value);
+        if (entries.length === 0) {
+          out[prefix] = {};
+          return;
+        }
+        entries.forEach(([key, child]) => {
+          flattenPatch(`${prefix}/${key}`, child, out);
+        });
       }
 
-      /**
-       * Remove a player by name from the list.
-       * @param {string} name - Exact player name to remove.
-       */
-      function removePlayer(name) {
-        players = players.filter(p => p.name !== name);
-        saveNames();
-        renderPlayerList();
-      }
-
-      /**
-       * Re-render the player chips and update the start button state.
-       * Requires at least 2 players to enable the start button.
-       */
-      function renderPlayerList() {
-        const list = document.getElementById('playerList');
-        const msg = document.getElementById('playerCountMsg');
-        const btn = document.getElementById('startBtn');
-
-        list.innerHTML = players
-          .map(
-            p =>
-              `<div class="player-chip">
-              <span>${escHtml(p.name)}</span>
-              <button data-remove="${escHtml(p.name)}">✕</button>
-            </div>`,
-          )
-          .join('');
-
-        // Attach remove listeners (avoids inline onclick quoting issues)
-        list.querySelectorAll('[data-remove]').forEach(btn => {
-          btn.addEventListener('click', () => removePlayer(btn.dataset.remove));
+      async function patchSession({ status = null, patch = {} } = {}) {
+        if (!sessionCode || !moderatorId) return;
+        const normalizedPatch = {};
+        Object.entries(patch).forEach(([key, value]) => {
+          if (key.includes('/')) {
+            normalizedPatch[key] = value;
+          } else {
+            flattenPatch(key, value, normalizedPatch);
+          }
         });
 
-        const n = players.length;
-        const removeAllBtn = document.getElementById('removeAllBtn');
-        if (n > 0) {
-          msg.style.display = 'block';
-          msg.textContent = n === 1 ? '1 player added — need at least 2' : `${n} players`;
-          removeAllBtn.style.display = 'inline-flex';
-        } else {
-          msg.style.display = 'none';
-          removeAllBtn.style.display = 'none';
+        const response = await fetch(`/api/multiplayer/sessions/${sessionCode}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ moderatorId, status, patch: normalizedPatch }),
+        });
+        if (!response.ok) {
+          throw new Error('Failed to update session');
         }
-        btn.disabled = n < 2;
       }
 
-      /**
-       * Escape HTML special characters to safely insert user input into innerHTML.
-       * @param {string} s - Raw string.
-       * @returns {string} HTML-escaped string.
-       */
-      function escHtml(s) {
-        return s
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#39;');
+      async function joinSession(code, name) {
+        const response = await fetch(`/api/multiplayer/sessions/${code}/players`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name }),
+        });
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload?.error || 'Unable to join session');
+        }
+        return response.json();
       }
 
-      /**
-       * Convert a player name to a DOM-safe ID fragment (alphanumeric + underscore).
-       * @param {string} name
-       * @returns {string}
-       */
-      function idSafe(name) {
-        return name.replace(/[^a-zA-Z0-9]/g, '_');
+      async function updatePlayer(playerPatch) {
+        if (!sessionCode || !playerId) return;
+        const response = await fetch(`/api/multiplayer/sessions/${sessionCode}/players/${playerId}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(playerPatch),
+        });
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload?.error || 'Unable to update player');
+        }
       }
 
-      // ── Game start ─────────────────────────────────────────────────────────
-
-      /**
-       * Reset scores and begin a new game from round 1.
-       * Shows the think-time screen (60-second countdown) for round 1.
-       */
-      function startGame() {
-        round = 1;
-        players.forEach(p => (p.points = 0));
-        buildSpeakerQueue();
-        showScreen('screenThink');
-        startTimer();
+      function activePlayers() {
+        if (!session?.players) return [];
+        return Object.values(session.players)
+          .filter((entry) => entry && entry.id)
+          .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
       }
 
-      /**
-       * Fill the speaker queue with all player names in their current order.
-       */
-      function buildSpeakerQueue() {
-        speakerQueue = players.map(p => p.name);
+      function gameState() {
+        return session?.game || null;
       }
 
-      // ── Think-time timer ───────────────────────────────────────────────────
-
-      const TIMER_CIRCUMFERENCE = 2 * Math.PI * 80; // r=80 matches the SVG
-
-      /**
-       * Start the 60-second countdown and update the ring + number each second.
-       * Automatically transitions to the spinner when time expires.
-       */
-      function startTimer() {
-        timerSecs = 60;
-        updateTimerDisplay(60);
-        clearInterval(timerInterval);
-        timerInterval = setInterval(() => {
-          timerSecs--;
-          updateTimerDisplay(timerSecs);
-          if (timerSecs <= 0) {
-            clearInterval(timerInterval);
-            showSpinner();
-          }
-        }, 1000);
+      function eligibleVoterIds(game) {
+        const speakerId = game?.currentSpeakerId || null;
+        return activePlayers()
+          .filter((p) => p.id !== speakerId)
+          .map((p) => p.id);
       }
 
-      /**
-       * Update the SVG ring progress and numeric label.
-       * Ring turns yellow below 20s and red below 10s.
-       * @param {number} secs - Seconds remaining.
-       */
-      function updateTimerDisplay(secs) {
-        document.getElementById('timerNum').textContent = secs;
-        const offset = TIMER_CIRCUMFERENCE * (1 - secs / 60);
-        const circle = document.getElementById('timerCircle');
-        circle.style.strokeDashoffset = offset;
-        circle.style.stroke =
-          secs <= 10 ? 'var(--danger)' : secs <= 20 ? 'var(--warning)' : 'var(--accent)';
+      function allVotesIn(game) {
+        if (!game || game.phase !== 'vote') return false;
+        const voters = eligibleVoterIds(game);
+        return voters.every((pid) => session?.players?.[pid]?.vote?.roundId === game.currentRoundId);
       }
 
-      /**
-       * Skip the think-time countdown and go directly to the spinner.
-       */
-      function skipTimer() {
-        clearInterval(timerInterval);
-        showSpinner();
+      function shuffle(array) {
+        const copy = [...array];
+        for (let i = copy.length - 1; i > 0; i -= 1) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [copy[i], copy[j]] = [copy[j], copy[i]];
+        }
+        return copy;
       }
 
-      // ── Spinner wheel ──────────────────────────────────────────────────────
-
-      /** Segment fill colors for the wheel, cycled for any player count. */
-      const WHEEL_COLORS = [
-        '#7c3aed',
-        '#2563eb',
-        '#059669',
-        '#d97706',
-        '#dc2626',
-        '#0891b2',
-        '#65a30d',
-        '#ea580c',
-        '#9333ea',
-        '#0f766e',
-      ];
-
-      /**
-       * Show the spinner screen, reset result area, and draw the wheel.
-       */
-      function showSpinner() {
-        document.getElementById('roundBadgeSpin').textContent = `Round ${round}`;
-        document.getElementById('spinTitle').textContent =
-          speakerQueue.length < players.length ? 'Who goes next?' : 'Who goes first?';
-        document.getElementById('spinResult').style.display = 'none';
-        document.getElementById('goTurnBtn').style.display = 'none';
-        document.getElementById('spinBtn').disabled = false;
-        showScreen('screenSpin');
-        drawWheel(spinAngle);
-        positionPointer();
+      function updateJoinLink() {
+        const input = document.getElementById('joinLinkInput');
+        if (!sessionCode || !input) return;
+        input.value = `${window.location.origin}${window.location.pathname}#join=${sessionCode}`;
       }
 
-      /**
-       * Position the arrow pointer flush against the right edge of the wheel canvas.
-       */
-      function positionPointer() {
+      function kickButtonHtml(entry) {
+        if (role !== 'moderator') return '';
+        return `<button type="button" class="btn btn-danger btn-sm" data-kick="${entry.id}">Kick</button>`;
+      }
+
+      function playerStatusLabel(entry) {
+        if (!entry?.submission?.ready) return '<span class="status-waiting">Joined</span>';
+        return '<span class="status-ready">Ready</span>';
+      }
+
+      function bindKickButtons(container) {
+        container.querySelectorAll('[data-kick]').forEach((btn) => {
+          btn.addEventListener('click', () => kickPlayer(btn.dataset.kick));
+        });
+      }
+
+      function renderModeratorPlayers(containerId) {
+        const container = document.getElementById(containerId);
+        const players = activePlayers();
+        if (!players.length) {
+          container.innerHTML = '<p class="muted">No players joined yet.</p>';
+          return;
+        }
+        container.innerHTML = players
+          .map(
+            (entry) => `<div class="player-row"><div>${esc(entry.name)}</div><div>${playerStatusLabel(entry)}</div><div>${kickButtonHtml(entry)}</div></div>`,
+          )
+          .join('');
+        bindKickButtons(container);
+      }
+
+      function renderWheel(names, angle = 0) {
         const canvas = document.getElementById('spinCanvas');
-        const r = canvas.width / 2;
         const pointer = document.getElementById('wheelPointer');
-        pointer.style.left = `calc(50% + ${r - 12}px)`;
-      }
-
-      /**
-       * Draw the spinner wheel at a given rotation angle.
-       * Each segment gets a label truncated to 12 characters.
-       * @param {number} angle - Wheel rotation in radians.
-       */
-      function drawWheel(angle) {
-        const canvas = document.getElementById('spinCanvas');
+        if (!canvas || !pointer) return;
         const ctx = canvas.getContext('2d');
         const cx = canvas.width / 2;
         const cy = canvas.height / 2;
-        const r = cx - 6;
-        const names = speakerQueue;
-        const n = names.length;
-        const slice = (2 * Math.PI) / n;
+        const r = cx - 8;
+
+        pointer.style.left = `calc(50% + ${r - 10}px)`;
 
         ctx.clearRect(0, 0, canvas.width, canvas.height);
+        if (!names.length) return;
 
-        for (let i = 0; i < n; i++) {
+        const slice = (2 * Math.PI) / names.length;
+        for (let i = 0; i < names.length; i += 1) {
           const start = angle + i * slice;
           const end = start + slice;
 
-          // Segment fill
           ctx.beginPath();
           ctx.moveTo(cx, cy);
           ctx.arc(cx, cy, r, start, end);
@@ -1229,452 +748,628 @@
           ctx.fillStyle = WHEEL_COLORS[i % WHEEL_COLORS.length];
           ctx.fill();
           ctx.strokeStyle = 'rgba(0,0,0,0.25)';
-          ctx.lineWidth = 1.5;
           ctx.stroke();
 
-          // Segment label — rotated to read along the slice midpoint
           ctx.save();
           ctx.translate(cx, cy);
           ctx.rotate(start + slice / 2);
           ctx.textAlign = 'right';
           ctx.fillStyle = 'white';
-          const fs = Math.min(16, Math.max(9, 220 / n));
-          ctx.font = `600 ${fs}px system-ui, sans-serif`;
-          ctx.shadowColor = 'rgba(0,0,0,0.6)';
-          ctx.shadowBlur = 4;
-          const label = names[i].length > 12 ? names[i].slice(0, 11) + '…' : names[i];
-          ctx.fillText(label, r - 8, 5);
+          ctx.font = `600 ${Math.max(10, Math.min(15, 220 / names.length))}px system-ui, sans-serif`;
+          const label = names[i].length > 12 ? `${names[i].slice(0, 11)}...` : names[i];
+          ctx.fillText(label, r - 8, 4);
           ctx.restore();
         }
 
-        // Center hub
         ctx.beginPath();
         ctx.arc(cx, cy, 18, 0, 2 * Math.PI);
         ctx.fillStyle = '#1e293b';
         ctx.fill();
-        ctx.strokeStyle = 'rgba(255,255,255,0.3)';
-        ctx.lineWidth = 2;
-        ctx.stroke();
       }
 
-      /**
-       * Animate the wheel with cubic ease-out over ~3.5s.
-       * Randomly selects a winner from the remaining speakerQueue.
-       * After landing, displays the winner's name and reveals the "go to turn" button.
-       */
-      function spinWheel() {
-        if (spinning || speakerQueue.length === 0) return;
+      function esc(value) {
+        return String(value || '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      async function createModeratorSession() {
+        for (let attempt = 0; attempt < 8; attempt += 1) {
+          const code = generateSessionCode(6);
+          const modId = generateId('mod');
+          // eslint-disable-next-line no-await-in-loop
+          const created = await createSession(code, modId);
+          if (!created) continue;
+          sessionCode = code;
+          moderatorId = modId;
+          role = 'moderator';
+          saveModeratorRecord(code, modId);
+          const params = new URLSearchParams({ code, role: 'moderator' });
+          setHash(params);
+          return;
+        }
+        throw new Error('Could not create session');
+      }
+
+      async function reconnectModerator(code) {
+        const existing = await fetchSession(code);
+        const saved = loadModeratorRecord(code);
+        if (!existing || !saved?.moderatorId || existing.moderatorId !== saved.moderatorId) {
+          await createModeratorSession();
+          return;
+        }
+        sessionCode = code;
+        moderatorId = saved.moderatorId;
+        role = 'moderator';
+      }
+
+      async function reconnectPlayer(code, pid) {
+        const existing = await fetchSession(code);
+        if (!existing || !existing.players?.[pid]) {
+          const params = new URLSearchParams({ join: code });
+          setHash(params);
+          prepareJoinScreen(code);
+          return;
+        }
+        sessionCode = code;
+        playerId = pid;
+        role = 'player';
+      }
+
+      function prepareJoinScreen(code) {
+        sessionCode = code.toUpperCase();
+        role = 'player';
+        playerId = null;
+        session = null;
+        document.getElementById('joinCodeLabel').textContent = sessionCode;
+        document.getElementById('joinNameInput').value = loadPlayerName();
+        document.getElementById('joinMessage').textContent = '';
+        showScreen('join');
+      }
+
+      function updateModeratorUi() {
+        showScreen('moderator');
+        const game = gameState();
+        const phase = game?.phase || 'lobby';
+
+        document.getElementById('modCodePill').textContent = `Code: ${sessionCode}`;
+        document.getElementById('modPhasePill').textContent = phase[0].toUpperCase() + phase.slice(1);
+        updateJoinLink();
+        renderModeratorPlayers('modLobbyPlayers');
+        renderModeratorPlayers('modRosterPlayers');
+
+        document.getElementById('modLobbyPanel').classList.toggle('hidden', phase !== 'lobby');
+        document.getElementById('modSpinPanel').classList.toggle('hidden', phase !== 'spin');
+        document.getElementById('modVotePanel').classList.toggle('hidden', phase !== 'vote');
+        document.getElementById('modResultsPanel').classList.toggle('hidden', phase !== 'results');
+
+        const players = activePlayers();
+        const readyCount = players.filter((p) => p?.submission?.ready).length;
+        const canStart = players.length >= 2 && readyCount === players.length;
+        document.getElementById('modStartGameBtn').disabled = !canStart;
+        document.getElementById('modLobbyMessage').textContent = `${readyCount}/${players.length} players ready.`;
+
+        const remainingIds = Array.isArray(game?.remainingSpeakerIds) ? game.remainingSpeakerIds : [];
+        const remainingNames = remainingIds
+          .map((id) => session?.players?.[id]?.name)
+          .filter(Boolean);
+
+        renderWheel(remainingNames, spinAngle);
+
+        const selectedSpeaker = game?.currentSpeakerId ? session?.players?.[game.currentSpeakerId] : null;
+        const speakerBox = document.getElementById('modSelectedSpeaker');
+        if (selectedSpeaker) {
+          speakerBox.style.display = 'block';
+          speakerBox.textContent = selectedSpeaker.name;
+        } else {
+          speakerBox.style.display = 'none';
+          speakerBox.textContent = '';
+        }
+
+        document.getElementById('modStartRoundBtn').disabled = !selectedSpeaker;
+
+        const statements = Array.isArray(game?.presentedStatements) ? game.presentedStatements : [];
+        document.getElementById('modStatements').innerHTML = statements
+          .map(
+            (entry, index) => `<div class="statement-item"><strong>${index + 1}.</strong> <span>${esc(entry.text)}</span></div>`,
+          )
+          .join('');
+
+        const voters = eligibleVoterIds(game);
+        const voted = voters.filter((pid) => session?.players?.[pid]?.vote?.roundId === game?.currentRoundId).length;
+        document.getElementById('modVoteHint').textContent =
+          selectedSpeaker ? `${selectedSpeaker.name} is speaking. Players are voting now.` : 'Waiting for speaker.';
+        document.getElementById('modVoteProgress').textContent = `Votes: ${voted}/${voters.length}`;
+        document.getElementById('modShowResultsBtn').disabled = !allVotesIn(game);
+
+        const results = Array.isArray(game?.results) ? game.results : [];
+        document.getElementById('modResultsRows').innerHTML = results
+          .map(
+            (row) => `<div class="result-row ${row.correct ? 'result-good' : 'result-bad'}"><strong>${esc(row.name)}</strong><span class="muted">voted #${Number(row.voteIndex) + 1}</span><span>${row.correct ? 'Correct' : 'Wrong'}</span></div>`,
+          )
+          .join('');
+        const answerIndex = Number(game?.answerIndexInPresented);
+        document.getElementById('modResultSummary').textContent = Number.isFinite(answerIndex)
+          ? `Lie was statement #${answerIndex + 1}.`
+          : '';
+      }
+
+      function updatePlayerUi() {
+        showScreen('player');
+        const player = session?.players?.[playerId];
+        const game = gameState();
+        const phase = game?.phase || 'lobby';
+
+        if (!player) {
+          setError('You were removed by the moderator.');
+          return;
+        }
+
+        document.getElementById('playerNamePill').textContent = player.name;
+        document.getElementById('playerPhasePill').textContent = phase[0].toUpperCase() + phase.slice(1);
+
+        const waitingPanel = document.getElementById('playerWaitingPanel');
+        const votePanel = document.getElementById('playerVotePanel');
+        const resultsPanel = document.getElementById('playerResultsPanel');
+
+        waitingPanel.classList.add('hidden');
+        votePanel.classList.add('hidden');
+        resultsPanel.classList.add('hidden');
+
+        if (phase === 'lobby' || phase === 'spin') {
+          waitingPanel.classList.remove('hidden');
+          const title = document.getElementById('playerWaitingTitle');
+          const text = document.getElementById('playerWaitingText');
+          title.textContent = phase === 'lobby' ? 'Waiting in lobby' : 'Moderator is selecting speaker';
+          text.textContent =
+            phase === 'lobby'
+              ? 'Your statements are submitted. Waiting for the moderator to start.'
+              : 'The moderator is spinning for the next speaker.';
+          return;
+        }
+
+        if (phase === 'vote') {
+          const speakerId = game?.currentSpeakerId;
+          const speaker = speakerId ? session?.players?.[speakerId] : null;
+          if (speakerId === playerId) {
+            waitingPanel.classList.remove('hidden');
+            document.getElementById('playerWaitingTitle').textContent = 'You are speaking';
+            document.getElementById('playerWaitingText').textContent =
+              'Tell everyone your statements while players vote for the lie.';
+            return;
+          }
+
+          votePanel.classList.remove('hidden');
+          document.getElementById('playerVoteTitle').textContent = speaker
+            ? `${speaker.name}'s statements`
+            : 'Statements';
+
+          const statements = Array.isArray(game?.presentedStatements) ? game.presentedStatements : [];
+          document.getElementById('playerStatements').innerHTML = statements
+            .map(
+              (entry, index) => `<div class="statement-item"><strong>${index + 1}.</strong><span>${esc(entry.text)}</span></div>`,
+            )
+            .join('');
+
+          const existingVote = player?.vote?.roundId === game?.currentRoundId ? player.vote.statementIndex : null;
+          document.querySelectorAll('[data-vote-index]').forEach((btn) => {
+            const idx = Number(btn.dataset.voteIndex);
+            btn.classList.toggle('active', idx === existingVote);
+            const locked = existingVote !== null;
+            btn.disabled = locked;
+          });
+          document.getElementById('playerVoteMessage').textContent =
+            existingVote !== null
+              ? `Vote submitted: statement #${existingVote + 1}. Waiting for everyone else.`
+              : 'Pick the statement you think is the lie.';
+          return;
+        }
+
+        if (phase === 'results') {
+          resultsPanel.classList.remove('hidden');
+          const answerIndex = Number(game?.answerIndexInPresented);
+          document.getElementById('playerResultSummary').textContent = Number.isFinite(answerIndex)
+            ? `Lie was statement #${answerIndex + 1}.`
+            : '';
+          const rows = Array.isArray(game?.results) ? game.results : [];
+          document.getElementById('playerResultsRows').innerHTML = rows
+            .map(
+              (row) => `<div class="result-row ${row.correct ? 'result-good' : 'result-bad'}"><strong>${esc(row.name)}</strong><span class="muted">voted #${Number(row.voteIndex) + 1}</span><span>${row.correct ? 'Correct' : 'Wrong'}</span></div>`,
+            )
+            .join('');
+        }
+      }
+
+      function updateScreenBySession() {
+        if (!session) return;
+        if (role === 'moderator') {
+          updateModeratorUi();
+        } else if (role === 'player') {
+          updatePlayerUi();
+        }
+      }
+
+      async function refreshSessionNow() {
+        if (!sessionCode) return;
+        const next = await fetchSession(sessionCode);
+        if (!next) {
+          setError('Session no longer exists.');
+          return;
+        }
+        session = next;
+        updateScreenBySession();
+      }
+
+      async function startPolling() {
+        if (pollHandle) {
+          clearInterval(pollHandle);
+        }
+        const tick = async () => {
+          if (!sessionCode) return;
+          try {
+            const next = await fetchSession(sessionCode);
+            if (!next) {
+              setError('Session no longer exists.');
+              return;
+            }
+            session = next;
+            updateScreenBySession();
+          } catch {
+            setError('Connection lost while syncing multiplayer state.');
+          }
+        };
+        await tick();
+        pollHandle = setInterval(tick, SESSION_POLL_MS);
+      }
+
+      async function kickPlayer(pid) {
+        if (role !== 'moderator' || !pid) return;
+        const entry = session?.players?.[pid];
+        if (!entry) return;
+        if (!window.confirm(`Kick ${entry.name}?`)) return;
+
+        const game = gameState() || {};
+        const remaining = Array.isArray(game.remainingSpeakerIds)
+          ? game.remainingSpeakerIds.filter((id) => id !== pid)
+          : [];
+
+        const patch = {
+          [`players/${pid}`]: null,
+          'game/remainingSpeakerIds': remaining,
+        };
+
+        if (game.currentSpeakerId === pid) {
+          patch['game/currentSpeakerId'] = null;
+          patch['game/phase'] = 'spin';
+          patch['game/presentedStatements'] = [];
+          patch['game/currentRoundId'] = null;
+          patch['game/results'] = [];
+        }
+
+        await patchSession({ patch });
+        await refreshSessionNow();
+      }
+
+      async function moderatorStartGame() {
+        if (role !== 'moderator') return;
+        const players = activePlayers();
+        const playerIds = players.map((p) => p.id);
+        const allReady = players.length >= 2 && players.every((p) => p?.submission?.ready);
+        if (!allReady) return;
+
+        selectedSpeakerId = null;
+        await patchSession({
+          status: 'playing',
+          patch: {
+            game: {
+              phase: 'spin',
+              roundNumber: 1,
+              remainingSpeakerIds: playerIds,
+              currentSpeakerId: null,
+              currentRoundId: null,
+              presentedStatements: [],
+              answerIndexInPresented: null,
+              results: [],
+            },
+          },
+        });
+        await refreshSessionNow();
+      }
+
+      async function spinForSpeaker() {
+        if (role !== 'moderator' || spinning) return;
+        const game = gameState();
+        const remainingIds = Array.isArray(game?.remainingSpeakerIds) ? game.remainingSpeakerIds : [];
+        const candidates = remainingIds.filter((id) => session?.players?.[id]);
+        if (!candidates.length) return;
+
         spinning = true;
-        document.getElementById('spinBtn').disabled = true;
-        document.getElementById('spinResult').style.display = 'none';
-        document.getElementById('goTurnBtn').style.display = 'none';
+        document.getElementById('modSpinBtn').disabled = true;
+        selectedSpeakerId = null;
 
-        const names = speakerQueue;
-        const n = names.length;
-        const slice = (2 * Math.PI) / n;
-
-        // Pick a random target segment
-        const winnerIdx = Math.floor(Math.random() * n);
-        // Use an integer number of extra rotations so the correction math is exact.
-        const extraRotations = 3 + Math.floor(Math.random() * 4); // 3, 4, 5, or 6
+        const names = candidates.map((id) => session.players[id].name);
+        const winnerIdx = Math.floor(Math.random() * candidates.length);
+        const slice = (2 * Math.PI) / names.length;
+        const extraRotations = 4 + Math.floor(Math.random() * 3);
         const targetSegmentCenter = winnerIdx * slice + slice / 2;
-        // Compute how much we need to rotate from the current position so that
-        // segment winnerIdx's center lands at angle 0 (where the pointer is).
-        // We want: (spinAngle + delta + targetSegmentCenter) ≡ 0 (mod 2π)
-        // → delta = -spinAngle - targetSegmentCenter + k*2π for the smallest positive k
         const correction =
-          ((2 * Math.PI - ((spinAngle + targetSegmentCenter) % (2 * Math.PI))) %
-            (2 * Math.PI)) +
+          ((2 * Math.PI - ((spinAngle + targetSegmentCenter) % (2 * Math.PI))) % (2 * Math.PI)) +
           extraRotations * 2 * Math.PI;
         const spinTarget = spinAngle + correction;
 
-        const duration = 3500;
+        const duration = 2200;
         const startTime = performance.now();
         const startAngle = spinAngle;
 
-        /**
-         * Animation frame: advances the wheel with cubic ease-out.
-         * @param {number} now - Current timestamp from requestAnimationFrame.
-         */
         function frame(now) {
           const t = Math.min((now - startTime) / duration, 1);
           const ease = 1 - Math.pow(1 - t, 3);
           spinAngle = startAngle + (spinTarget - startAngle) * ease;
-          drawWheel(spinAngle);
-
+          renderWheel(names, spinAngle);
           if (t < 1) {
             requestAnimationFrame(frame);
-          } else {
-            spinning = false;
-            spinAngle = spinTarget;
-            currentSpeaker = names[winnerIdx];
-            showSpinResult(currentSpeaker);
+            return;
           }
+          spinAngle = spinTarget;
+          spinning = false;
+          selectedSpeakerId = candidates[winnerIdx];
+          document.getElementById('modSpinBtn').disabled = false;
+          patchSession({
+            patch: {
+              'game/currentSpeakerId': selectedSpeakerId,
+              'game/phase': 'spin',
+            },
+          })
+            .then(refreshSessionNow)
+            .catch(() => setError('Could not save selected speaker.'));
         }
 
         requestAnimationFrame(frame);
       }
 
-      /**
-       * Display the spin result with a bounce animation and show the turn button.
-       * @param {string} name - The selected player's name.
-       */
-      function showSpinResult(name) {
-        const el = document.getElementById('spinResult');
-        el.textContent = `🎉 ${name}!`;
-        el.style.display = 'block';
-        el.classList.remove('spin-result');
-        void el.offsetWidth; // trigger reflow to restart animation
-        el.classList.add('spin-result');
-        document.getElementById('goTurnBtn').style.display = 'flex';
-      }
+      async function moderatorStartRound() {
+        if (role !== 'moderator') return;
+        const game = gameState();
+        const speakerId = game?.currentSpeakerId;
+        const speaker = speakerId ? session?.players?.[speakerId] : null;
+        if (!speaker?.submission?.ready) return;
 
-      // ── Turn screen ────────────────────────────────────────────────────────
-
-      /**
-       * Transition to the turn screen for the current speaker.
-       * Shows the statement-capture phase first; guess grid is hidden until statements are submitted.
-       */
-      function goToTurn() {
-        guesses = {};
-        currentLie = null;
-        currentStatements = ['', '', ''];
-        document.getElementById('roundBadgeTurn').textContent = `Round ${round}`;
-        document.getElementById('turnSpeakerName').textContent = currentSpeaker;
-        document.getElementById('turnSpeakerName2').textContent = currentSpeaker;
-
-        // Reset statement inputs
-        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
-          const el = document.getElementById(id);
-          el.value = '';
-          el.disabled = false;
-        });
-        document.getElementById('showStatementsBtn').disabled = true;
-        document.getElementById('statementCapture').style.display = 'block';
-        document.getElementById('statementsDisplay').style.display = 'none';
-
-        resetLieButtons();
-        showScreen('screenTurn');
-
-        // Enable submit button when all 3 statements are non-empty
-        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
-          document.getElementById(id).addEventListener('input', checkStatementsReady);
-        });
-      }
-
-      /**
-       * Enable the "Show Statements" button only when all 3 inputs have content.
-       */
-      function checkStatementsReady() {
-        const all = ['stmt1', 'stmt2', 'stmt3'].every(
-          id => document.getElementById(id).value.trim().length > 0,
+        const statements = speaker.submission.statements.map((text, originalIndex) => ({
+          text,
+          originalIndex,
+        }));
+        const shuffled = shuffle(statements);
+        const answerIndexInPresented = shuffled.findIndex(
+          (entry) => entry.originalIndex === Number(speaker.submission.lieIndex),
         );
-        document.getElementById('showStatementsBtn').disabled = !all;
-      }
+        const roundId = generateId('round');
 
-      /**
-       * Lock the statement inputs, display them numbered on screen, and reveal the guess grid.
-       */
-      function submitStatements() {
-        currentStatements = ['stmt1', 'stmt2', 'stmt3'].map(id =>
-          document.getElementById(id).value.trim(),
-        );
-
-        // Lock inputs
-        ['stmt1', 'stmt2', 'stmt3'].forEach(id => {
-          document.getElementById(id).disabled = true;
-        });
-
-        // Display numbered statements
-        ['stmtDisplay1', 'stmtDisplay2', 'stmtDisplay3'].forEach((id, i) => {
-          document.getElementById(id).textContent = currentStatements[i];
-        });
-
-        // Switch phases
-        document.getElementById('statementCapture').style.display = 'none';
-        document.getElementById('statementsDisplay').style.display = 'block';
-
-        buildGuessGrid();
-        document.getElementById('revealBtn').disabled = true;
-      }
-
-      /**
-       * Build the guess entry grid: one row per non-speaker player.
-       * Each row has three numbered buttons (1, 2, 3) to record a guess.
-       * Uses data-* attributes + addEventListener to avoid inline onclick quoting issues.
-       */
-      function buildGuessGrid() {
-        const grid = document.getElementById('guessGrid');
-        const guessers = players.filter(p => p.name !== currentSpeaker);
-        grid.innerHTML = guessers
-          .map(
-            p =>
-              `<div class="guess-row" id="gr-${idSafe(p.name)}">
-              <span class="guess-name">${escHtml(p.name)}</span>
-              <div class="guess-btns">
-                ${[1, 2, 3]
-                  .map(
-                    n =>
-                      `<button class="guess-btn" id="gb-${idSafe(p.name)}-${n}"
-                        data-player="${escHtml(p.name)}" data-num="${n}">${n}</button>`,
-                  )
-                  .join('')}
-              </div>
-              <span class="guess-icon" id="gi-${idSafe(p.name)}"></span>
-            </div>`,
-          )
-          .join('');
-
-        // Attach click listeners after building HTML — avoids inline onclick quoting bugs
-        grid.querySelectorAll('.guess-btn').forEach(btn => {
-          btn.addEventListener('click', () => {
-            recordGuess(btn.dataset.player, parseInt(btn.dataset.num, 10));
-          });
-        });
-      }
-
-      /**
-       * Record a player's guess and highlight their selected button.
-       * Checks whether the reveal button should be enabled.
-       * @param {string} name - The guesser's name.
-       * @param {number} num - The guessed statement number (1, 2, or 3).
-       */
-      function recordGuess(name, num) {
-        guesses[name] = num;
-        [1, 2, 3].forEach(n => {
-          const btn = document.getElementById(`gb-${idSafe(name)}-${n}`);
-          if (btn) btn.classList.toggle('selected', n === num);
-        });
-        // Highlight the whole row once a guess has been made
-        const row = document.getElementById(`gr-${idSafe(name)}`);
-        if (row) row.classList.add('has-guess');
-        checkRevealReady();
-      }
-
-      /**
-       * Enable the reveal button once the lie statement has been selected.
-       * Players who haven't recorded a guess are counted as wrong on reveal.
-       */
-      function checkRevealReady() {
-        document.getElementById('revealBtn').disabled = currentLie === null;
-      }
-
-      /**
-       * Mark a statement as the lie and highlight the corresponding button.
-       * @param {number} num - The lie statement number (1, 2, or 3).
-       */
-      function selectLie(num) {
-        currentLie = num;
-        const btns = document.getElementById('lieButtons').querySelectorAll('.btn');
-        btns.forEach((btn, i) => {
-          btn.classList.toggle('btn-danger', i + 1 === num);
-          btn.classList.toggle('btn-ghost', i + 1 !== num);
-        });
-        document.getElementById('lieSelectedMsg').style.display = 'block';
-        document.getElementById('lieSelectedMsg').textContent = `Statement ${num} is the lie.`;
-        checkRevealReady();
-      }
-
-      /**
-       * Reset all lie-selection buttons to their default ghost state.
-       */
-      function resetLieButtons() {
-        document.getElementById('lieButtons').querySelectorAll('.btn').forEach(btn => {
-          btn.classList.remove('btn-danger');
-          btn.classList.add('btn-ghost');
-        });
-        document.getElementById('lieSelectedMsg').style.display = 'none';
-      }
-
-      // ── Reveal screen ──────────────────────────────────────────────────────
-
-      /**
-       * Reveal the lie, award points to correct guessers, and show the reveal screen.
-       * Removes the current speaker from the queue after this turn.
-       */
-      function revealLie() {
-        document.getElementById('roundBadgeReveal').textContent = `Round ${round}`;
-        document.getElementById('lieNumDisplay').textContent = currentLie;
-        document.getElementById('revealSpeakerNote').textContent =
-          `${currentSpeaker}'s lie was statement ${currentLie}`;
-
-        // Show the 3 statements on the reveal screen if they were captured
-        const revealStmts = document.getElementById('revealStatements');
-        const revealList = document.getElementById('revealStmtList');
-        if (currentStatements.some(s => s.length > 0)) {
-          revealList.innerHTML = currentStatements
-            .map((s, i) => {
-              const isLie = i + 1 === currentLie;
-              return `<div class="guess-row ${isLie ? 'wrong' : 'correct'}">
-                <span style="background:${isLie ? 'var(--danger)' : 'var(--success)'};color:white;border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;font-weight:700;flex-shrink:0">${i + 1}</span>
-                <span style="flex:1;font-size:0.95rem">${escHtml(s)}</span>
-                <span>${isLie ? '🤥' : '✓'}</span>
-              </div>`;
-            })
-            .join('');
-          revealStmts.style.display = 'block';
-        } else {
-          revealStmts.style.display = 'none';
-        }
-
-        const guessers = players.filter(p => p.name !== currentSpeaker);
-        let correct = 0;
-        const winners = [];
-
-        document.getElementById('revealGrid').innerHTML = guessers
-          .map(p => {
-            const isCorrect = guesses[p.name] === currentLie;
-            if (isCorrect) {
-              p.points++;
-              correct++;
-              winners.push(p.name);
-            }
-            const guessLabel =
-              guesses[p.name] !== undefined ? `guessed #${guesses[p.name]}` : 'no guess';
-            return `<div class="guess-row ${isCorrect ? 'correct' : 'wrong'}">
-            <span class="guess-name">${escHtml(p.name)}</span>
-            <span style="color:var(--text-muted);font-size:0.9rem">${guessLabel}</span>
-            <span class="guess-icon">${isCorrect ? '✅' : '❌'}</span>
-          </div>`;
-          })
-          .join('');
-
-        // Winners banner
-        const banner = document.getElementById('winnersBanner');
-        if (winners.length > 0) {
-          banner.innerHTML = `<div class="winners-banner">
-            <h2>🏆 Winner${winners.length > 1 ? 's' : ''}!</h2>
-            <div class="winners-list">
-              ${winners.map(n => `<span class="winner-chip">${escHtml(n)}</span>`).join('')}
-            </div>
-          </div>`;
-        } else {
-          banner.innerHTML = `<div class="no-winners-banner">😅 Nobody guessed the lie!</div>`;
-        }
-
-        // Remove speaker from the queue
-        speakerQueue = speakerQueue.filter(n => n !== currentSpeaker);
-
-        document.getElementById('nextTurnBtn').textContent =
-          speakerQueue.length > 0 ? 'Next Speaker →' : 'Round Complete →';
-
-        showScreen('screenReveal');
-      }
-
-      /**
-       * Advance from the reveal screen.
-       * Spins again if speakers remain; otherwise shows the round-end scoreboard.
-       */
-      function nextTurn() {
-        if (speakerQueue.length > 0) {
-          showSpinner();
-        } else {
-          showRoundEnd();
-        }
-      }
-
-      // ── Round end ──────────────────────────────────────────────────────────
-
-      /**
-       * Show the end-of-round scoreboard with current cumulative scores.
-       */
-      function showRoundEnd() {
-        document.getElementById('roundEndNum').textContent = round;
-        renderScoreTable('roundEndScores');
-        showScreen('screenRoundEnd');
-      }
-
-      /**
-       * Start the next round. Rebuilds the speaker queue; no think timer after round 1.
-       */
-      function nextRound() {
-        round++;
-        buildSpeakerQueue();
-        showSpinner();
-      }
-
-      /**
-       * End the current round early from the spinner screen.
-       * Clears the remaining speaker queue and shows the round-end scoreboard.
-       */
-      function endRoundEarly() {
-        speakerQueue = [];
-        showRoundEnd();
-      }
-
-      /**
-       * Return to the setup screen with player names preserved but scores reset.
-       */
-      function returnToSetup() {
-        round = 1;
-        spinAngle = 0;
-        currentStatements = ['', '', ''];
-        players.forEach(p => (p.points = 0));
-        renderPlayerList();
-        showScreen('screenSetup');
-      }
-
-      /**
-       * Remove all players from the list.
-       */
-      function removeAllPlayers() {
-        players = [];
-        saveNames();
-        renderPlayerList();
-      }
-
-      /**
-       * Skip to the final scores screen immediately.
-       */
-      function endGame() {
-        renderScoreTable('finalScores');
-        showScreen('screenFinal');
-      }
-
-      // ── Final scores ───────────────────────────────────────────────────────
-
-      /**
-       * Render players sorted by score descending into a score table body.
-       * @param {string} tbodyId - ID of the <tbody> element to populate.
-       */
-      function renderScoreTable(tbodyId) {
-        const sorted = [...players].sort((a, b) => b.points - a.points);
-        const medalByRank = {
-          1: '🥇',
-          2: '🥈',
-          3: '🥉',
+        const patch = {
+          'game/phase': 'vote',
+          'game/currentRoundId': roundId,
+          'game/presentedStatements': shuffled,
+          'game/answerIndexInPresented': answerIndexInPresented,
+          'game/results': [],
         };
-        let lastPoints = null;
-        let lastRank = 0;
-        document.getElementById(tbodyId).innerHTML = sorted
-          .map(
-            (p, i) => {
-              const rank = p.points === lastPoints ? lastRank : i + 1;
-              lastPoints = p.points;
-              lastRank = rank;
 
-              return `<tr>
-            <td class="score-rank">${medalByRank[rank] || rank}</td>
-            <td>${escHtml(p.name)}</td>
-            <td class="score-points">${p.points}</td>
-          </tr>`;
+        activePlayers().forEach((p) => {
+          patch[`players/${p.id}/vote`] = null;
+        });
+
+        await patchSession({ patch });
+        await refreshSessionNow();
+      }
+
+      async function submitVote(statementIndex) {
+        if (role !== 'player') return;
+        const game = gameState();
+        if (!game || game.phase !== 'vote') return;
+        if (session?.players?.[playerId]?.vote?.roundId === game.currentRoundId) return;
+
+        await updatePlayer({
+          action: 'vote',
+          roundId: game.currentRoundId,
+          statementIndex,
+        });
+        await refreshSessionNow();
+      }
+
+      async function moderatorShowResults() {
+        if (role !== 'moderator') return;
+        const game = gameState();
+        if (!allVotesIn(game)) return;
+
+        const answer = Number(game.answerIndexInPresented);
+        const rows = [];
+        const patch = {};
+
+        eligibleVoterIds(game).forEach((pid) => {
+          const entry = session?.players?.[pid];
+          const voteIndex = Number(entry?.vote?.statementIndex);
+          const correct = voteIndex === answer;
+          const currentScore = Number(entry?.score || 0);
+          patch[`players/${pid}/score`] = correct ? currentScore + 1 : currentScore;
+          rows.push({ name: entry?.name || 'Player', voteIndex, correct });
+        });
+
+        const remaining = Array.isArray(game.remainingSpeakerIds)
+          ? game.remainingSpeakerIds.filter((id) => id !== game.currentSpeakerId)
+          : [];
+
+        patch['game/results'] = rows;
+        patch['game/remainingSpeakerIds'] = remaining;
+        patch['game/phase'] = 'results';
+
+        await patchSession({ patch });
+        await refreshSessionNow();
+      }
+
+      async function moderatorContinue() {
+        if (role !== 'moderator') return;
+        const game = gameState();
+        const activeIds = activePlayers().map((p) => p.id);
+        const remaining = Array.isArray(game?.remainingSpeakerIds) ? game.remainingSpeakerIds : [];
+
+        if (!remaining.length) {
+          await patchSession({
+            patch: {
+              'game/roundNumber': Number(game?.roundNumber || 1) + 1,
+              'game/remainingSpeakerIds': activeIds,
+              'game/currentSpeakerId': null,
+              'game/currentRoundId': null,
+              'game/presentedStatements': [],
+              'game/answerIndexInPresented': null,
+              'game/results': [],
+              'game/phase': 'spin',
             },
-          )
-          .join('');
+          });
+          await refreshSessionNow();
+          return;
+        }
+
+        await patchSession({
+          patch: {
+            'game/currentSpeakerId': null,
+            'game/currentRoundId': null,
+            'game/presentedStatements': [],
+            'game/answerIndexInPresented': null,
+            'game/results': [],
+            'game/phase': 'spin',
+          },
+        });
+        await refreshSessionNow();
       }
 
-      /**
-       * Reset the entire game: clear players and scores, return to setup screen.
-       */
-      function resetGame() {
-        players = [];
-        round = 1;
-        spinAngle = 0;
-        currentStatements = ['', '', ''];
-        saveNames();
-        renderPlayerList();
-        showScreen('screenSetup');
+      async function bootstrap() {
+        showScreen('loading');
+
+        const configured = await isMultiplayerConfigured();
+        if (!configured) {
+          setError('Multiplayer backend is not configured on this deployment.');
+          return;
+        }
+
+        const params = hashParams();
+        const joinCode = params.get('join');
+        const code = params.get('code');
+        const hashRole = params.get('role');
+        const pid = params.get('pid');
+
+        if (hashRole === 'player' && code && pid) {
+          await reconnectPlayer(code.toUpperCase(), pid);
+          await startPolling();
+          return;
+        }
+
+        if (joinCode) {
+          prepareJoinScreen(joinCode);
+          return;
+        }
+
+        if (hashRole === 'moderator' && code) {
+          await reconnectModerator(code.toUpperCase());
+        } else {
+          await createModeratorSession();
+        }
+
+        await startPolling();
       }
+
+      document.getElementById('copyJoinLinkBtn').addEventListener('click', async () => {
+        const input = document.getElementById('joinLinkInput');
+        if (!input.value) return;
+        try {
+          await navigator.clipboard.writeText(input.value);
+          document.getElementById('modLobbyMessage').textContent = 'Join link copied.';
+        } catch {
+          document.getElementById('modLobbyMessage').textContent = 'Could not copy join link.';
+        }
+      });
+
+      document.getElementById('modStartGameBtn').addEventListener('click', () => {
+        moderatorStartGame().catch(() => setError('Could not start game.'));
+      });
+
+      document.getElementById('modSpinBtn').addEventListener('click', () => {
+        spinForSpeaker();
+      });
+
+      document.getElementById('modStartRoundBtn').addEventListener('click', () => {
+        moderatorStartRound().catch(() => setError('Could not start round.'));
+      });
+
+      document.getElementById('modShowResultsBtn').addEventListener('click', () => {
+        moderatorShowResults().catch(() => setError('Could not reveal results.'));
+      });
+
+      document.getElementById('modContinueBtn').addEventListener('click', () => {
+        moderatorContinue().catch(() => setError('Could not continue game.'));
+      });
+
+      document.querySelectorAll('[data-vote-index]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const index = Number(btn.dataset.voteIndex);
+          submitVote(index).catch(() => setError('Could not submit vote.'));
+        });
+      });
+
+      document.getElementById('joinSubmitBtn').addEventListener('click', async () => {
+        const joinMessage = document.getElementById('joinMessage');
+        const name = document.getElementById('joinNameInput').value.trim();
+        const statements = [
+          document.getElementById('joinStatement1').value.trim(),
+          document.getElementById('joinStatement2').value.trim(),
+          document.getElementById('joinStatement3').value.trim(),
+        ];
+        const lieIndex = Number(document.getElementById('joinLieSelect').value);
+
+        if (!name) {
+          joinMessage.textContent = 'Please enter your name.';
+          return;
+        }
+        if (statements.some((s) => !s)) {
+          joinMessage.textContent = 'Please fill in all three statements.';
+          return;
+        }
+
+        const btn = document.getElementById('joinSubmitBtn');
+        btn.disabled = true;
+        joinMessage.textContent = 'Joining room...';
+
+        try {
+          savePlayerName(name);
+          const joined = await joinSession(sessionCode, name);
+          playerId = joined.playerId;
+          role = 'player';
+
+          await updatePlayer({
+            action: 'submitStatements',
+            statements,
+            lieIndex,
+          });
+
+          const params = new URLSearchParams({ code: sessionCode, role: 'player', pid: playerId });
+          setHash(params);
+          await startPolling();
+        } catch (error) {
+          joinMessage.textContent = error.message || 'Unable to join room.';
+          btn.disabled = false;
+        }
+      });
+
+      document.getElementById('joinNameInput').addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          document.getElementById('joinSubmitBtn').click();
+        }
+      });
+
+      bootstrap().catch(() => {
+        setError('Unable to initialize multiplayer room.');
+      });
     </script>
   </body>
 </html>

--- a/apps/2026/03/31/two-truths-lie-game/meta.json
+++ b/apps/2026/03/31/two-truths-lie-game/meta.json
@@ -73,6 +73,16 @@
       "implementedAt": "2026-04-18T16:14:49Z",
       "agentName": "Claude Code",
       "llmModel": "claude-opus-4-7"
+    },
+    {
+      "issueNumber": 375,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/375",
+      "runId": "run-20260420T125914Z-8ff7c0",
+      "description": "Upgraded the app to a backend-powered multiplayer flow with moderator lobby/share link, player statement submission, kicking, synced voting, and shared results progression.",
+      "requestor": "jeffholst",
+      "implementedAt": "2026-04-20T12:59:14Z",
+      "agentName": "Codex",
+      "llmModel": "gpt-5.4"
     }
   ],
   "suggestion": {

--- a/apps/2026/03/31/two-truths-lie-game/thumbnail.svg
+++ b/apps/2026/03/31/two-truths-lie-game/thumbnail.svg
@@ -1,213 +1,68 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="2 Truths and a Lie multiplayer thumbnail">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="100%" stop-color="#1e1040"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
     </linearGradient>
-    <!-- Title gradient -->
-    <linearGradient id="titleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#818cf8"/>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1f2f4a" />
+      <stop offset="100%" stop-color="#0f1f33" />
     </linearGradient>
-    <!-- Card surface gradient -->
-    <linearGradient id="cardGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#172033"/>
-    </linearGradient>
-    <!-- Glow filter for title -->
-    <filter id="titleGlow" x="-20%" y="-50%" width="140%" height="200%">
-      <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
+    <radialGradient id="wheelGlow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#a78bfa" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0" />
+    </radialGradient>
+    <filter id="softGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="6" result="blur" />
       <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
       </feMerge>
     </filter>
-    <!-- Drop shadow for wheel -->
-    <filter id="wheelShadow" x="-15%" y="-15%" width="130%" height="130%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="8" result="blur"/>
-      <feOffset dx="0" dy="4" result="shadow"/>
-      <feFlood flood-color="#8b5cf6" flood-opacity="0.4" result="color"/>
-      <feComposite in="color" in2="shadow" operator="in" result="coloredShadow"/>
-      <feMerge>
-        <feMergeNode in="coloredShadow"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    <!-- Card shadow -->
-    <filter id="cardShadow" x="-5%" y="-5%" width="110%" height="120%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"/>
-      <feOffset dx="0" dy="3"/>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    <!-- Clip to enforce perfectly circular wheel boundary -->
-    <clipPath id="wheelClip">
-      <circle cx="230" cy="250" r="135"/>
-    </clipPath>
   </defs>
 
-  <!-- Background -->
-  <rect x="0" y="0" width="800" height="450" fill="url(#bgGrad)"/>
+  <rect width="512" height="512" fill="url(#bg)" />
+  <circle cx="356" cy="194" r="118" fill="url(#wheelGlow)" />
 
-  <!-- Subtle grid texture -->
-  <g opacity="0.06">
-    <line x1="0" y1="75" x2="800" y2="75" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="0" y1="150" x2="800" y2="150" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="0" y1="225" x2="800" y2="225" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="0" y1="300" x2="800" y2="300" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="0" y1="375" x2="800" y2="375" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="100" y1="0" x2="100" y2="450" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="200" y1="0" x2="200" y2="450" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="300" y1="0" x2="300" y2="450" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="400" y1="0" x2="400" y2="450" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="500" y1="0" x2="500" y2="450" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="600" y1="0" x2="600" y2="450" stroke="#a78bfa" stroke-width="1"/>
-    <line x1="700" y1="0" x2="700" y2="450" stroke="#a78bfa" stroke-width="1"/>
-  </g>
+  <rect x="34" y="58" width="444" height="396" rx="26" fill="url(#panel)" stroke="#334155" stroke-width="3" />
 
-  <!-- Edge glow frame -->
-  <rect x="0" y="0" width="800" height="450" fill="none" stroke="#8b5cf6" stroke-width="3" opacity="0.5"/>
-  <rect x="4" y="4" width="792" height="442" fill="none" stroke="#a78bfa" stroke-width="1" opacity="0.2"/>
+  <text x="56" y="104" fill="#c4b5fd" font-family="Segoe UI, sans-serif" font-size="28" font-weight="700" filter="url(#softGlow)">
+    2 Truths and a Lie
+  </text>
+  <text x="56" y="132" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="16">
+    Multiplayer Lobby + Live Voting
+  </text>
 
-  <!-- ── Spinner wheel ── -->
-  <!-- Glow halo behind wheel -->
-  <circle cx="230" cy="250" r="145" fill="#8b5cf6" opacity="0.07"/>
+  <rect x="56" y="156" width="220" height="174" rx="14" fill="#111d31" stroke="#334155" />
+  <text x="72" y="184" fill="#a78bfa" font-family="Segoe UI, sans-serif" font-size="15" font-weight="700">Players</text>
 
-  <!--
-    8 equal segments, 45deg each, clockwise from top.
-    All arcs use rx=135 ry=135 (perfect circle), large-arc-flag=0, sweep=1 (CW).
-    Segment endpoints computed from cx=230 cy=250 r=135:
-      P0 (  0deg top):    (230,   115)
-      P1 ( 45deg):        (325.5, 154.5)
-      P2 ( 90deg right):  (365,   250)
-      P3 (135deg):        (325.5, 345.5)
-      P4 (180deg bottom): (230,   385)
-      P5 (225deg):        (134.5, 345.5)
-      P6 (270deg left):   (95,    250)
-      P7 (315deg):        (134.5, 154.5)
-  -->
-  <g filter="url(#wheelShadow)" clip-path="url(#wheelClip)">
-    <!-- Seg 0: purple  0-45deg -->
-    <path d="M230,250 L230,115 A135,135 0 0,1 325.5,154.5 Z" fill="#7c3aed"/>
-    <!-- Seg 1: blue   45-90deg -->
-    <path d="M230,250 L325.5,154.5 A135,135 0 0,1 365,250 Z" fill="#2563eb"/>
-    <!-- Seg 2: green  90-135deg -->
-    <path d="M230,250 L365,250 A135,135 0 0,1 325.5,345.5 Z" fill="#059669"/>
-    <!-- Seg 3: orange 135-180deg -->
-    <path d="M230,250 L325.5,345.5 A135,135 0 0,1 230,385 Z" fill="#d97706"/>
-    <!-- Seg 4: red    180-225deg -->
-    <path d="M230,250 L230,385 A135,135 0 0,1 134.5,345.5 Z" fill="#dc2626"/>
-    <!-- Seg 5: teal   225-270deg -->
-    <path d="M230,250 L134.5,345.5 A135,135 0 0,1 95,250 Z" fill="#0891b2"/>
-    <!-- Seg 6: lime   270-315deg -->
-    <path d="M230,250 L95,250 A135,135 0 0,1 134.5,154.5 Z" fill="#65a30d"/>
-    <!-- Seg 7: violet 315-360deg -->
-    <path d="M230,250 L134.5,154.5 A135,135 0 0,1 230,115 Z" fill="#9333ea"/>
-  </g>
+  <rect x="72" y="198" width="188" height="30" rx="8" fill="#1e293b" stroke="#334155" />
+  <text x="84" y="218" fill="#f8fafc" font-family="Segoe UI, sans-serif" font-size="13">Alex</text>
+  <text x="210" y="218" fill="#10b981" font-family="Segoe UI, sans-serif" font-size="12" font-weight="700">READY</text>
 
-  <!-- Spoke lines (inside the clip) -->
-  <g clip-path="url(#wheelClip)" stroke="rgba(0,0,0,0.3)" stroke-width="1.5">
-    <line x1="230" y1="250" x2="230" y2="115"/>
-    <line x1="230" y1="250" x2="325.5" y2="154.5"/>
-    <line x1="230" y1="250" x2="365" y2="250"/>
-    <line x1="230" y1="250" x2="325.5" y2="345.5"/>
-    <line x1="230" y1="250" x2="230" y2="385"/>
-    <line x1="230" y1="250" x2="134.5" y2="345.5"/>
-    <line x1="230" y1="250" x2="95" y2="250"/>
-    <line x1="230" y1="250" x2="134.5" y2="154.5"/>
-  </g>
+  <rect x="72" y="236" width="188" height="30" rx="8" fill="#1e293b" stroke="#334155" />
+  <text x="84" y="256" fill="#f8fafc" font-family="Segoe UI, sans-serif" font-size="13">Jordan</text>
+  <text x="199" y="256" fill="#10b981" font-family="Segoe UI, sans-serif" font-size="12" font-weight="700">READY</text>
 
-  <!-- Outer ring border -->
-  <circle cx="230" cy="250" r="135" fill="none" stroke="rgba(0,0,0,0.4)" stroke-width="2"/>
+  <rect x="72" y="274" width="188" height="30" rx="8" fill="#1e293b" stroke="#334155" />
+  <text x="84" y="294" fill="#f8fafc" font-family="Segoe UI, sans-serif" font-size="13">Taylor</text>
+  <text x="205" y="294" fill="#f59e0b" font-family="Segoe UI, sans-serif" font-size="12" font-weight="700">VOTING</text>
 
-  <!--
-    Segment labels at 65% radius (r=88) at each segment midpoint angle.
-    Midpoint angles (clockwise from top): 22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5
-    Label positions:
-      22.5:  (264, 169)   67.5:  (311, 216)   112.5: (311, 284)   157.5: (264, 331)
-      202.5: (196, 331)   247.5: (149, 284)   292.5: (149, 216)   337.5: (196, 169)
-  -->
-  <g font-family="system-ui,sans-serif" font-size="12" font-weight="600" fill="white" text-anchor="middle" dominant-baseline="central">
-    <text x="264" y="169" transform="rotate(22.5,264,169)">Alex</text>
-    <text x="311" y="216" transform="rotate(67.5,311,216)">Sam</text>
-    <text x="311" y="284" transform="rotate(112.5,311,284)">Jordan</text>
-    <text x="264" y="331" transform="rotate(157.5,264,331)">Taylor</text>
-    <text x="196" y="331" transform="rotate(202.5,196,331)">Morgan</text>
-    <text x="149" y="284" transform="rotate(247.5,149,284)">Casey</text>
-    <text x="149" y="216" transform="rotate(292.5,149,216)">Riley</text>
-    <text x="196" y="169" transform="rotate(337.5,196,169)">Jamie</text>
-  </g>
+  <circle cx="356" cy="226" r="92" fill="#0f172a" stroke="#334155" stroke-width="4" />
+  <path d="M356 226 L356 134 A92 92 0 0 1 435 184 Z" fill="#7c3aed" />
+  <path d="M356 226 L435 184 A92 92 0 0 1 434 269 Z" fill="#2563eb" />
+  <path d="M356 226 L434 269 A92 92 0 0 1 356 318 Z" fill="#059669" />
+  <path d="M356 226 L356 318 A92 92 0 0 1 279 268 Z" fill="#d97706" />
+  <path d="M356 226 L279 268 A92 92 0 0 1 279 183 Z" fill="#dc2626" />
+  <path d="M356 226 L279 183 A92 92 0 0 1 356 134 Z" fill="#0891b2" />
+  <circle cx="356" cy="226" r="14" fill="#1e293b" stroke="#c4b5fd" stroke-width="2" />
+  <polygon points="463,226 438,214 438,238" fill="#a78bfa" filter="url(#softGlow)" />
 
-  <!-- Center hub -->
-  <circle cx="230" cy="250" r="20" fill="#1e293b"/>
-  <circle cx="230" cy="250" r="20" fill="none" stroke="rgba(255,255,255,0.25)" stroke-width="2"/>
-
-  <!-- Pointer arrow pointing left, tip at wheel right edge -->
-  <polygon points="375,250 362,238 362,262" fill="#a78bfa" filter="url(#titleGlow)"/>
-
-  <!-- Spin result label -->
-  <text x="230" y="425" fill="#a78bfa" font-size="15" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">🎉 Sam!</text>
-
-  <!-- ── Right panel: Guess recording ── -->
-  <rect x="420" y="100" width="355" height="330" rx="14" fill="url(#cardGrad)" stroke="#334155" stroke-width="1.5" filter="url(#cardShadow)"/>
-
-  <!-- Panel header -->
-  <text x="597" y="133" fill="#94a3b8" font-size="11" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" letter-spacing="0.08em">NOW SPEAKING</text>
-  <text x="597" y="162" fill="#a78bfa" font-size="22" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">Sam</text>
-  <text x="597" y="180" fill="#64748b" font-size="11" font-family="system-ui,sans-serif" text-anchor="middle">Round 2</text>
-
-  <!-- Divider -->
-  <line x1="436" y1="190" x2="758" y2="190" stroke="#334155" stroke-width="1"/>
-
-  <!-- Statements section label -->
-  <text x="436" y="208" fill="#94a3b8" font-size="10" font-weight="700" font-family="system-ui,sans-serif" letter-spacing="0.07em">STATEMENTS</text>
-
-  <!-- Statement 1 -->
-  <rect x="434" y="213" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
-  <circle cx="452" cy="230" r="10" fill="#8b5cf6"/>
-  <text x="452" y="230" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">1</text>
-  <text x="468" y="230" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I once swam with sharks</text>
-
-  <!-- Statement 2 -->
-  <rect x="434" y="251" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
-  <circle cx="452" cy="268" r="10" fill="#8b5cf6"/>
-  <text x="452" y="268" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">2</text>
-  <text x="468" y="268" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I speak four languages</text>
-
-  <!-- Statement 3 -->
-  <rect x="434" y="289" width="322" height="34" rx="7" fill="#172033" stroke="#6d28d9" stroke-width="1.2"/>
-  <circle cx="452" cy="306" r="10" fill="#8b5cf6"/>
-  <text x="452" y="306" fill="white" font-size="10" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">3</text>
-  <text x="468" y="306" fill="#f9fafb" font-size="11" font-family="system-ui,sans-serif" dominant-baseline="central">I've climbed Mt. Rainier</text>
-
-  <!-- Divider -->
-  <line x1="436" y1="332" x2="758" y2="332" stroke="#334155" stroke-width="1"/>
-  <text x="436" y="348" fill="#94a3b8" font-size="10" font-weight="700" font-family="system-ui,sans-serif" letter-spacing="0.07em">PLAYER GUESSES</text>
-
-  <!-- Guess row: Alex → 2 -->
-  <rect x="434" y="354" width="322" height="34" rx="7" fill="#172033" stroke="#334155" stroke-width="1.2"/>
-  <text x="450" y="371" fill="#f9fafb" font-size="12" font-weight="600" font-family="system-ui,sans-serif" dominant-baseline="central">Alex</text>
-  <rect x="683" y="359" width="28" height="24" rx="5" fill="#8b5cf6" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="697" y="371" fill="white" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">2</text>
-  <rect x="715" y="359" width="28" height="24" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="729" y="371" fill="#94a3b8" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">3</text>
-  <rect x="747" y="359" width="28" height="24" rx="5" fill="#0f172a" stroke="#334155" stroke-width="1.2"/>
-  <text x="761" y="371" fill="#94a3b8" font-size="12" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" dominant-baseline="central">1</text>
-
-  <!-- ── Title ── -->
-  <text x="400" y="55" fill="url(#titleGrad)" font-size="36" font-weight="700" font-family="system-ui,sans-serif" text-anchor="middle" filter="url(#titleGlow)">2 Truths and a Lie</text>
-  <text x="400" y="80" fill="#64748b" font-size="14" font-family="system-ui,sans-serif" text-anchor="middle">party game for Zoom</text>
-
-  <!-- Corner accents -->
-  <line x1="0" y1="0" x2="40" y2="0" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="0" y1="0" x2="0" y2="40" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="800" y1="0" x2="760" y2="0" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="800" y1="0" x2="800" y2="40" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="0" y1="450" x2="40" y2="450" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="0" y1="450" x2="0" y2="410" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="800" y1="450" x2="760" y2="450" stroke="#8b5cf6" stroke-width="3"/>
-  <line x1="800" y1="450" x2="800" y2="410" stroke="#8b5cf6" stroke-width="3"/>
+  <rect x="56" y="348" width="400" height="86" rx="14" fill="#111d31" stroke="#334155" />
+  <text x="72" y="378" fill="#f8fafc" font-family="Segoe UI, sans-serif" font-size="14" font-weight="700">
+    Results Board
+  </text>
+  <text x="72" y="404" fill="#94a3b8" font-family="Segoe UI, sans-serif" font-size="13">
+    Lie was statement #2 • Continue to next participant
+  </text>
 </svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -722,6 +722,16 @@
         "implementedAt": "2026-04-18T16:14:49Z",
         "agentName": "Claude Code",
         "llmModel": "claude-opus-4-7"
+      },
+      {
+        "issueNumber": 375,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/375",
+        "runId": "run-20260420T125914Z-8ff7c0",
+        "description": "Upgraded the app to a backend-powered multiplayer flow with moderator lobby/share link, player statement submission, kicking, synced voting, and shared results progression.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-04-20T12:59:14Z",
+        "agentName": "Codex",
+        "llmModel": "gpt-5.4"
       }
     ],
     "allowImprovements": true,
@@ -756,6 +766,11 @@
         "runId": "run-20260418T161449Z-b2be10",
         "path": "backups/run-20260418T161449Z-b2be10/index.html",
         "url": "/apps/2026/03/31/two-truths-lie-game/backups/run-20260418T161449Z-b2be10/index.html"
+      },
+      {
+        "runId": "run-20260420T125914Z-8ff7c0",
+        "path": "backups/run-20260420T125914Z-8ff7c0/index.html",
+        "url": "/apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/index.html"
       }
     ]
   },


### PR DESCRIPTION
Closes #375

## What changed
- Reworked the app into a backend-powered multiplayer flow using `/api/multiplayer` sessions.
- Moderator now starts in a lobby with a share link, sees player readiness, can kick players from every game phase, and controls progression.
- Players join with name + two truths + one lie; submission disables controls and waits for moderator start.
- Moderator spins to pick a speaker, starts each round, all non-speakers vote, and synchronized results are shown to everyone.
- Added `PATCH /api/multiplayer/sessions/[code]/players/[playerId]` for player statement submission and vote persistence.

## Preserved behavior checks
- Required head tags and app shell integration remain intact.
- Responsive/mobile layout remains usable with shared header/footer safe area.
- Theme variables and light/dark support preserved.

## Required backup snapshot
- Included at `apps/2026/03/31/two-truths-lie-game/backups/run-20260420T125914Z-8ff7c0/` (`index.html`, `meta.json`, `thumbnail.svg`).

## Validation
- npm run generate:apps
- npm run validate:apps
- npm run lint:fix
- npm run format
- npm run lint
- npm test
- npm run validate:responsive:sample
- npm run build

All commands passed.
