### PR TITLE
Refactor leaderboard capability detection to metadata-driven flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ See [Project Structure](wiki/Project-Structure.md) for the full annotated tree c
 ## 📊 App Metadata
 
 Every app includes a `meta.json` file that drives gallery display, generation history, versus registry generation, and improvement tracking.
-See [App Metadata Reference](wiki/App-Metadata-Reference.md) for the annotated example, field-by-field notes, and the optional `visible`, `allowImprovements`, and `maxScore` flags.
+See [App Metadata Reference](wiki/App-Metadata-Reference.md) for the annotated example, field-by-field notes, and the `visible`, `allowImprovements`, `leaderboard`, and `maxScore` flags.
 
 ---
 

--- a/__tests__/data/apps.test.js
+++ b/__tests__/data/apps.test.js
@@ -46,6 +46,7 @@ describe('Apps Registry', () => {
         'thumbnailUrl',
         'createdAt',
         'route',
+        'leaderboard',
       ];
       appsData.forEach((app) => {
         for (const field of requiredFields) {
@@ -72,6 +73,12 @@ describe('Apps Registry', () => {
         const date = new Date(app.createdAt);
         expect(date.toString()).not.toBe('Invalid Date');
         expect(app.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      });
+    });
+
+    it('apps should have a boolean leaderboard capability flag', () => {
+      appsData.forEach((app) => {
+        expect(typeof app.leaderboard).toBe('boolean');
       });
     });
   }

--- a/__tests__/scripts/apps-registry.test.js
+++ b/__tests__/scripts/apps-registry.test.js
@@ -60,6 +60,16 @@ describe('apps-registry leaderboard detection', () => {
     expect(detectLeaderboardUsageFromHtml(html)).toBe(false);
   });
 
+  it('ignores usage strings that only appear in inline comments', () => {
+    const html = `
+      <script>
+        doSomething(); // fetch('/api/scores', { method: 'POST' });
+        doOther(); // window.voaLeaderboard.submit(score);
+      </script>
+    `;
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(false);
+  });
+
   it('detects usage from app directory index.html', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'voa-leaderboard-'));
     try {
@@ -76,8 +86,8 @@ describe('apps-registry leaderboard detection', () => {
 });
 
 describe('transformMeta leaderboard projection', () => {
-  const appsDir = '/tmp/apps';
-  const filePath = '/tmp/apps/2026/04/23/example-app/meta.json';
+  const appsDir = path.join(os.tmpdir(), 'apps');
+  const filePath = path.join(os.tmpdir(), 'apps', '2026', '04', '23', 'example-app', 'meta.json');
   const dateInfo = { year: 2026, month: 4, day: 23 };
 
   it('defaults leaderboard to false when missing', () => {

--- a/__tests__/scripts/apps-registry.test.js
+++ b/__tests__/scripts/apps-registry.test.js
@@ -70,6 +70,16 @@ describe('apps-registry leaderboard detection', () => {
     expect(detectLeaderboardUsageFromHtml(html)).toBe(false);
   });
 
+  it('still detects usage when it appears after an unrelated inline comment', () => {
+    const html = `
+      <script>
+        doSomething(); // just a regular comment
+        window.voaLeaderboard.submit(score);
+      </script>
+    `;
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(true);
+  });
+
   it('detects usage from app directory index.html', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'voa-leaderboard-'));
     try {

--- a/__tests__/scripts/apps-registry.test.js
+++ b/__tests__/scripts/apps-registry.test.js
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  detectLeaderboardUsageFromAppDir,
+  detectLeaderboardUsageFromHtml,
+  transformMeta,
+} from '../../scripts/apps-registry.mjs';
+
+describe('apps-registry leaderboard detection', () => {
+  it('detects shared leaderboard submission usage', () => {
+    const html = `
+      <script>
+        if (window.voaLeaderboard) {
+          window.voaLeaderboard.submit(score);
+        }
+      </script>
+    `;
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(true);
+  });
+
+  it('detects manual score submission via fetch', () => {
+    const html = `
+      <script>
+        await fetch('/api/scores', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' }
+        });
+      </script>
+    `;
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(true);
+  });
+
+  it('detects manual score submission via XMLHttpRequest', () => {
+    const html = `
+      <script>
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', '/api/scores');
+      </script>
+    `;
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(true);
+  });
+
+  it('does not match plain leaderboard text', () => {
+    const html = '<section><h2>Final leaderboard</h2></section>';
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(false);
+  });
+
+  it('ignores usage strings that only appear in comments', () => {
+    const html = `
+      <!-- window.voaLeaderboard.submit(score) -->
+      <script>
+        // fetch('/api/scores', { method: 'POST' });
+        /*
+          const xhr = new XMLHttpRequest();
+          xhr.open('POST', '/api/scores');
+        */
+      </script>
+    `;
+    expect(detectLeaderboardUsageFromHtml(html)).toBe(false);
+  });
+
+  it('detects usage from app directory index.html', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'voa-leaderboard-'));
+    try {
+      fs.writeFileSync(
+        path.join(dir, 'index.html'),
+        '<script>window.voaLeaderboard.submit(42);</script>',
+        'utf8'
+      );
+      expect(detectLeaderboardUsageFromAppDir(dir)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('transformMeta leaderboard projection', () => {
+  const appsDir = '/tmp/apps';
+  const filePath = '/tmp/apps/2026/04/23/example-app/meta.json';
+  const dateInfo = { year: 2026, month: 4, day: 23 };
+
+  it('defaults leaderboard to false when missing', () => {
+    const result = transformMeta(
+      appsDir,
+      {
+        name: 'Example',
+        shortDescription: 'Example app',
+        thumbnail: 'thumbnail.svg',
+        createdAt: '2026-04-23T00:00:00Z',
+        category: 'Games',
+        homepagePath: 'index.html',
+      },
+      filePath,
+      dateInfo
+    );
+
+    expect(result.leaderboard).toBe(false);
+  });
+
+  it('preserves leaderboard=true from meta', () => {
+    const result = transformMeta(
+      appsDir,
+      {
+        name: 'Example',
+        shortDescription: 'Example app',
+        thumbnail: 'thumbnail.svg',
+        createdAt: '2026-04-23T00:00:00Z',
+        category: 'Games',
+        homepagePath: 'index.html',
+        leaderboard: true,
+      },
+      filePath,
+      dateInfo
+    );
+
+    expect(result.leaderboard).toBe(true);
+  });
+});

--- a/app/leaderboard/page.jsx
+++ b/app/leaderboard/page.jsx
@@ -9,8 +9,7 @@ export const metadata = {
 
 export const revalidate = 60;
 
-async function fetchTopScoresByApp() {
-  const appIds = appsData.map((app) => app.id).filter(Boolean);
+async function fetchTopScoresByApp(appIds) {
   const supabase = createServiceClient();
 
   if (!supabase) {
@@ -91,11 +90,18 @@ function ScoreCard({ app, scores }) {
 }
 
 export default async function LeaderboardPage() {
-  const scoreGroups = await fetchTopScoresByApp();
-  const appIds = Object.keys(scoreGroups);
+  const leaderboardCapableAppIds = appsData
+    .filter((app) => app?.leaderboard === true)
+    .map((app) => app.id);
+  const scoreGroups = await fetchTopScoresByApp(leaderboardCapableAppIds);
 
   const appsWithScores = appsData
-    .filter((app) => appIds.includes(app.id) && app.status === 'active')
+    .filter(
+      (app) =>
+        app.status === 'active' &&
+        leaderboardCapableAppIds.includes(app.id) &&
+        (scoreGroups[app.id]?.length ?? 0) > 0
+    )
     .sort((a, b) => {
       // Sort by number of scores desc, then by highest score desc
       const aScores = scoreGroups[a.id] ?? [];

--- a/apps/2026/03/05/breathing-orb/meta.json
+++ b/apps/2026/03/05/breathing-orb/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260305T225348Z-affe05",
     "notes": "Original concept built as a lightweight static app; token counters unavailable in this runtime so set to 0 for this run."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/05/color-palette-generator/meta.json
+++ b/apps/2026/03/05/color-palette-generator/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 8200,
     "runId": "run-20260305T215412Z-f06c2c",
     "notes": "Implemented user suggestion for Color Palette Generator with comprehensive color theory harmonies and multiple export formats."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/05/pomodoro-timer/meta.json
+++ b/apps/2026/03/05/pomodoro-timer/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 4200,
     "runId": "run-20260305T220000Z-0b56cb",
     "notes": "Implemented from user suggestion 2026-03-05-003. Added circular progress indicator, settings panel, and Web Audio API notifications."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/05/snake-game/meta.json
+++ b/apps/2026/03/05/snake-game/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 4800,
     "runId": "run-20260305T233000Z-1cf987",
     "notes": "Original creation - classic Snake game with modern polish, touch support, and progressive difficulty."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/06/memory-match/meta.json
+++ b/apps/2026/03/06/memory-match/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 4500,
     "runId": "run-20260306T213500Z-4484c3",
     "notes": "Classic memory card matching game with CSS 3D flip animations and multiple difficulty levels."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/06/sorting-visualizer/meta.json
+++ b/apps/2026/03/06/sorting-visualizer/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 12600,
     "runId": "run-20260306T194500Z-b7e42a",
     "notes": "Original creation - interactive sorting algorithm visualizer with 5 algorithms, speed controls, and multiple initial conditions."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/06/word-scramble/meta.json
+++ b/apps/2026/03/06/word-scramble/meta.json
@@ -80,5 +80,6 @@
     "totalTokensOut": 12200,
     "runId": "run-20260306T143200Z-318d76",
     "notes": "Generated as a test of the full agent workflow including git operations and transactional logging."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/06/word-weaver/meta.json
+++ b/apps/2026/03/06/word-weaver/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260307T020216Z-324c8d",
     "notes": "Token counters unavailable in runtime; set to 0."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/archery-physics/meta.json
+++ b/apps/2026/03/07/archery-physics/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 10000,
     "runId": "run-20260307T183500Z-5b69aa",
     "notes": "Realistic archery game with projectile motion physics including gravity, air resistance, and wind effects. Features power-based bow draw, trajectory preview, and target scoring zones."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/blackjack/meta.json
+++ b/apps/2026/03/07/blackjack/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 9000,
     "runId": "run-20260307T190500Z-0afa75",
     "notes": "Classic blackjack game with spectacular blackjack celebration animations including fireworks, sparks, falling coins, and rotating light rays. Features proper casino rules with 3:2 blackjack payout."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/contrast-lab/meta.json
+++ b/apps/2026/03/07/contrast-lab/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 5000,
     "runId": "run-20260307T080041Z-a1b2c3",
     "notes": "Built a responsive no-dependency accessibility tool with live contrast metrics, dark/light theme toggle, and one-click AA/AAA correction nudges."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/debug-rush/meta.json
+++ b/apps/2026/03/07/debug-rush/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 12000,
     "runId": "run-20260307T194000Z-d3b9f1",
     "notes": "Inspired by computer programmers debugging code as quickly as possible. Features 20 real-world coding bugs across JavaScript and Python with syntax highlighting and time pressure."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/design-dash/meta.json
+++ b/apps/2026/03/07/design-dash/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 10000,
     "runId": "run-20260307T221300Z-dd5c7f",
     "notes": "Speed-based arcade game themed around graphic design. Players match design elements (colors, fonts, icons) to client briefs under time pressure with combo system."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/disco-runner/meta.json
+++ b/apps/2026/03/07/disco-runner/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 12000,
     "runId": "run-20260307T181500Z-a6229f",
     "notes": "Side-scrolling runner with a funky twist: collecting disco balls flips gravity. Features neon colors, disco dancer character with afro, and pulsing background effects."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/fishing-frenzy/meta.json
+++ b/apps/2026/03/07/fishing-frenzy/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260307T230000Z-ff0b4b",
     "notes": "Fishing arcade game with casting mechanics and time challenge."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/flappy-bird/meta.json
+++ b/apps/2026/03/07/flappy-bird/meta.json
@@ -33,5 +33,6 @@
       "agentName": "claude-code",
       "llmModel": "claude-sonnet-4-6"
     }
-  ]
+  ],
+  "leaderboard": true
 }

--- a/apps/2026/03/07/halftime-hustle/meta.json
+++ b/apps/2026/03/07/halftime-hustle/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 12000,
     "runId": "run-20260307T234500Z-59fbd6",
     "notes": "Stealth action game where you play as a dancer avoiding a tyrannical instructor's spotlight while collecting dance marks. Features patrol AI, spotlight cone detection, progressive difficulty, and touch controls."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/pacman-classic/meta.json
+++ b/apps/2026/03/07/pacman-classic/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260307T200104Z-dd2835",
     "notes": "Token counters are not exposed by this runtime; set to 0."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/realtor-tycoon/meta.json
+++ b/apps/2026/03/07/realtor-tycoon/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 12000,
     "runId": "run-20260307T215800Z-7df140",
     "notes": "Lemonade Stand-style business simulation game themed around real estate. Features market conditions, pricing strategies, marketing budgets, and reputation system."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/road-rage/meta.json
+++ b/apps/2026/03/07/road-rage/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 12000,
     "runId": "run-20260308T020940Z-60cf1d",
     "notes": "Vertical scrolling racing game with 4-lane highway, enemy traffic, wet spots causing spin-outs, score/distance/speed tracking, and responsive touch controls."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/07/workout-timer-pulse/meta.json
+++ b/apps/2026/03/07/workout-timer-pulse/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260308T024243Z-e7e6e0",
     "notes": "Feature set prioritized from common interval timer app patterns: presets, prep, rounds, cues, pause/skip. Token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/07/zorkish-text-adventure/meta.json
+++ b/apps/2026/03/07/zorkish-text-adventure/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260307T201657Z-3f5846",
     "notes": "Token counters unavailable in runtime; set to 0."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/08/daredevil-moto-jump/meta.json
+++ b/apps/2026/03/08/daredevil-moto-jump/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 9500,
     "runId": "run-20260308T182000Z-d4e5f6",
     "notes": "Evel Knievel-inspired motorcycle stunt game with ramp launching, mid-air flips, star collection, bus obstacles, and progressive difficulty. Canvas-based rendering with fire trail particles."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/08/eagle-eye-teacher/meta.json
+++ b/apps/2026/03/08/eagle-eye-teacher/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 8500,
     "runId": "run-20260308T113000Z-4d43ac",
     "notes": "Middle school classroom themed reaction game. Teacher must spot misbehavior while avoiding penalizing good students."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/08/logic-lights-out/meta.json
+++ b/apps/2026/03/08/logic-lights-out/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 3900,
     "runId": "run-20260308T080103Z-3c1eed",
     "notes": "Built a mobile-friendly Lights Out game with dark/light theming, keyboard-accessible controls, and deterministic daily mode. Token counts are estimated for this autonomous run."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/08/mini-putt-gauntlet/meta.json
+++ b/apps/2026/03/08/mini-putt-gauntlet/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 5200,
     "runId": "run-20260308T175600Z-c4f9a1",
     "notes": "Built a responsive 3-hole mini putt experience with obstacle-specific mechanics per hole and fixed par 3 scoring. Token counts are estimated for this autonomous run."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/08/space-invaders-clone/meta.json
+++ b/apps/2026/03/08/space-invaders-clone/meta.json
@@ -59,5 +59,6 @@
     "runId": "run-20260308T030021Z-4c5ceb",
     "notes": "Nightly build: Space Invaders clone. Token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/08/typing-speed-sprint/meta.json
+++ b/apps/2026/03/08/typing-speed-sprint/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260308T232048Z-63dd5b",
     "notes": "Nightly app run. Token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/09/gravity-dodge/meta.json
+++ b/apps/2026/03/09/gravity-dodge/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260309T025838Z-f8372e",
     "notes": "Nightly run app. Token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/10/habit-streak-garden/meta.json
+++ b/apps/2026/03/10/habit-streak-garden/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 6500,
     "runId": "run-20260310T070111Z-fcb4dd",
     "notes": "Created an original productivity app with persistent streak tracking, responsive UI, shared shell support, and a garden metaphor for completion progress."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/10/neon-breakout/meta.json
+++ b/apps/2026/03/10/neon-breakout/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260310T050133Z-fda811",
     "notes": "Nightly app run. Token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/10/pixel-painter/meta.json
+++ b/apps/2026/03/10/pixel-painter/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260310T010445Z-0a7ac4",
     "notes": "Nightly task run. Token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/11/lucky-decision-wheel/meta.json
+++ b/apps/2026/03/11/lucky-decision-wheel/meta.json
@@ -22,5 +22,6 @@
     "notes": "Concept generated autonomously; token counts are estimated from generation steps and may vary slightly from provider accounting. Runtime smoke test passed for spin controls, winner state updates, and repeated restart via consecutive spins."
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://valleyofai.com/schemas/meta.json"
+  "$id": "https://valleyofai.com/schemas/meta.json",
+  "leaderboard": false
 }

--- a/apps/2026/03/12/constellation-explorer/meta.json
+++ b/apps/2026/03/12/constellation-explorer/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 10000,
     "runId": "run-20260312T204701Z-c7a3f9",
     "notes": "Original concept: Educational constellation explorer filling the gap in the gallery (no Education apps existed). Features a full-canvas starfield with 10 major constellations (Orion, Ursa Major, Ursa Minor, Cassiopeia, Leo, Scorpius, Cygnus, Canis Major, Gemini, Lyra). Click/tap hit detection selects nearest constellation; animated glow, info panel with mythology and star data, show/hide lines and labels controls, shooting star animation, twinkling background stars. Token counts are estimates."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/12/meeting-cost-calculator/meta.json
+++ b/apps/2026/03/12/meeting-cost-calculator/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260312T234958Z-7f3934",
     "notes": "Built a mobile-first meeting burn-rate tool with attendee management, timer controls, planned-vs-live cost, and keyboard shortcuts."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/12/sorting-race-visualizer/meta.json
+++ b/apps/2026/03/12/sorting-race-visualizer/meta.json
@@ -22,5 +22,6 @@
     "notes": "Agent-generated concept (no pending suggestion). Added shared shell, GA placeholder snippet, responsive UI, and side-by-side sorting race with comparison/swap counters. Token values are best-effort estimates from model-side interaction logs."
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://valleyofai.com/schemas/meta.json"
+  "$id": "https://valleyofai.com/schemas/meta.json",
+  "leaderboard": false
 }

--- a/apps/2026/03/12/timezone-overlap-finder/meta.json
+++ b/apps/2026/03/12/timezone-overlap-finder/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 6800,
     "runId": "run-20260312T233733Z-5e2c9a",
     "notes": "Built a utility app to compare three timezone schedules with work-hour sliders, real-time local clocks, and a UTC overlap timeline. Token counts are estimated from generation phases."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/13/bubble-tap/meta.json
+++ b/apps/2026/03/13/bubble-tap/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 7150,
     "runId": "run-20260313T001721Z-3ba148",
     "notes": "Mobile-first responsive bubble popping game with 3 difficulty levels (Easy/Normal/Hard), touch and click controls, real-time score/combo tracking, particle effects, and local storage for persistent best scores. Fully themed with dark/light mode support and responsive design for all screen sizes."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/13/interval-breathing-coach/meta.json
+++ b/apps/2026/03/13/interval-breathing-coach/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 3890,
     "runId": "run-20260313T070113Z-9f2be5",
     "notes": "Built a mobile-first interval breathing coach with presets, keyboard shortcuts, animated radial guide, progress timeline, and shared shell/theme compatibility."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/14/decision-spinner/meta.json
+++ b/apps/2026/03/14/decision-spinner/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260314T215059Z-ccf7ac",
     "notes": "Inspired by wheel-based picker UX with weighted entries; added fairness penalty to reduce repetitive winners."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/14/password-entropy-lab/meta.json
+++ b/apps/2026/03/14/password-entropy-lab/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260314T070102Z-48238d",
     "notes": "Inspired by zxcvbn-style strength meters; added attack-rate controls and entropy/keyspace visibility for educational use."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/15/focus-sprint-planner/meta.json
+++ b/apps/2026/03/15/focus-sprint-planner/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260315T142146Z-afcd88",
     "notes": "Created mobile-first static app with shared shell, analytics placeholders, keyboard shortcuts, and priority suggestion logic."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/15/hydration-nudge-tracker/meta.json
+++ b/apps/2026/03/15/hydration-nudge-tracker/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260315T070254Z-dea346",
     "notes": "Nightly cron generation; token counters unavailable in runtime."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/16/mindful-breathing-tracker/meta.json
+++ b/apps/2026/03/16/mindful-breathing-tracker/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 3500,
     "runId": "run-20260316T041541Z-3410bf",
     "notes": "Built responsive breathing app with 4-7-8 technique, dark/light theme support, progress tracking, and streak gamification"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/17/focus-timer/meta.json
+++ b/apps/2026/03/17/focus-timer/meta.json
@@ -27,5 +27,6 @@
     "keyboardNavigation": true,
     "darkModeSupport": true,
     "motionPreferences": true
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/17/hangman-word-game/meta.json
+++ b/apps/2026/03/17/hangman-word-game/meta.json
@@ -27,5 +27,6 @@
     "keyboardNavigation": true,
     "darkModeSupport": true,
     "motionPreferences": false
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/18/cyber-hop/meta.json
+++ b/apps/2026/03/18/cyber-hop/meta.json
@@ -30,5 +30,6 @@
     "runId": "run-20260318T182754Z-1209f1",
     "notes": "Cyberpunk Frogger with canvas rendering, requestAnimationFrame smooth tween movement (110ms easing), neon hover vehicles, glowing data-stream platforms, time-warp power-up (slows obstacles 72%), particle death effects, mobile D-pad + swipe controls, keyboard WASD/arrow support, level progression with speed scaling, lives system, local high score."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/19/orbit-memory-match/meta.json
+++ b/apps/2026/03/19/orbit-memory-match/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260319T070047Z-d71684",
     "notes": "Spatial-memory game with 8 orbit nodes, progressive rounds, lives, local best score, keyboard 1-8 support, tap/click controls, and swipe-down replay gesture."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/19/slide-2048/meta.json
+++ b/apps/2026/03/19/slide-2048/meta.json
@@ -20,5 +20,6 @@
     "totalTokensOut": 8800,
     "runId": "run-20260319T214200Z-a3f7b2",
     "notes": "Neon-themed 2048 sliding tile puzzle. Features: 4x4 grid, keyboard/WASD/swipe controls, merge animations, localStorage best score, win/lose/continue overlays, responsive mobile-first layout, full light/dark theme support."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/20/sudoku-sprint/meta.json
+++ b/apps/2026/03/20/sudoku-sprint/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260320T070025Z-921e39",
     "notes": "Built as a responsive single-file static Sudoku app with full shell integration and accessibility-focused controls."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/21/morse-code-radio/meta.json
+++ b/apps/2026/03/21/morse-code-radio/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260321T122150Z-46a700",
     "notes": "Static HTML/CSS/JS app with Web Audio API oscillator for morse code audio, canvas oscilloscope visualization, animated dot/dash symbols, manual key button, speed/frequency sliders, and collapsible reference chart. Mobile-first responsive design with touch support."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/21/neighborhood-home-ranker/meta.json
+++ b/apps/2026/03/21/neighborhood-home-ranker/meta.json
@@ -36,5 +36,6 @@
     "runId": "run-20260321T175153Z-a3f9c2",
     "notes": "Demo app using 14 realistic mock MLS listings in Austin TX metro area. Weighted venue category scoring across 7 categories (restaurants, bars, coffee, grocery, parks, schools, health). Adjustable search radius (0.25-5mi), price/beds/baths/sqft filters, sort options, SVG house illustrations, detail modal with full venue breakdown. Mock data shows how real MLS + Google Places API integration would work."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/21/pattern-pulse-memory/meta.json
+++ b/apps/2026/03/21/pattern-pulse-memory/meta.json
@@ -21,5 +21,6 @@
     "runId": "run-20260321T070022Z-52c4df",
     "notes": "Built as a responsive static game integrated with the shared shell, including keyboard/touch controls and persistent best score."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/21/tetris-classic/meta.json
+++ b/apps/2026/03/21/tetris-classic/meta.json
@@ -27,5 +27,6 @@
     "runId": "run-20260321T145539Z-66db0e",
     "notes": "Tetris clone with 7 tetrominoes, SRS wall kicks, ghost piece, touch swipe + button controls, keyboard support, level progression, and line scoring."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/21/texas-lotto-generator/meta.json
+++ b/apps/2026/03/21/texas-lotto-generator/meta.json
@@ -26,5 +26,6 @@
     "totalTokensOut": 8700,
     "runId": "run-20260321T181439Z-a7f3c2",
     "notes": "All 8 major Texas Lottery games included. Animated ball machine with bouncing balls. One-at-a-time draw reveal with pop animation. Full confetti celebration on draw complete. Mobile-first responsive design."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/22/freecell-mobile-classic/meta.json
+++ b/apps/2026/03/22/freecell-mobile-classic/meta.json
@@ -27,5 +27,6 @@
     "runId": "run-20260322T070033Z-7511ad",
     "notes": "Implemented a static FreeCell game with 8 tableau columns, 4 free cells, 4 foundations, move validation, undo support, and auto-move assistance."
   },
-  "votes": 0
+  "votes": 0,
+  "leaderboard": false
 }

--- a/apps/2026/03/23/dungeon-puzzle-run/meta.json
+++ b/apps/2026/03/23/dungeon-puzzle-run/meta.json
@@ -37,5 +37,6 @@
     "totalTokensOut": 9400,
     "runId": "run-20260323T174555Z-c330b7",
     "notes": "Built from approved community suggestion #175. All 6 puzzle types implemented: logic (truth grid), memory (pair matching), timing (cursor stop), tile (pattern match), pathing (draw path), resource (budget allocation). Seeded mulberry32 RNG for reproducible runs. Token counts are estimates."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/23/tic-tac-toe-strategy-lab/meta.json
+++ b/apps/2026/03/23/tic-tac-toe-strategy-lab/meta.json
@@ -19,5 +19,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260323T070037Z-1a17e4",
     "notes": "Built a static mobile-first tic-tac-toe app with minimax AI, score tracking, keyboard navigation, and swipe-to-reset gesture support."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/24/charades-chaos-deck/meta.json
+++ b/apps/2026/03/24/charades-chaos-deck/meta.json
@@ -39,5 +39,6 @@
     "totalTokensOut": 1400,
     "runId": "run-20260324T070031Z-fa2a04",
     "notes": "Selected from vote-and-category-analysis recommendation (Entertainment) and built as a social charades experience with keyboard/touch support."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/25/neon-slot-rush/meta.json
+++ b/apps/2026/03/25/neon-slot-rush/meta.json
@@ -63,5 +63,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260325T070025Z-5460ff",
     "notes": "Built from approved community suggestion issue #198; optimized for 320px portrait and keyboard/touch parity."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/25/peg-solitaire/meta.json
+++ b/apps/2026/03/25/peg-solitaire/meta.json
@@ -25,5 +25,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260325T000318Z-adea94",
     "notes": "Built from GitHub issue #196 suggestion by Perplexity"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/26/galaxian-blitz/meta.json
+++ b/apps/2026/03/26/galaxian-blitz/meta.json
@@ -59,5 +59,6 @@
     "totalTokensOut": 0,
     "runId": "run-20260326T111937Z-a4f8c2",
     "notes": "Built from approved community suggestion issue #216. Galaxian-style shooter with formation-breaking dive-bomb AI, 3 distinct enemy types (scout/bomber/elite), 3 power-up types (rapid fire/spread shot/shield), particle explosion system, and wave-based difficulty scaling. Differentiated from existing Space Invaders Clone via dynamic dive-bomb behavior and power-up system."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/26/sokoban-warehouse/meta.json
+++ b/apps/2026/03/26/sokoban-warehouse/meta.json
@@ -101,5 +101,6 @@
     "totalTokensOut": 20000,
     "runId": "run-20260326T185345Z-a3f7c2",
     "notes": "Built from approved community suggestion issue #230. 12 hand-crafted levels of increasing difficulty. Canvas-based rendering with brick walls, wooden crate aesthetic, amber color palette. Token counts are estimates."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/03/31/two-truths-lie-game/meta.json
+++ b/apps/2026/03/31/two-truths-lie-game/meta.json
@@ -120,5 +120,6 @@
     "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/243",
     "prompt": "Build a browser-based \"2 Truths and a Lie\" game for a Zoom screen-share host. Start with a setup screen where the host enters participant names. Then show instructions and a 60-second countdown for everyone to think of 3 statements (2 true, 1 false). After the first round timer ends, show a wheel containing all participant names and a button to spin and randomly choose the next speaker. For each turn, show a scoreboard where the host records which statement (1, 2, or 3) each participant guessed was the lie. After reveal, mark everyone who guessed correctly as round winners. Support multiple rounds; only the first round uses the 60-second timer. Make it simple, responsive, and easy to run live on a shared screen.",
     "requestor": "Jeff Holst"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/01/emoji-quiz-party/meta.json
+++ b/apps/2026/04/01/emoji-quiz-party/meta.json
@@ -76,5 +76,6 @@
     "totalTokensOut": 30000,
     "runId": "run-20260401T140448Z-e3970d",
     "notes": "Built from community suggestion #259. Emoji quiz party game with setup/game/scoreboard screens, 20 preloaded quiz rounds, progressive clue timer, and confetti celebration. Token counts are estimates."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/04/plasma-chain-reaction/meta.json
+++ b/apps/2026/04/04/plasma-chain-reaction/meta.json
@@ -55,5 +55,6 @@
     "totalTokensOut": 25000,
     "runId": "run-20260404T142245Z-4c93e0",
     "notes": "Built from approved community suggestion issue #277. Canvas-based chain reaction game with 5 ball types (Normal, Splitter, Shield, Ghost, Magnet, Golden), roguelite upgrade system (5 upgrades that stack), particle effects, shockwave rings, screen shake, parallax star background. Token counts are estimates."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/06/neon-bingo-caller/meta.json
+++ b/apps/2026/04/06/neon-bingo-caller/meta.json
@@ -19,5 +19,6 @@
     "totalTokensOut": 3580,
     "runId": "run-20260406T070015Z-a1b2c3",
     "notes": "Built from vote-and-category-analysis recommendation; no approved GitHub suggestion issue available."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/08/asteroids-modern/meta.json
+++ b/apps/2026/04/08/asteroids-modern/meta.json
@@ -46,5 +46,6 @@
       "agentName": "Claude Code",
       "llmModel": "claude-opus-4-6"
     }
-  ]
+  ],
+  "leaderboard": false
 }

--- a/apps/2026/04/10/benchmark-breakout-turbo/meta.json
+++ b/apps/2026/04/10/benchmark-breakout-turbo/meta.json
@@ -33,5 +33,6 @@
     "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/307",
     "prompt": "Category: Games | Benchmark Breakout request. Treat as a controlled repeatable test where duplication is acceptable. Build a premium mobile-first Breakout game with smooth paddle control for touch, mouse, and keyboard; responsive layout; crisp graphics; fluid animation; readable HUD; score, lives, combo scoring; increasing difficulty; multiple brick patterns; fair rebound angles; progressive speed tuning; balanced power-ups; particle effects; subtle screen shake; adaptive audio; polished transitions; onboarding; sound toggle; 44px+ touch targets; no placeholders; no broken features; no build tools.",
     "requestor": "Jeff Holst"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/10/benchmark-breakout/meta.json
+++ b/apps/2026/04/10/benchmark-breakout/meta.json
@@ -33,5 +33,6 @@
     "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/308",
     "prompt": "Category: Games | Benchmark Breakout request. Treat as a controlled, repeatable test where duplication is acceptable. Build a premium mobile-first Breakout game with smooth paddle control for touch, mouse, and keyboard; responsive layout; crisp graphics; fluid animation; satisfying collisions; readable HUD; score, lives, combo/bonus scoring; increasing difficulty; multiple brick patterns; fair rebound angles; progressive speed tuning; balanced power-ups; particle effects; subtle screen shake; adaptive audio; polished transitions; onboarding; sound toggle; 44px+ touch targets; no hover UI; stable 60 FPS; no placeholders; no broken features; no build tools.",
     "requestor": "Jeff Holst"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/10/neon-maze-chase/meta.json
+++ b/apps/2026/04/10/neon-maze-chase/meta.json
@@ -25,5 +25,6 @@
     "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/304",
     "prompt": "## App Suggestion\n\n**Category:** Games\n**Requestor:** Jeff Holst\n\n### Description\n\nBuild a mobile\\-first Pac\\-Man\\-inspired browser game using plain JavaScript and HTML5 Canvas in a single self\\-contained HTML file with embedded CSS and JS\\. Include a tile\\-based maze, walls, pellets, score, lives, start screen, game over, restart, and win state\\. The player must move smoothly on the grid and collect all pellets to clear the level\\. Add 4 ghosts with simple but distinct chase behavior; they cannot be purely random\\. Include proper collision detection, responsive canvas sizing, portrait-friendly layout, keyboard controls, and touch controls for phones\\. Keep visuals retro and simple using Canvas shapes only—no external assets or libraries\\. Code should be modular, clean, and fully playable, with separated logic for state, rendering, input, and enemy behavior\\. Prioritize correctness, smooth gameplay, and mobile usability\\.",
     "requestor": "Jeff Holst"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/10/spectral-pellet-chase/meta.json
+++ b/apps/2026/04/10/spectral-pellet-chase/meta.json
@@ -25,5 +25,6 @@
     "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/301",
     "prompt": "## App Suggestion\n\n**Category:** Games\n**Requestor:** Jeff Holst\n\n### Description\n\nBuild a mobile\\-first Pac\\-Man\\-inspired browser game using plain JavaScript and HTML5 Canvas in a single self\\-contained HTML file with embedded CSS and JS\\. Include a tile\\-based maze, walls, pellets, score, lives, start screen, game over, restart, and win state\\. The player must move smoothly on the grid and collect all pellets to clear the level\\. Add 4 ghosts with simple but distinct chase behavior; they cannot be purely random\\. Include proper collision detection, responsive canvas sizing, portrait\\-friendly layout, keyboard controls, and touch controls for phones\\. Keep visuals retro and simple using Canvas shapes only—no external assets or libraries\\. Code should be modular, clean, and fully playable, with separated logic for state, rendering, input, and enemy behavior\\. Prioritize correctness, smooth gameplay, and mobile usability\\.",
     "requestor": "Jeff Holst"
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/11/benchmark-breakout-opus/meta.json
+++ b/apps/2026/04/11/benchmark-breakout-opus/meta.json
@@ -33,5 +33,6 @@
     "totalTokensOut": 25000,
     "runId": "run-20260411T031917Z-68c4bc",
     "notes": "Benchmark Breakout built by Claude Opus 4.6 from issue #306. Features canvas-based rendering, Web Audio API synthesized SFX, 5 level patterns, 3 power-up types, combo multiplier scoring, particle effects, and screen shake. Token counts are estimates."
-  }
+  },
+  "leaderboard": false
 }

