### PR TITLE
test: add multiplayer API route coverage

### DIFF
--- a/__tests__/api/multiplayer/sessions-code-answers.test.js
+++ b/__tests__/api/multiplayer/sessions-code-answers.test.js
@@ -1,0 +1,289 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/supabaseAdmin', () => ({ createServiceClient: jest.fn() }));
+
+import { POST } from '@/app/api/multiplayer/sessions/[code]/answers/route';
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const VALID_CODE = 'ABCD23';
+const VALID_PLAYER_ID = 'player-abc12345678';
+
+const ACTIVE_GAME = {
+  roundState: 'active',
+  word: 'banana',
+  roundWinnerId: null,
+  roundWinnerName: null,
+  solvedRounds: 0,
+};
+
+const SAMPLE_PLAYERS = {
+  [VALID_PLAYER_ID]: { id: VALID_PLAYER_ID, name: 'Alice', score: 0 },
+};
+
+function makeParams(code = VALID_CODE) {
+  return { params: Promise.resolve({ code }) };
+}
+
+function makeRequest(body) {
+  return new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}/answers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeSelectThenUpdateClient(selectResult, updateResult = { error: null }) {
+  const selectChain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(selectResult),
+  };
+  const updateChain = {
+    update: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockResolvedValue(updateResult),
+  };
+  const client = {
+    from: jest.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(updateChain),
+  };
+  createServiceClient.mockReturnValue(client);
+  return client;
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe('POST /api/multiplayer/sessions/[code]/answers', () => {
+  it('returns 400 for invalid code', async () => {
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams('BAD!')
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const req = new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}/answers`, {
+      method: 'POST',
+      body: 'not-json',
+    });
+    const res = await POST(req, makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid playerId (too short)', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const res = await POST(makeRequest({ playerId: 'short', guess: 'banana' }), makeParams());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/player/i);
+  });
+
+  it('returns 400 for missing playerId', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const res = await POST(makeRequest({ guess: 'banana' }), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on DB load error', async () => {
+    makeSelectThenUpdateClient({ data: null, error: { message: 'DB error' } });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 when session not found', async () => {
+    makeSelectThenUpdateClient({ data: null, error: null });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when player not found in session', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        status: 'playing',
+        game: ACTIVE_GAME,
+        players: { 'other-player-12345': { id: 'other-player-12345', name: 'Bob' } },
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns round-inactive when session status is not playing', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        status: 'lobby',
+        game: { ...ACTIVE_GAME, roundState: 'active' },
+        players: SAMPLE_PLAYERS,
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('round-inactive');
+  });
+
+  it('returns round-inactive when roundState is not active', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        status: 'playing',
+        game: { ...ACTIVE_GAME, roundState: 'between' },
+        players: SAMPLE_PLAYERS,
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('round-inactive');
+  });
+
+  it('includes current winner info in round-inactive response', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        status: 'playing',
+        game: {
+          ...ACTIVE_GAME,
+          roundState: 'between',
+          roundWinnerId: 'winner-id-12345',
+          roundWinnerName: 'Bob',
+        },
+        players: SAMPLE_PLAYERS,
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    const body = await res.json();
+    expect(body.winnerId).toBe('winner-id-12345');
+    expect(body.winnerName).toBe('Bob');
+  });
+
+  it('returns incorrect for wrong guess', async () => {
+    makeSelectThenUpdateClient({
+      data: { status: 'playing', game: ACTIVE_GAME, players: SAMPLE_PLAYERS },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'apple' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('incorrect');
+  });
+
+  it('is case-insensitive for answer matching', async () => {
+    const client = makeSelectThenUpdateClient(
+      { data: { status: 'playing', game: ACTIVE_GAME, players: SAMPLE_PLAYERS }, error: null },
+      { error: null }
+    );
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'BANANA' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(body.alreadyAwarded).toBe(false);
+    // Verify DB was actually updated (not a dry-run)
+    const updateChain = client.from.mock.results[1].value;
+    expect(updateChain.update).toHaveBeenCalled();
+  });
+
+  it('returns already-awarded when another player already won', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        status: 'playing',
+        game: { ...ACTIVE_GAME, roundWinnerId: 'other-player-12345', roundWinnerName: 'Bob' },
+        players: SAMPLE_PLAYERS,
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(true);
+    expect(body.alreadyAwarded).toBe(true);
+    expect(body.winnerId).toBe('other-player-12345');
+  });
+
+  it('returns 500 when DB update fails', async () => {
+    makeSelectThenUpdateClient(
+      { data: { status: 'playing', game: ACTIVE_GAME, players: SAMPLE_PLAYERS }, error: null },
+      { error: { message: 'update failed' } }
+    );
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 200 with winner info on correct first answer', async () => {
+    makeSelectThenUpdateClient(
+      { data: { status: 'playing', game: ACTIVE_GAME, players: SAMPLE_PLAYERS }, error: null },
+      { error: null }
+    );
+    const res = await POST(
+      makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.accepted).toBe(true);
+    expect(body.alreadyAwarded).toBe(false);
+    expect(body.winnerId).toBe(VALID_PLAYER_ID);
+    expect(body.winnerName).toBe('Alice');
+  });
+
+  it('awards a point and updates game state on correct answer', async () => {
+    const client = makeSelectThenUpdateClient(
+      { data: { status: 'playing', game: ACTIVE_GAME, players: SAMPLE_PLAYERS }, error: null },
+      { error: null }
+    );
+    await POST(makeRequest({ playerId: VALID_PLAYER_ID, guess: 'banana' }), makeParams());
+    const updateChain = client.from.mock.results[1].value;
+    const { players, game } = updateChain.update.mock.calls[0][0];
+    expect(players[VALID_PLAYER_ID].score).toBe(1);
+    expect(game.roundWinnerId).toBe(VALID_PLAYER_ID);
+    expect(game.roundState).toBe('between');
+    expect(game.solvedRounds).toBe(1);
+    expect(game.roundWinnerAt).toBeDefined();
+  });
+});

--- a/__tests__/api/multiplayer/sessions-code-players-playerId.test.js
+++ b/__tests__/api/multiplayer/sessions-code-players-playerId.test.js
@@ -1,0 +1,415 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/supabaseAdmin', () => ({ createServiceClient: jest.fn() }));
+
+import { PATCH } from '@/app/api/multiplayer/sessions/[code]/players/[playerId]/route';
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const VALID_CODE = 'ABCD23';
+const VALID_PLAYER_ID = 'player-abc12345678';
+const VALID_ROUND_ID = 'round-id-12345678';
+
+const SAMPLE_PLAYERS = {
+  [VALID_PLAYER_ID]: { id: VALID_PLAYER_ID, name: 'Alice', score: 0 },
+};
+
+const VOTE_PHASE_GAME = {
+  phase: 'vote',
+  currentRoundId: VALID_ROUND_ID,
+  currentSpeakerId: 'speaker-abc12345678',
+};
+
+function makeParams(code = VALID_CODE, playerId = VALID_PLAYER_ID) {
+  return { params: Promise.resolve({ code, playerId }) };
+}
+
+function makeRequest(body) {
+  return new Request(
+    `http://localhost/api/multiplayer/sessions/${VALID_CODE}/players/${VALID_PLAYER_ID}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makeSelectThenUpdateClient(selectResult, updateResult = { error: null }) {
+  const selectChain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(selectResult),
+  };
+  const updateChain = {
+    update: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockResolvedValue(updateResult),
+  };
+  const client = {
+    from: jest.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(updateChain),
+  };
+  createServiceClient.mockReturnValue(client);
+  return client;
+}
+
+afterEach(() => jest.clearAllMocks());
+
+// ─── Shared validation ────────────────────────────────────────────────────────
+
+describe('PATCH /api/multiplayer/sessions/[code]/players/[playerId] — shared validation', () => {
+  it('returns 400 for invalid code', async () => {
+    const res = await PATCH(makeRequest({ action: 'vote' }), makeParams('BAD!'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid playerId (too short)', async () => {
+    const res = await PATCH(makeRequest({ action: 'vote' }), makeParams(VALID_CODE, 'short'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/player/i);
+  });
+
+  it('returns 503 when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await PATCH(makeRequest({ action: 'vote' }), makeParams());
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const req = new Request(
+      `http://localhost/api/multiplayer/sessions/${VALID_CODE}/players/${VALID_PLAYER_ID}`,
+      { method: 'PATCH', body: 'not-json' }
+    );
+    const res = await PATCH(req, makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when action is missing', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const res = await PATCH(makeRequest({}), makeParams());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/action/i);
+  });
+
+  it('returns 400 for unsupported action', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(makeRequest({ action: 'fly' }), makeParams());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/unsupported/i);
+  });
+
+  it('returns 500 on DB load error', async () => {
+    const selectChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+    };
+    createServiceClient.mockReturnValue({ from: jest.fn().mockReturnValue(selectChain) });
+    const res = await PATCH(makeRequest({ action: 'vote' }), makeParams());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 when session not found', async () => {
+    const selectChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    createServiceClient.mockReturnValue({ from: jest.fn().mockReturnValue(selectChain) });
+    const res = await PATCH(makeRequest({ action: 'vote' }), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when player not found in session', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        players: { 'other-player-12345678': { id: 'other-player-12345678', name: 'Bob' } },
+        game: VOTE_PHASE_GAME,
+      },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 1 }),
+      makeParams()
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── submitStatements ─────────────────────────────────────────────────────────
+
+describe('PATCH — action: submitStatements', () => {
+  const VALID_STATEMENTS = ['I climbed Everest.', 'I love pizza.', 'I speak five languages.'];
+
+  it('returns 400 for fewer than 3 statements', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: ['Only one.'], lieIndex: 0 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/3/);
+  });
+
+  it('returns 400 for more than 3 statements', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({
+        action: 'submitStatements',
+        statements: ['a', 'b', 'c', 'd'],
+        lieIndex: 0,
+      }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an empty statement', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: ['a', '', 'c'], lieIndex: 0 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/1-180/i);
+  });
+
+  it('returns 400 for a statement exceeding 180 characters', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({
+        action: 'submitStatements',
+        statements: ['a', 'b', 'x'.repeat(181)],
+        lieIndex: 0,
+      }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for lieIndex below 0', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: VALID_STATEMENTS, lieIndex: -1 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/lie index/i);
+  });
+
+  it('returns 400 for lieIndex above 2', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: VALID_STATEMENTS, lieIndex: 3 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-integer lieIndex', async () => {
+    makeSelectThenUpdateClient({ data: { players: SAMPLE_PLAYERS, game: {} }, error: null });
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: VALID_STATEMENTS, lieIndex: 1.5 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on DB update error', async () => {
+    makeSelectThenUpdateClient(
+      { data: { players: SAMPLE_PLAYERS, game: {} }, error: null },
+      { error: { message: 'update failed' } }
+    );
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: VALID_STATEMENTS, lieIndex: 2 }),
+      makeParams()
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 200 and stores submission on player', async () => {
+    const client = makeSelectThenUpdateClient(
+      { data: { players: SAMPLE_PLAYERS, game: {} }, error: null },
+      { error: null }
+    );
+    const res = await PATCH(
+      makeRequest({ action: 'submitStatements', statements: VALID_STATEMENTS, lieIndex: 2 }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+    const updateChain = client.from.mock.results[1].value;
+    const { players } = updateChain.update.mock.calls[0][0];
+    expect(players[VALID_PLAYER_ID].submission).toEqual(
+      expect.objectContaining({
+        statements: VALID_STATEMENTS,
+        lieIndex: 2,
+        ready: true,
+      })
+    );
+    expect(players[VALID_PLAYER_ID].submission.submittedAt).toBeDefined();
+  });
+
+  it('trims whitespace from each statement', async () => {
+    const client = makeSelectThenUpdateClient(
+      { data: { players: SAMPLE_PLAYERS, game: {} }, error: null },
+      { error: null }
+    );
+    await PATCH(
+      makeRequest({
+        action: 'submitStatements',
+        statements: ['  padded  ', ' also padded ', 'clean'],
+        lieIndex: 0,
+      }),
+      makeParams()
+    );
+    const updateChain = client.from.mock.results[1].value;
+    const { players } = updateChain.update.mock.calls[0][0];
+    expect(players[VALID_PLAYER_ID].submission.statements).toEqual([
+      'padded',
+      'also padded',
+      'clean',
+    ]);
+  });
+});
+
+// ─── vote ─────────────────────────────────────────────────────────────────────
+
+describe('PATCH — action: vote', () => {
+  it('returns 400 for missing roundId', async () => {
+    makeSelectThenUpdateClient({
+      data: { players: SAMPLE_PLAYERS, game: VOTE_PHASE_GAME },
+      error: null,
+    });
+    const res = await PATCH(makeRequest({ action: 'vote', statementIndex: 1 }), makeParams());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/round/i);
+  });
+
+  it('returns 400 for statementIndex below 0', async () => {
+    makeSelectThenUpdateClient({
+      data: { players: SAMPLE_PLAYERS, game: VOTE_PHASE_GAME },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: -1 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/vote/i);
+  });
+
+  it('returns 400 for statementIndex above 2', async () => {
+    makeSelectThenUpdateClient({
+      data: { players: SAMPLE_PLAYERS, game: VOTE_PHASE_GAME },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 3 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-integer statementIndex', async () => {
+    makeSelectThenUpdateClient({
+      data: { players: SAMPLE_PLAYERS, game: VOTE_PHASE_GAME },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 0.5 }),
+      makeParams()
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns round-inactive when game phase is not vote', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        players: SAMPLE_PLAYERS,
+        game: { ...VOTE_PHASE_GAME, phase: 'reveal' },
+      },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 1 }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('round-inactive');
+  });
+
+  it('returns round-inactive when roundId does not match current round', async () => {
+    makeSelectThenUpdateClient({
+      data: {
+        players: SAMPLE_PLAYERS,
+        game: { ...VOTE_PHASE_GAME, currentRoundId: 'different-round-12345' },
+      },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 1 }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('round-inactive');
+  });
+
+  it('returns speaker-cannot-vote when the player is the current speaker', async () => {
+    const speakerId = VALID_PLAYER_ID;
+    makeSelectThenUpdateClient({
+      data: {
+        players: { [speakerId]: { id: speakerId, name: 'Alice' } },
+        game: { ...VOTE_PHASE_GAME, currentSpeakerId: speakerId },
+      },
+      error: null,
+    });
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 0 }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('speaker-cannot-vote');
+  });
+
+  it('returns 500 on DB update error', async () => {
+    makeSelectThenUpdateClient(
+      { data: { players: SAMPLE_PLAYERS, game: VOTE_PHASE_GAME }, error: null },
+      { error: { message: 'update failed' } }
+    );
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 1 }),
+      makeParams()
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 200 and records vote on player', async () => {
+    const client = makeSelectThenUpdateClient(
+      { data: { players: SAMPLE_PLAYERS, game: VOTE_PHASE_GAME }, error: null },
+      { error: null }
+    );
+    const res = await PATCH(
+      makeRequest({ action: 'vote', roundId: VALID_ROUND_ID, statementIndex: 2 }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+    const updateChain = client.from.mock.results[1].value;
+    const { players } = updateChain.update.mock.calls[0][0];
+    expect(players[VALID_PLAYER_ID].vote).toEqual(
+      expect.objectContaining({
+        roundId: VALID_ROUND_ID,
+        statementIndex: 2,
+      })
+    );
+    expect(players[VALID_PLAYER_ID].vote.votedAt).toBeDefined();
+  });
+});

--- a/__tests__/api/multiplayer/sessions-code-players.test.js
+++ b/__tests__/api/multiplayer/sessions-code-players.test.js
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/supabaseAdmin', () => ({ createServiceClient: jest.fn() }));
+
+import { POST } from '@/app/api/multiplayer/sessions/[code]/players/route';
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const VALID_CODE = 'ABCD23';
+const VALID_APP_PATH = '/apps/2026/01/01/test-app';
+
+function makeParams(code = VALID_CODE) {
+  return { params: Promise.resolve({ code }) };
+}
+
+function makeRequest(body) {
+  return new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}/players`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeClient({ selectResult, rpcResult }) {
+  const selectChain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(selectResult),
+  };
+  const client = {
+    from: jest.fn().mockReturnValue(selectChain),
+    rpc: jest.fn().mockResolvedValue(rpcResult),
+  };
+  createServiceClient.mockReturnValue(client);
+  return client;
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe('POST /api/multiplayer/sessions/[code]/players', () => {
+  it('returns 400 for invalid code', async () => {
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams('BAD!'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for code with banned characters', async () => {
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams('ABCD01'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams());
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn(), rpc: jest.fn() });
+    const req = new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}/players`, {
+      method: 'POST',
+      body: 'not-json',
+    });
+    const res = await POST(req, makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for empty name', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: null, error: null },
+    });
+    const res = await POST(makeRequest({ name: '' }), makeParams());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/name/i);
+  });
+
+  it('returns 400 for name that is only whitespace', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: null, error: null },
+    });
+    const res = await POST(makeRequest({ name: '   ' }), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for name longer than 30 characters', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: null, error: null },
+    });
+    const res = await POST(makeRequest({ name: 'A'.repeat(31) }), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing name', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: null, error: null },
+    });
+    const res = await POST(makeRequest({}), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on DB load error', async () => {
+    makeClient({
+      selectResult: { data: null, error: { message: 'DB error' } },
+      rpcResult: { data: null, error: null },
+    });
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 when session not found', async () => {
+    makeClient({
+      selectResult: { data: null, error: null },
+      rpcResult: { data: null, error: null },
+    });
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 on RPC error', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: null, error: { message: 'rpc failed' } },
+    });
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 201 with playerId and appPath on success', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: [{ app_path: VALID_APP_PATH }], error: null },
+    });
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.playerId).toBeDefined();
+    expect(body.appPath).toBe(VALID_APP_PATH);
+  });
+
+  it('falls back to row.app_path when rpc returns no rows', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: [], error: null },
+    });
+    const res = await POST(makeRequest({ name: 'Alice' }), makeParams());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.appPath).toBe(VALID_APP_PATH);
+  });
+
+  it('calls rpc with the correct function name and player record', async () => {
+    const client = makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: [{ app_path: VALID_APP_PATH }], error: null },
+    });
+    await POST(makeRequest({ name: 'Bob' }), makeParams());
+    expect(client.rpc).toHaveBeenCalledWith(
+      'add_multiplayer_player',
+      expect.objectContaining({
+        p_code: VALID_CODE,
+        p_player: expect.objectContaining({ name: 'Bob', online: true }),
+      })
+    );
+  });
+
+  it('accepts a name of exactly 30 characters', async () => {
+    makeClient({
+      selectResult: { data: { app_path: VALID_APP_PATH }, error: null },
+      rpcResult: { data: [{ app_path: VALID_APP_PATH }], error: null },
+    });
+    const res = await POST(makeRequest({ name: 'A'.repeat(30) }), makeParams());
+    expect(res.status).toBe(201);
+  });
+});