--- a/apps/2026/04/14/missile-command-modern/meta.json
+++ b/apps/2026/04/14/missile-command-modern/meta.json
@@ -45,5 +45,6 @@
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
     }
-  ]
+  ],
+  "leaderboard": true
 }

--- a/apps/2026/04/16/mental-gymnastics/meta.json
+++ b/apps/2026/04/16/mental-gymnastics/meta.json
@@ -125,5 +125,6 @@
       "agentName": "Codex",
       "llmModel": "GPT-5.4"
     }
-  ]
+  ],
+  "leaderboard": false
 }

--- a/apps/2026/04/17/alibi/meta.json
+++ b/apps/2026/04/17/alibi/meta.json
@@ -45,5 +45,6 @@
       "agentName": "Claude Code",
       "llmModel": "claude-opus-4-7"
     }
-  ]
+  ],
+  "leaderboard": true
 }

--- a/apps/2026/04/18/team-taboo/meta.json
+++ b/apps/2026/04/18/team-taboo/meta.json
@@ -36,5 +36,6 @@
       "llmModel": "claude-opus-4-7",
       "runId": "run-20260418T202731Z-3e9b28"
     }
-  ]
+  ],
+  "leaderboard": false
 }

--- a/apps/2026/04/23/guess-who-said-it/meta.json
+++ b/apps/2026/04/23/guess-who-said-it/meta.json
@@ -45,5 +45,6 @@
       "agentName": "Codex",
       "llmModel": "GPT-5.4"
     }