--- a/__tests__/api/multiplayer/sessions-code.test.js
+++ b/__tests__/api/multiplayer/sessions-code.test.js
@@ -1,0 +1,307 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/supabaseAdmin', () => ({ createServiceClient: jest.fn() }));
+
+import { GET, PATCH } from '@/app/api/multiplayer/sessions/[code]/route';
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const VALID_CODE = 'ABCD23';
+const VALID_MOD_ID = 'mod-user-12345678';
+
+const SAMPLE_ROW = {
+  app_id: 'test-app',
+  app_name: 'Test App',
+  app_path: '/apps/2026/01/01/test-app',
+  moderator_id: VALID_MOD_ID,
+  created_at: '2026-01-01T00:00:00Z',
+  status: 'lobby',
+  settings: { maxPlayers: 4 },
+  game: { round: 1 },
+  players: { 'player-abc12345': { id: 'player-abc12345', name: 'Alice' } },
+};
+
+function makeParams(code = VALID_CODE) {
+  return { params: Promise.resolve({ code }) };
+}
+
+function makeGetRequest() {
+  return new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}`);
+}
+
+function makePatchRequest(body) {
+  return new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeSelectClient(selectResult) {
+  const selectChain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(selectResult),
+  };
+  const client = { from: jest.fn().mockReturnValue(selectChain) };
+  createServiceClient.mockReturnValue(client);
+  return client;
+}
+
+function makeSelectThenUpdateClient(selectResult, updateResult) {
+  const selectChain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(selectResult),
+  };
+  const updateChain = {
+    update: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockResolvedValue(updateResult),
+  };
+  const client = {
+    from: jest.fn().mockReturnValueOnce(selectChain).mockReturnValueOnce(updateChain),
+  };
+  createServiceClient.mockReturnValue(client);
+  return client;
+}
+
+afterEach(() => jest.clearAllMocks());
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/multiplayer/sessions/[code]', () => {
+  it('returns 400 for invalid code', async () => {
+    const res = await GET(makeGetRequest(), makeParams('BAD!'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for code with banned characters', async () => {
+    const res = await GET(makeGetRequest(), makeParams('ABCD01'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 500 on DB error', async () => {
+    makeSelectClient({ data: null, error: { message: 'DB error' } });
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 when session not found', async () => {
+    makeSelectClient({ data: null, error: null });
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 with sanitized session on success', async () => {
+    makeSelectClient({ data: SAMPLE_ROW, error: null });
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.session).toEqual({
+      appId: SAMPLE_ROW.app_id,
+      appName: SAMPLE_ROW.app_name,
+      appPath: SAMPLE_ROW.app_path,
+      moderatorId: SAMPLE_ROW.moderator_id,
+      createdAt: SAMPLE_ROW.created_at,
+      status: SAMPLE_ROW.status,
+      settings: SAMPLE_ROW.settings,
+      game: SAMPLE_ROW.game,
+      players: SAMPLE_ROW.players,
+    });
+  });
+
+  it('normalizes code to uppercase for the DB query', async () => {
+    const client = makeSelectClient({ data: SAMPLE_ROW, error: null });
+    await GET(makeGetRequest(), makeParams('abcd23'));
+    const chain = client.from.mock.results[0].value;
+    expect(chain.eq).toHaveBeenCalledWith('code', 'ABCD23');
+  });
+
+  it('returns empty objects for null settings/game/players', async () => {
+    makeSelectClient({
+      data: { ...SAMPLE_ROW, settings: null, game: null, players: null },
+      error: null,
+    });
+    const res = await GET(makeGetRequest(), makeParams());
+    const body = await res.json();
+    expect(body.session.settings).toEqual({});
+    expect(body.session.game).toBeNull();
+    expect(body.session.players).toEqual({});
+  });
+});
+
+// ─── PATCH ───────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/multiplayer/sessions/[code]', () => {
+  it('returns 400 for invalid code', async () => {
+    const res = await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID }), makeParams('BAD!'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 503 when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID }), makeParams());
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const req = new Request(`http://localhost/api/multiplayer/sessions/${VALID_CODE}`, {
+      method: 'PATCH',
+      body: 'not-json',
+    });
+    const res = await PATCH(req, makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid moderatorId', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const res = await PATCH(makePatchRequest({ moderatorId: 'short' }), makeParams());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on DB load error', async () => {
+    const selectChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+    };
+    const client = { from: jest.fn().mockReturnValue(selectChain) };
+    createServiceClient.mockReturnValue(client);
+    const res = await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID }), makeParams());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 when session not found', async () => {
+    const selectChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    const client = { from: jest.fn().mockReturnValue(selectChain) };
+    createServiceClient.mockReturnValue(client);
+    const res = await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID }), makeParams());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when moderatorId does not match', async () => {
+    makeSelectThenUpdateClient(
+      { data: { ...SAMPLE_ROW, moderator_id: 'other-mod-12345' }, error: null },
+      { error: null }
+    );
+    const res = await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID }), makeParams());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 on DB update error', async () => {
+    makeSelectThenUpdateClient(
+      { data: SAMPLE_ROW, error: null },
+      { error: { message: 'update failed' } }
+    );
+    const res = await PATCH(
+      makePatchRequest({ moderatorId: VALID_MOD_ID, status: 'playing' }),
+      makeParams()
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 200 on success', async () => {
+    makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    const res = await PATCH(
+      makePatchRequest({ moderatorId: VALID_MOD_ID, status: 'playing' }),
+      makeParams()
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('updates status when a valid value is provided', async () => {
+    const client = makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID, status: 'ended' }), makeParams());
+    const updateChain = client.from.mock.results[1].value;
+    expect(updateChain.update).toHaveBeenCalledWith(expect.objectContaining({ status: 'ended' }));
+  });
+
+  it('ignores invalid status values', async () => {
+    const client = makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID, status: 'invalid' }), makeParams());
+    const updateChain = client.from.mock.results[1].value;
+    const updateArg = updateChain.update.mock.calls[0][0];
+    expect(updateArg.status).toBeUndefined();
+  });
+
+  it('only writes touched roots for game/ patch', async () => {
+    const client = makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    await PATCH(
+      makePatchRequest({ moderatorId: VALID_MOD_ID, patch: { 'game/word': 'banana' } }),
+      makeParams()
+    );
+    const updateChain = client.from.mock.results[1].value;
+    const updateArg = updateChain.update.mock.calls[0][0];
+    expect(updateArg.game).toBeDefined();
+    expect(updateArg.settings).toBeUndefined();
+    expect(updateArg.players).toBeUndefined();
+    expect(updateArg.game.word).toBe('banana');
+  });
+
+  it('only writes touched roots for settings/ patch', async () => {
+    const client = makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    await PATCH(
+      makePatchRequest({ moderatorId: VALID_MOD_ID, patch: { 'settings/maxPlayers': 8 } }),
+      makeParams()
+    );
+    const updateChain = client.from.mock.results[1].value;
+    const updateArg = updateChain.update.mock.calls[0][0];
+    expect(updateArg.settings).toBeDefined();
+    expect(updateArg.game).toBeUndefined();
+    expect(updateArg.players).toBeUndefined();
+    expect(updateArg.settings.maxPlayers).toBe(8);
+  });
+
+  it('writes all three roots for unknown-root patch paths', async () => {
+    const client = makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    await PATCH(
+      makePatchRequest({ moderatorId: VALID_MOD_ID, patch: { unknownField: 'value' } }),
+      makeParams()
+    );
+    const updateChain = client.from.mock.results[1].value;
+    const updateArg = updateChain.update.mock.calls[0][0];
+    expect(updateArg.settings).toBeDefined();
+    expect(updateArg.game).toBeDefined();
+    expect(updateArg.players).toBeDefined();
+  });
+
+  it('skips empty update when no status change and no patch keys', async () => {
+    const client = makeSelectThenUpdateClient({ data: SAMPLE_ROW, error: null }, { error: null });
+    await PATCH(makePatchRequest({ moderatorId: VALID_MOD_ID }), makeParams());
+    const updateChain = client.from.mock.results[1].value;
+    expect(updateChain.update).toHaveBeenCalledWith({});
+  });
+
+  it('patches nested game state correctly', async () => {
+    const rowWithGame = {
+      ...SAMPLE_ROW,
+      game: { round: 1, roundState: 'lobby' },
+    };
+    const client = makeSelectThenUpdateClient({ data: rowWithGame, error: null }, { error: null });
+    await PATCH(
+      makePatchRequest({
+        moderatorId: VALID_MOD_ID,
+        patch: { 'game/roundState': 'active', 'game/word': 'apple' },
+      }),
+      makeParams()
+    );
+    const updateChain = client.from.mock.results[1].value;
+    const updateArg = updateChain.update.mock.calls[0][0];
+    expect(updateArg.game.roundState).toBe('active');
+    expect(updateArg.game.word).toBe('apple');
+    expect(updateArg.game.round).toBe(1);
+  });
+});

--- a/__tests__/api/multiplayer/sessions.test.js
+++ b/__tests__/api/multiplayer/sessions.test.js
@@ -1,0 +1,256 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/supabaseAdmin', () => ({ createServiceClient: jest.fn() }));
+
+import { POST } from '@/app/api/multiplayer/sessions/route';
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+const VALID_CODE = 'ABCD23';
+const VALID_MOD_ID = 'mod-user-12345678';
+const VALID_APP = {
+  appId: 'test-app',
+  appName: 'Test App',
+  appPath: '/apps/2026/01/01/test-app',
+};
+
+function makeRequest(body) {
+  return new Request('http://localhost/api/multiplayer/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeClient({ selectResult, insertResult }) {
+  const selectChain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue(selectResult),
+  };
+  const client = {
+    from: jest
+      .fn()
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce({ insert: jest.fn().mockResolvedValue(insertResult) }),
+  };
+  createServiceClient.mockReturnValue(client);
+  return client;
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe('POST /api/multiplayer/sessions', () => {
+  it('returns 503 when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    createServiceClient.mockReturnValue({});
+    const req = new Request('http://localhost/api/multiplayer/sessions', {
+      method: 'POST',
+      body: 'not-json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing code', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(makeRequest({ ...VALID_APP, moderatorId: VALID_MOD_ID }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/code/i);
+  });
+
+  it('returns 400 for code with banned characters (0, O, 1, I)', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: 'ABCD01', ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for code that is too short', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(makeRequest({ code: 'AB2', ...VALID_APP, moderatorId: VALID_MOD_ID }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for code that is too long', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: 'ABCDEFGHJ23', ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('normalizes code to uppercase before validation', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: 'abcd23', ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.code).toBe('ABCD23');
+  });
+
+  it('returns 400 for missing appId', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, appName: 'Test', appPath: '/x', moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/metadata/i);
+  });
+
+  it('returns 400 for missing appName', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, appId: 'x', appPath: '/x', moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing appPath', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, appId: 'x', appName: 'x', moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid moderatorId (too short)', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: 'short' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/moderator/i);
+  });
+
+  it('returns 400 for missing moderatorId', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(makeRequest({ code: VALID_CODE, ...VALID_APP }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when collision check query fails', async () => {
+    const selectChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+    };
+    const client = { from: jest.fn().mockReturnValue(selectChain) };
+    createServiceClient.mockReturnValue(client);
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 409 when code already exists (pre-flight check)', async () => {
+    const selectChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: { code: VALID_CODE }, error: null }),
+    };
+    const client = { from: jest.fn().mockReturnValue(selectChain) };
+    createServiceClient.mockReturnValue(client);
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/exists/i);
+  });
+
+  it('returns 409 on race-condition unique_violation (23505)', async () => {
+    makeClient({
+      selectResult: { data: null, error: null },
+      insertResult: { error: { code: '23505', message: 'duplicate key' } },
+    });
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 500 when insert fails with a non-duplicate error', async () => {
+    makeClient({
+      selectResult: { data: null, error: null },
+      insertResult: { error: { code: '42501', message: 'permission denied' } },
+    });
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 201 with ok and code on success', async () => {
+    makeClient({ selectResult: { data: null, error: null }, insertResult: { error: null } });
+    const res = await POST(
+      makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, code: VALID_CODE });
+  });
+
+  it('inserts the row with correct structure', async () => {
+    const client = makeClient({
+      selectResult: { data: null, error: null },
+      insertResult: { error: null },
+    });
+    await POST(
+      makeRequest({
+        code: VALID_CODE,
+        ...VALID_APP,
+        moderatorId: VALID_MOD_ID,
+        settings: { maxPlayers: 8 },
+      })
+    );
+    const insertChain = client.from.mock.results[1].value;
+    expect(insertChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: VALID_CODE,
+        app_id: VALID_APP.appId,
+        app_name: VALID_APP.appName,
+        app_path: VALID_APP.appPath,
+        moderator_id: VALID_MOD_ID,
+        status: 'lobby',
+        settings: { maxPlayers: 8 },
+        players: {},
+        game: null,
+      })
+    );
+  });
+
+  it('uses empty object for settings when not provided', async () => {
+    const client = makeClient({
+      selectResult: { data: null, error: null },
+      insertResult: { error: null },
+    });
+    await POST(makeRequest({ code: VALID_CODE, ...VALID_APP, moderatorId: VALID_MOD_ID }));
+    const insertChain = client.from.mock.results[1].value;
+    expect(insertChain.insert).toHaveBeenCalledWith(expect.objectContaining({ settings: {} }));
+  });
+
+  it('ignores array settings values and uses empty object fallback', async () => {
+    const client = makeClient({
+      selectResult: { data: null, error: null },
+      insertResult: { error: null },
+    });
+    await POST(
+      makeRequest({
+        code: VALID_CODE,
+        ...VALID_APP,
+        moderatorId: VALID_MOD_ID,
+        settings: [1, 2, 3],
+      })
+    );
+    const insertChain = client.from.mock.results[1].value;
+    expect(insertChain.insert).toHaveBeenCalledWith(expect.objectContaining({ settings: {} }));
+  });
+});