-  ]
+  ],
+  "leaderboard": false
 }

--- a/apps/shared/app-shell.js
+++ b/apps/shared/app-shell.js
@@ -13,6 +13,7 @@
   const DEFAULT_MAIN_SITE_URL = '';
   const DEFAULT_MAIN_SITE_NAME = '';
   let shellConfig = null;
+  let leaderboardSupportPromise = null;
 
   function isResolvedValue(value, placeholder) {
     return !!value && value !== placeholder;
@@ -112,6 +113,44 @@
     }
 
     return false;
+  }
+
+  async function pageSupportsLeaderboard(appId) {
+    // Explicit page-level override wins.
+    if (document.documentElement?.hasAttribute('data-voa-has-leaderboard')) {
+      return document.documentElement.getAttribute('data-voa-has-leaderboard') === 'true';
+    }
+
+    // Optional meta-level override for future templates.
+    const metaValue = document
+      .querySelector('meta[name="voa-app-leaderboard"]')
+      ?.getAttribute('content')
+      ?.trim()
+      ?.toLowerCase();
+    if (metaValue === 'true') {
+      return true;
+    }
+    if (metaValue === 'false') {
+      return false;
+    }
+
+    // Canonical source of truth: sibling app meta.json leaderboard boolean.
+    if (appId) {
+      try {
+        const response = await fetch('./meta.json', { cache: 'force-cache' });
+        if (response.ok) {
+          const parsed = await response.json();
+          if (typeof parsed?.leaderboard === 'boolean') {
+            return parsed.leaderboard;
+          }
+        }
+      } catch {
+        // Fall through to runtime hook detection.
+      }
+    }
+
+    // Legacy fallback for older pages if metadata is unavailable.
+    return pageUsesLeaderboardHook();
   }
 
   function getLocalVoteRecord(appId) {
@@ -1633,7 +1672,9 @@
     improveLink.title = 'Suggest an improvement for this app';
     container.appendChild(improveLink);
 
-    if (pageUsesLeaderboardHook()) {
+    const leaderboardSupported =
+      leaderboardSupportPromise || (leaderboardSupportPromise = pageSupportsLeaderboard(appId));
+    if (await leaderboardSupported) {
       const lbHeaderBtn = document.createElement('button');
       lbHeaderBtn.id = 'voa-lb-btn';
       lbHeaderBtn.type = 'button';

--- a/data/apps.json
+++ b/data/apps.json
@@ -51,6 +51,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": 200,
     "backups": [
       {
@@ -104,6 +105,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -165,6 +167,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": true,
     "maxScore": 100,
     "backups": [
       {
@@ -306,6 +309,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": 2000,
     "backups": [
       {
@@ -402,6 +406,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": true,
     "maxScore": 999999,
     "backups": [
       {
@@ -453,6 +458,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -498,6 +504,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -543,6 +550,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -600,6 +608,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -677,6 +686,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -775,6 +785,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -941,6 +952,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -1104,6 +1116,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -1209,6 +1222,7 @@
       }
     ],
     "allowImprovements": false,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1282,6 +1296,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1318,6 +1333,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1368,6 +1384,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1414,6 +1431,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1445,6 +1463,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1481,6 +1500,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1526,6 +1546,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1562,6 +1583,7 @@
     },
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1593,6 +1615,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1624,6 +1647,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1655,6 +1679,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1686,6 +1711,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1717,6 +1743,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1757,6 +1784,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1788,6 +1816,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1819,6 +1848,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1850,6 +1880,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1881,6 +1912,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1912,6 +1944,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1943,6 +1976,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -1974,6 +2008,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2005,6 +2040,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2036,6 +2072,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2067,6 +2104,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2098,6 +2136,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2129,6 +2168,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2160,6 +2200,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2191,6 +2232,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2222,6 +2264,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2253,6 +2296,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2284,6 +2328,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2315,6 +2360,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2346,6 +2392,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2377,6 +2424,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2408,6 +2456,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2439,6 +2488,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2470,6 +2520,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2545,6 +2596,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -2597,6 +2649,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2628,6 +2681,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2659,6 +2713,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2690,6 +2745,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2721,6 +2777,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2752,6 +2809,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2783,6 +2841,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2814,6 +2873,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2845,6 +2905,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2876,6 +2937,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2907,6 +2969,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2938,6 +3001,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -2980,6 +3044,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": true,
     "maxScore": 999,
     "backups": [
       {
@@ -3017,6 +3082,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3048,6 +3114,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3079,6 +3146,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3110,6 +3178,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3200,6 +3269,7 @@
       }
     ],
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": [
       {
@@ -3262,6 +3332,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3293,6 +3364,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3324,6 +3396,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   },
@@ -3355,6 +3428,7 @@
     "suggestion": null,
     "improvements": null,
     "allowImprovements": true,
+    "leaderboard": false,
     "maxScore": null,
     "backups": null
   }

--- a/schemas/meta.json
+++ b/schemas/meta.json
@@ -92,6 +92,11 @@
       "enum": ["desktop", "mobile", "responsive"],
       "description": "Dominant input style: desktop (keyboard/mouse), mobile (touch/gestures), or responsive for both."
     },
+    "leaderboard": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether the app implements global leaderboard integration (e.g., submits scores via the shared leaderboard API)."
+    },
     "suggestion": {
       "type": "object",
       "description": "GitHub Issue that originated this app, if generated from a user suggestion.",

--- a/scripts/apps-registry.mjs
+++ b/scripts/apps-registry.mjs
@@ -18,6 +18,9 @@ const LEADERBOARD_USAGE_PATTERNS = [
 ];
 
 function stripCommentsForDetection(text) {
+  // Note: the // line-comment replacement also strips '//' inside string
+  // literals (e.g. 'https://…'), but this is acceptable for pattern-matching
+  // purposes — none of the LEADERBOARD_USAGE_PATTERNS contain '//'.
   return text
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/\/\*[\s\S]*?\*\//g, ' ')

--- a/scripts/apps-registry.mjs
+++ b/scripts/apps-registry.mjs
@@ -8,6 +8,43 @@
 import fs from 'fs';
 import path from 'path';
 
+const LEADERBOARD_USAGE_PATTERNS = [
+  // Preferred shared integration helper.
+  /\b(?:window\s*\.\s*)?voaLeaderboard\s*\.\s*submit\s*\(/i,
+  // Manual score API submission via fetch.
+  /\bfetch\s*\(\s*['"`]\/api\/scores(?:[/?'"`]|\\?)/i,
+  // Manual score API submission via XHR open('POST', '/api/scores').
+  /\bopen\s*\(\s*['"`]POST['"`]\s*,\s*['"`]\/api\/scores(?:[/?'"`]|\\?)/i,
+];
+
+function stripCommentsForDetection(text) {
+  return text
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/^\s*\/\/.*$/gm, ' ');
+}
+
+export function detectLeaderboardUsageFromHtml(html) {
+  if (typeof html !== 'string' || html.length === 0) {
+    return false;
+  }
+  const searchable = stripCommentsForDetection(html);
+  return LEADERBOARD_USAGE_PATTERNS.some((pattern) => pattern.test(searchable));
+}
+
+export function detectLeaderboardUsageFromAppDir(appDir) {
+  const indexPath = path.join(appDir, 'index.html');
+  if (!fs.existsSync(indexPath)) {
+    return false;
+  }
+  try {
+    const html = fs.readFileSync(indexPath, 'utf8');
+    return detectLeaderboardUsageFromHtml(html);
+  } catch {
+    return false;
+  }
+}
+
 export function findMetaFiles(dir, files = []) {
   if (!fs.existsSync(dir)) {
     return files;
@@ -95,6 +132,7 @@ export function transformMeta(appsDir, meta, filePath, dateInfo, basePath = '', 
     suggestion: meta.suggestion || null,
     improvements: meta.improvements || null,
     allowImprovements: meta.allowImprovements ?? true,
+    leaderboard: meta.leaderboard === true,
     maxScore: meta.maxScore ?? null,
     backups:
       backups.length > 0

--- a/scripts/apps-registry.mjs
+++ b/scripts/apps-registry.mjs
@@ -21,7 +21,7 @@ function stripCommentsForDetection(text) {
   return text
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/\/\*[\s\S]*?\*\//g, ' ')
-    .replace(/^\s*\/\/.*$/gm, ' ');
+    .replace(/\/\/.*$/gm, ' ');
 }
 
 export function detectLeaderboardUsageFromHtml(html) {
@@ -40,7 +40,8 @@ export function detectLeaderboardUsageFromAppDir(appDir) {
   try {
     const html = fs.readFileSync(indexPath, 'utf8');
     return detectLeaderboardUsageFromHtml(html);
-  } catch {
+  } catch (err) {
+    console.warn(`[apps-registry] Could not read ${indexPath}: ${err.message}`);
     return false;
   }
 }

--- a/scripts/generate-apps.mjs
+++ b/scripts/generate-apps.mjs
@@ -13,7 +13,11 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { format as formatWithPrettier } from 'prettier';
-import { buildAppsRegistry } from './apps-registry.mjs';
+import {
+  buildAppsRegistry,
+  detectLeaderboardUsageFromAppDir,
+  findMetaFiles,
+} from './apps-registry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,11 +27,43 @@ const APPS_DIR = path.join(rootDir, 'apps');
 const OUTPUT_FILE = path.join(rootDir, 'data', 'apps.json');
 const BASE_PATH = '';
 
+async function syncLeaderboardFlags() {
+  const metaFiles = findMetaFiles(APPS_DIR);
+  let updatedCount = 0;
+
+  for (const metaFile of metaFiles) {
+    try {
+      const rawMeta = fs.readFileSync(metaFile, 'utf8');
+      const meta = JSON.parse(rawMeta);
+      const appDir = path.dirname(metaFile);
+      const detectedLeaderboard = detectLeaderboardUsageFromAppDir(appDir);
+
+      if (meta.leaderboard === detectedLeaderboard) {
+        continue;
+      }
+
+      meta.leaderboard = detectedLeaderboard;
+      const formattedMeta = await formatWithPrettier(JSON.stringify(meta), { parser: 'json' });
+      fs.writeFileSync(metaFile, formattedMeta);
+      updatedCount += 1;
+    } catch (error) {
+      throw new Error(`Failed to sync leaderboard flag for ${metaFile}: ${error.message}`);
+    }
+  }
+
+  return { metaFilesCount: metaFiles.length, updatedCount };
+}
+
 /**
  * Main function
  */
 async function main() {
   console.log('🔍 Scanning for apps...');
+
+  const { metaFilesCount, updatedCount } = await syncLeaderboardFlags();
+  console.log(
+    `   Synced leaderboard metadata for ${metaFilesCount} app(s) (${updatedCount} file(s) updated)`
+  );
 
   const { apps, metaFiles, warnings } = buildAppsRegistry({
     appsDir: APPS_DIR,

--- a/scripts/validate-apps.mjs
+++ b/scripts/validate-apps.mjs
@@ -11,7 +11,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { buildAppsRegistry } from './apps-registry.mjs';
+import { buildAppsRegistry, detectLeaderboardUsageFromHtml } from './apps-registry.mjs';
 import { validateVersusData, buildVersusRegistry } from './versus-registry.mjs';
 export { parseIssueTemplateCategories, parseSharedPromptCategories } from './category-parsers.mjs';
 import { parseIssueTemplateCategories, parseSharedPromptCategories } from './category-parsers.mjs';
@@ -489,6 +489,26 @@ function main() {
     }
 
     const errors = validateMetaJson(metaData, schema);
+
+    const relPathParts = rel.split(path.sep);
+    if (!relPathParts.includes('backups')) {
+      const appDir = path.dirname(file);
+      const indexPath = path.join(appDir, 'index.html');
+      if (fs.existsSync(indexPath)) {
+        try {
+          const html = fs.readFileSync(indexPath, 'utf8');
+          const expectedLeaderboard = detectLeaderboardUsageFromHtml(html);
+          if (metaData.leaderboard !== expectedLeaderboard) {
+            errors.push(
+              `leaderboard: expected ${expectedLeaderboard} based on index.html usage; run \`npm run generate:apps\``
+            );
+          }
+        } catch (e) {
+          errors.push(`cannot read sibling index.html for leaderboard validation: ${e.message}`);
+        }
+      }
+    }
+
     if (errors.length > 0) {
       metaFailures.push({ file: rel, errors });
     }


### PR DESCRIPTION
## Summary
- add leaderboard boolean support to app metadata schema and registry output
- auto-sync app meta leaderboard flags from each app index.html during npm run generate:apps
- tighten leaderboard detection patterns and add tests for detection and registry guarantees
- update leaderboard page filtering and app shell trophy visibility to use metadata-driven capability checks
- refresh README wording for the new metadata field

## Validation
- npm test -- __tests__/scripts/apps-registry.test.js __tests__/data/apps.test.js
- npm run validate:apps