--- a/__tests__/api/multiplayer/status.test.js
+++ b/__tests__/api/multiplayer/status.test.js
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/supabaseAdmin', () => ({ createServiceClient: jest.fn() }));
+
+import { GET } from '@/app/api/multiplayer/status/route';
+import { createServiceClient } from '@/lib/supabaseAdmin';
+
+afterEach(() => jest.clearAllMocks());
+
+describe('GET /api/multiplayer/status', () => {
+  it('returns configured: false when createServiceClient returns null', async () => {
+    createServiceClient.mockReturnValue(null);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ configured: false });
+  });
+
+  it('returns configured: true when createServiceClient returns a client', async () => {
+    createServiceClient.mockReturnValue({ from: jest.fn() });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ configured: true });
+  });
+});


### PR DESCRIPTION
## Summary\n- add focused Jest coverage for multiplayer session API routes under \n- include create/read/update flows and failure handling assertions for sessions and players\n- add status endpoint coverage for health checks\n\n## Files\n- __tests__/api/multiplayer/sessions.test.js\n- __tests__/api/multiplayer/sessions-code.test.js\n- __tests__/api/multiplayer/sessions-code-players.test.js\n- __tests__/api/multiplayer/sessions-code-players-playerId.test.js\n- __tests__/api/multiplayer/sessions-code-answers.test.js\n- __tests__/api/multiplayer/status.test.js\n\n## Validation\n- npm run lint\n- npm test\n- npm run validate:apps\n