### PR TITLE
improve: impostor-question — fix voting race condition

### DIFF
--- a/app/api/multiplayer/sessions/[code]/answers/route.js
+++ b/app/api/multiplayer/sessions/[code]/answers/route.js
@@ -72,29 +72,26 @@ export async function POST(request, { params }) {
     }
 
     const roundIndex = Number(game.roundIndex || 0);
-    if (Number(player.voteRound || 0) === roundIndex && player.lastAnswer) {
-      return Response.json({ ok: true, accepted: true, alreadySubmitted: true });
-    }
 
-    const responses = structuredClone(game.responses || {});
-    responses[playerId] = guess;
-    player.lastAnswer = guess;
-    player.voteRound = roundIndex;
-    player.updatedAt = new Date().toISOString();
-    players[playerId] = player;
-    game.responses = responses;
+    // Use an atomic JSONB merge via RPC to avoid lost-update races when
+    // multiple players vote simultaneously.
+    const { data: rpcRows, error: rpcError } = await supabase.rpc('record_session_vote', {
+      p_code: code,
+      p_player_id: playerId,
+      p_voted_for: guess,
+      p_round: roundIndex,
+    });
 
-    const { error: updateError } = await supabase
-      .from('multiplayer_sessions')
-      .update({ players, game })
-      .eq('code', code);
-
-    if (updateError) {
-      console.error('Failed to persist quiz vote', updateError);
+    if (rpcError) {
+      console.error('Failed to persist quiz vote', rpcError);
       return Response.json({ error: 'Failed to submit answer' }, { status: 500 });
     }
 
-    return Response.json({ ok: true, accepted: true, alreadySubmitted: false });
+    const result = rpcRows?.[0];
+    const accepted = Boolean(result?.accepted);
+    const alreadySubmitted = Boolean(result?.already_submitted);
+
+    return Response.json({ ok: true, accepted, alreadySubmitted });
   }
 
   if (row.status !== 'playing' || game.roundState !== 'active') {

--- a/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/index.html
+++ b/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/index.html
@@ -1,0 +1,1391 @@
+<!doctype html>
+<html lang="en" data-theme="auto">
+  <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=__GA_MEASUREMENT_ID__"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '__GA_MEASUREMENT_ID__');
+    </script>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The Impostor Question - __MAIN_SITE_NAME__</title>
+    <meta name="voa-main-site-url" content="__MAIN_SITE_URL__" />
+    <meta name="voa-main-site-name" content="__MAIN_SITE_NAME__" />
+    <meta name="voa-github-url" content="__GITHUB_URL__" />
+    <meta name="voa-social-x-url" content="__SOCIAL_X_URL__" />
+    <meta name="voa-social-facebook-url" content="__SOCIAL_FACEBOOK_URL__" />
+    <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__" />
+    <meta name="application-name" content="The Impostor Question" />
+    <meta name="voa-app-id" content="2026/04/24/impostor-question" />
+    <script src="/apps/shared/app-shell.js" defer></script>
+
+    <style>
+      :root {
+        --bg: #111827;
+        --text: #f8fafc;
+        --surface: #1f2937;
+        --card: #172033;
+        --card-strong: #22304a;
+        --border: #40506f;
+        --muted: #aab8d3;
+        --accent: #2dd4bf;
+        --accent-strong: #14b8a6;
+        --gold: #fbbf24;
+        --danger: #fb7185;
+        --good: #86efac;
+        --ink: #08111f;
+        --shadow: 0 18px 34px rgb(0 0 0 / 30%);
+      }
+
+      [data-theme='light'] {
+        --bg: #f4f7fb;
+        --text: #132033;
+        --surface: #ffffff;
+        --card: #ffffff;
+        --card-strong: #e8f2ff;
+        --border: #c5d2e6;
+        --muted: #5d6f8c;
+        --accent: #0f766e;
+        --accent-strong: #0d9488;
+        --gold: #b7791f;
+        --danger: #be123c;
+        --good: #15803d;
+        --ink: #ffffff;
+        --shadow: 0 12px 24px rgb(31 41 55 / 12%);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        min-width: 320px;
+        color: var(--text);
+        background:
+          radial-gradient(circle at 18% 8%, rgb(45 212 191 / 18%), transparent 34%),
+          radial-gradient(circle at 82% 2%, rgb(251 191 36 / 14%), transparent 32%),
+          linear-gradient(135deg, var(--bg), #0b1120);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        line-height: 1.42;
+      }
+
+      #app {
+        position: fixed;
+        top: 64px;
+        right: 0;
+        bottom: 56px;
+        left: 0;
+        overflow: auto;
+      }
+
+      .wrap {
+        width: min(1060px, 100%);
+        margin: 0 auto;
+        padding: 14px 12px 20px;
+        display: grid;
+        gap: 12px;
+      }
+
+      .hero,
+      .card,
+      .panel {
+        background: linear-gradient(180deg, rgb(255 255 255 / 5%), transparent 60%), var(--card);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        box-shadow: var(--shadow);
+      }
+
+      .hero {
+        padding: 14px 16px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin: 0;
+      }
+
+      h1 {
+        font-size: clamp(1.4rem, 4.8vw, 2rem);
+        line-height: 1.08;
+      }
+
+      .subtitle {
+        margin-top: 4px;
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      .badge,
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 30px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--card-strong);
+        color: var(--muted);
+        padding: 5px 10px;
+        font-size: 0.76rem;
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .badge.live {
+        color: var(--ink);
+        background: linear-gradient(135deg, var(--accent), #99f6e4);
+        border-color: transparent;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.65fr) minmax(280px, 0.9fr);
+        gap: 12px;
+        align-items: start;
+      }
+
+      .card,
+      .panel {
+        padding: 14px;
+      }
+
+      .screen {
+        display: none;
+      }
+
+      .screen.active {
+        display: block;
+        animation: rise 180ms ease-out;
+      }
+
+      @keyframes rise {
+        from {
+          opacity: 0;
+          transform: translateY(6px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .stack {
+        display: grid;
+        gap: 10px;
+      }
+
+      .row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      label {
+        display: block;
+        color: var(--muted);
+        font-size: 0.82rem;
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-bottom: 5px;
+      }
+
+      select,
+      input,
+      textarea {
+        width: 100%;
+        border: 1px solid var(--border);
+        border-radius: 11px;
+        background: var(--surface);
+        color: var(--text);
+        font: inherit;
+        min-height: 44px;
+        padding: 10px 12px;
+      }
+
+      textarea {
+        min-height: 96px;
+        resize: vertical;
+      }
+
+      select:focus,
+      input:focus,
+      textarea:focus,
+      button:focus-visible {
+        outline: 3px solid rgb(45 212 191 / 45%);
+        outline-offset: 2px;
+      }
+
+      .btn {
+        appearance: none;
+        border: 1px solid var(--border);
+        border-radius: 11px;
+        background: var(--surface);
+        color: var(--text);
+        cursor: pointer;
+        font: inherit;
+        font-weight: 800;
+        min-height: 44px;
+        padding: 10px 14px;
+        transition:
+          transform 90ms ease,
+          filter 140ms ease,
+          background 140ms ease;
+      }
+
+      .btn:hover:not(:disabled) {
+        filter: brightness(1.08);
+      }
+
+      .btn:active:not(:disabled) {
+        transform: translateY(1px);
+      }
+
+      .btn:disabled {
+        cursor: not-allowed;
+        opacity: 0.52;
+      }
+
+      .btn.primary {
+        background: linear-gradient(135deg, var(--accent), #99f6e4);
+        color: var(--ink);
+        border-color: transparent;
+      }
+
+      .btn.gold {
+        background: linear-gradient(135deg, var(--gold), #fde68a);
+        color: #201400;
+        border-color: transparent;
+      }
+
+      .btn.danger {
+        background: var(--danger);
+        color: white;
+        border-color: transparent;
+      }
+
+      .join-url {
+        overflow-wrap: anywhere;
+        border: 1px dashed var(--border);
+        border-radius: 12px;
+        background: var(--card-strong);
+        color: var(--accent);
+        font-size: clamp(1rem, 3.4vw, 1.35rem);
+        font-weight: 900;
+        padding: 11px 12px;
+      }
+
+      .player-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(136px, 1fr));
+        gap: 8px;
+      }
+
+      .player {
+        min-height: 72px;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: var(--card-strong);
+        padding: 10px;
+        display: grid;
+        gap: 4px;
+      }
+
+      .player.me {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px rgb(45 212 191 / 28%);
+      }
+
+      .player.impostor {
+        border-color: var(--danger);
+      }
+
+      .name {
+        font-weight: 900;
+        overflow-wrap: anywhere;
+      }
+
+      .small,
+      .muted {
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .big-card {
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        background:
+          linear-gradient(135deg, rgb(45 212 191 / 16%), transparent 48%),
+          var(--card-strong);
+        padding: 16px;
+        min-height: 150px;
+        display: grid;
+        gap: 8px;
+        align-content: center;
+      }
+
+      .role-card {
+        border-color: var(--accent);
+      }
+
+      .role-card.impostor {
+        border-color: var(--danger);
+        background:
+          linear-gradient(135deg, rgb(251 113 133 / 18%), transparent 50%),
+          var(--card-strong);
+      }
+
+      .role-title {
+        color: var(--muted);
+        font-size: 0.8rem;
+        font-weight: 900;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .role-value {
+        font-size: clamp(1.45rem, 5vw, 2.4rem);
+        font-weight: 950;
+        line-height: 1.05;
+      }
+
+      .question {
+        color: var(--gold);
+        font-size: clamp(1.35rem, 5vw, 2.1rem);
+        font-weight: 950;
+      }
+
+      .turn-list {
+        display: grid;
+        gap: 7px;
+      }
+
+      .turn-item {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        border: 1px solid var(--border);
+        border-radius: 11px;
+        background: rgb(255 255 255 / 4%);
+        padding: 8px 10px;
+      }
+
+      .turn-item.current {
+        border-color: var(--gold);
+        background: rgb(251 191 36 / 12%);
+      }
+
+      .answer-list,
+      .vote-list {
+        display: grid;
+        gap: 8px;
+      }
+
+      .answer {
+        border-left: 4px solid var(--accent);
+        border-radius: 10px;
+        background: rgb(255 255 255 / 5%);
+        padding: 9px 10px;
+      }
+
+      .vote-option {
+        text-align: left;
+      }
+
+      .result-banner {
+        border-radius: 16px;
+        border: 1px solid var(--border);
+        background: linear-gradient(135deg, rgb(251 191 36 / 16%), rgb(45 212 191 / 12%));
+        padding: 16px;
+      }
+
+      .score-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        border-bottom: 1px solid rgb(255 255 255 / 9%);
+        padding: 8px 0;
+      }
+
+      .score-row:last-child {
+        border-bottom: 0;
+      }
+
+      .empty {
+        border: 1px dashed var(--border);
+        border-radius: 12px;
+        color: var(--muted);
+        padding: 12px;
+        text-align: center;
+      }
+
+      .hide {
+        display: none !important;
+      }
+
+      @media (max-width: 760px) {
+        .hero {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+
+        .wrap {
+          padding: 10px 10px 18px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main id="app">
+      <div class="wrap">
+        <section class="hero">
+          <div>
+            <h1>The Impostor Question</h1>
+            <p class="subtitle">One player is bluffing. Everyone else shares the same secret topic.</p>
+          </div>
+          <span class="badge live" id="roomBadge">Room setup</span>
+        </section>
+
+        <section class="screen active" id="loadingScreen">
+          <div class="card stack">
+            <h2>Preparing the room...</h2>
+            <p class="muted">Creating a moderator session and checking multiplayer availability.</p>
+          </div>
+        </section>
+
+        <section class="screen" id="configErrorScreen">
+          <div class="card stack">
+            <h2>Multiplayer is unavailable</h2>
+            <p class="muted">This site is missing the shared multiplayer configuration.</p>
+          </div>
+        </section>
+
+        <section class="screen" id="lobbyScreen">
+          <div class="grid">
+            <div class="card stack">
+              <h2>Moderator Lobby</h2>
+              <div class="stack" id="moderatorSetup">
+                <div>
+                  <label for="roundCount">Rounds</label>
+                  <select id="roundCount">
+                    <option value="3">3 rounds</option>
+                    <option value="5" selected>5 rounds</option>
+                    <option value="7">7 rounds</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="topicPack">Topic pack</label>
+                  <select id="topicPack">
+                    <option value="work" selected>Office friendly</option>
+                    <option value="travel">Travel and weekends</option>
+                    <option value="food">Food and rituals</option>
+                  </select>
+                </div>
+                <div>
+                  <label>Share link</label>
+                  <div class="join-url" id="joinUrl">/join/------</div>
+                </div>
+                <div class="row">
+                  <button class="btn primary" id="copyLinkBtn" type="button">Copy join link</button>
+                  <button class="btn gold" id="startBtn" type="button">Start game</button>
+                </div>
+                <p class="muted" id="lobbyHint">Need at least 3 active players to start.</p>
+              </div>
+              <div class="stack hide" id="playerWaiting">
+                <h2>You are in.</h2>
+                <p class="muted">Waiting for the moderator to start the first round. Keep this tab open.</p>
+              </div>
+            </div>
+
+            <aside class="panel stack">
+              <div class="row">
+                <span class="pill" id="playerCount">0 players</span>
+                <span class="pill" id="roundPill">Lobby</span>
+              </div>
+              <div class="player-grid" id="playerGrid"></div>
+            </aside>
+          </div>
+        </section>
+
+        <section class="screen" id="gameScreen">
+          <div class="grid">
+            <div class="card stack">
+              <div class="row">
+                <span class="pill" id="stagePill">Question round</span>
+                <span class="pill" id="turnPill">Turn 1</span>
+              </div>
+              <div class="big-card role-card" id="roleCard">
+                <div class="role-title" id="roleTitle">Your role</div>
+                <div class="role-value" id="roleValue">Topic loading</div>
+                <p class="muted" id="roleHint">Answer naturally, but not too obviously.</p>
+              </div>
+              <div class="big-card">
+                <div class="role-title">Question</div>
+                <div class="question" id="questionText">What is your favorite?</div>
+                <p class="muted" id="phaseHint">Take turns giving short answers out loud or in the app.</p>
+              </div>
+
+              <form class="stack" id="answerForm">
+                <label for="answerInput">Your answer</label>
+                <textarea id="answerInput" maxlength="140" placeholder="A careful answer that fits your role..."></textarea>
+                <button class="btn primary" id="answerBtn" type="submit">Submit answer</button>
+              </form>
+
+              <div class="stack hide" id="voteBox">
+                <h2>Who is the impostor?</h2>
+                <div class="vote-list" id="voteChoices"></div>
+              </div>
+
+              <form class="stack hide" id="guessForm">
+                <h2>Impostor topic guess</h2>
+                <p class="muted">The impostor escaped the vote. One exact topic guess can steal the round.</p>
+                <input id="topicGuessInput" maxlength="80" placeholder="Guess the shared topic..." />
+                <button class="btn gold" id="topicGuessBtn" type="submit">Submit topic guess</button>
+              </form>
+
+              <div class="stack hide" id="resultsBox">
+                <div class="result-banner stack">
+                  <h2 id="resultTitle">Round reveal</h2>
+                  <p id="resultText"></p>
+                </div>
+                <div class="row" id="resultActions">
+                  <button class="btn primary" id="nextRoundBtn" type="button">Next round</button>
+                  <button class="btn gold" id="endGameBtn" type="button">Show final scores</button>
+                </div>
+              </div>
+            </div>
+
+            <aside class="panel stack">
+              <h2>Room board</h2>
+              <div class="player-grid" id="gamePlayerGrid"></div>
+              <h3>Turn order</h3>
+              <div class="turn-list" id="turnList"></div>
+              <h3>Responses</h3>
+              <div class="answer-list" id="answerList"></div>
+              <div class="row" id="moderatorControls">
+                <button class="btn primary" id="nextTurnBtn" type="button">Next turn</button>
+                <button class="btn gold" id="openVoteBtn" type="button">Open voting</button>
+                <button class="btn primary" id="revealVotesBtn" type="button">Reveal votes</button>
+                <button class="btn gold" id="finishGuessBtn" type="button">Reveal topic guess</button>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section class="screen" id="finalScreen">
+          <div class="grid">
+            <div class="card stack">
+              <h2>Final scores</h2>
+              <p class="muted">Shared placements are used for ties.</p>
+              <div id="finalScores"></div>
+              <div class="row">
+                <button class="btn primary" id="playAgainBtn" type="button">Back to lobby</button>
+              </div>
+            </div>
+            <aside class="panel stack">
+              <h2>Players</h2>
+              <div class="player-grid" id="finalPlayerGrid"></div>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <script>
+      (() => {
+        const APP_ID = '2026/04/24/impostor-question';
+        const APP_NAME = 'The Impostor Question';
+        const APP_PATH = '2026/04/24/impostor-question';
+        const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+        const TOPICS = {
+          work: [
+            { topic: 'Coffee', question: "What's your favorite way to start the day?" },
+            { topic: 'Team chat', question: 'What do you check too often?' },
+            { topic: 'Calendar invites', question: 'What needs better boundaries?' },
+            { topic: 'Desk snacks', question: 'What saves a long afternoon?' },
+            { topic: 'Brainstorming', question: 'What works best with a group?' },
+            { topic: 'Headphones', question: 'What helps you focus?' }
+          ],
+          travel: [
+            { topic: 'Beach trips', question: "What's your ideal pace?" },
+            { topic: 'Museums', question: 'What makes a day memorable?' },
+            { topic: 'Road trips', question: 'What belongs in the plan?' },
+            { topic: 'Hotel breakfast', question: 'What is surprisingly important?' },
+            { topic: 'City walks', question: 'What do you notice first?' },
+            { topic: 'Packing cubes', question: 'What keeps chaos away?' }
+          ],
+          food: [
+            { topic: 'Pizza', question: 'What is worth debating?' },
+            { topic: 'Tacos', question: 'What needs the right balance?' },
+            { topic: 'Ice cream', question: 'What flavor has range?' },
+            { topic: 'Soup', question: 'What is underrated when shared?' },
+            { topic: 'Brunch', question: 'What makes a weekend feel real?' },
+            { topic: 'Leftovers', question: 'What gets better tomorrow?' }
+          ]
+        };
+
+        const els = {
+          roomBadge: document.getElementById('roomBadge'),
+          loadingScreen: document.getElementById('loadingScreen'),
+          configErrorScreen: document.getElementById('configErrorScreen'),
+          lobbyScreen: document.getElementById('lobbyScreen'),
+          gameScreen: document.getElementById('gameScreen'),
+          finalScreen: document.getElementById('finalScreen'),
+          moderatorSetup: document.getElementById('moderatorSetup'),
+          playerWaiting: document.getElementById('playerWaiting'),
+          roundCount: document.getElementById('roundCount'),
+          topicPack: document.getElementById('topicPack'),
+          joinUrl: document.getElementById('joinUrl'),
+          copyLinkBtn: document.getElementById('copyLinkBtn'),
+          startBtn: document.getElementById('startBtn'),
+          lobbyHint: document.getElementById('lobbyHint'),
+          playerCount: document.getElementById('playerCount'),
+          roundPill: document.getElementById('roundPill'),
+          playerGrid: document.getElementById('playerGrid'),
+          gamePlayerGrid: document.getElementById('gamePlayerGrid'),
+          finalPlayerGrid: document.getElementById('finalPlayerGrid'),
+          stagePill: document.getElementById('stagePill'),
+          turnPill: document.getElementById('turnPill'),
+          roleCard: document.getElementById('roleCard'),
+          roleTitle: document.getElementById('roleTitle'),
+          roleValue: document.getElementById('roleValue'),
+          roleHint: document.getElementById('roleHint'),
+          questionText: document.getElementById('questionText'),
+          phaseHint: document.getElementById('phaseHint'),
+          answerForm: document.getElementById('answerForm'),
+          answerInput: document.getElementById('answerInput'),
+          answerBtn: document.getElementById('answerBtn'),
+          voteBox: document.getElementById('voteBox'),
+          voteChoices: document.getElementById('voteChoices'),
+          guessForm: document.getElementById('guessForm'),
+          topicGuessInput: document.getElementById('topicGuessInput'),
+          topicGuessBtn: document.getElementById('topicGuessBtn'),
+          resultsBox: document.getElementById('resultsBox'),
+          resultTitle: document.getElementById('resultTitle'),
+          resultText: document.getElementById('resultText'),
+          resultActions: document.getElementById('resultActions'),
+          nextRoundBtn: document.getElementById('nextRoundBtn'),
+          endGameBtn: document.getElementById('endGameBtn'),
+          turnList: document.getElementById('turnList'),
+          answerList: document.getElementById('answerList'),
+          moderatorControls: document.getElementById('moderatorControls'),
+          nextTurnBtn: document.getElementById('nextTurnBtn'),
+          openVoteBtn: document.getElementById('openVoteBtn'),
+          revealVotesBtn: document.getElementById('revealVotesBtn'),
+          finishGuessBtn: document.getElementById('finishGuessBtn'),
+          finalScores: document.getElementById('finalScores'),
+          playAgainBtn: document.getElementById('playAgainBtn')
+        };
+
+        let role = 'moderator';
+        let sessionCode = null;
+        let moderatorId = null;
+        let playerId = null;
+        let session = null;
+        let pollHandle = null;
+
+        function generateCode() {
+          return Array.from({ length: 6 }, () => CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)]).join('');
+        }
+
+        function generateId(prefix) {
+          const random = Math.random().toString(36).slice(2, 12);
+          return `${prefix}_${Date.now().toString(36)}_${random}`;
+        }
+
+        function parseHash() {
+          const params = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+          return {
+            code: (params.get('code') || '').toUpperCase(),
+            pid: params.get('pid') || '',
+            role: params.get('role') || ''
+          };
+        }
+
+        function moderatorStorageKey(code) {
+          return `voa:${APP_ID}:moderator:${code}`;
+        }
+
+        function saveModeratorRecord(code, id) {
+          try {
+            localStorage.setItem(moderatorStorageKey(code), JSON.stringify({ moderatorId: id }));
+          } catch {
+            // Local persistence is nice to have; the game can still run without it.
+          }
+        }
+
+        function loadModeratorRecord(code) {
+          try {
+            const raw = localStorage.getItem(moderatorStorageKey(code));
+            return raw ? JSON.parse(raw) : null;
+          } catch {
+            return null;
+          }
+        }
+
+        async function fetchJson(url, options) {
+          const response = await fetch(url, options);
+          let payload = null;
+          try {
+            payload = await response.json();
+          } catch {
+            payload = null;
+          }
+          if (!response.ok) {
+            throw new Error(payload?.error || `Request failed (${response.status})`);
+          }
+          return payload;
+        }
+
+        async function checkStatus() {
+          try {
+            const result = await fetchJson('/api/multiplayer/status', { cache: 'no-store' });
+            return Boolean(result?.configured);
+          } catch {
+            return false;
+          }
+        }
+
+        async function loadSession(code) {
+          const payload = await fetchJson(`/api/multiplayer/sessions/${code}`, { cache: 'no-store' });
+          return payload?.session || null;
+        }
+
+        async function patchSession(patch, status = null) {
+          if (!sessionCode || !moderatorId) return;
+          const body = { moderatorId, patch };
+          if (status) body.status = status;
+          await fetchJson(`/api/multiplayer/sessions/${sessionCode}`, {
+            method: 'PATCH',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body)
+          });
+        }
+
+        async function submitValue(value) {
+          if (!sessionCode || !playerId) return;
+          await fetchJson(`/api/multiplayer/sessions/${sessionCode}/answers`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ playerId, guess: value })
+          });
+        }
+
+        async function createSession() {
+          for (let attempt = 0; attempt < 8; attempt += 1) {
+            const code = generateCode();
+            const modId = generateId('mod');
+            try {
+              await fetchJson('/api/multiplayer/sessions', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                  code,
+                  moderatorId: modId,
+                  appId: APP_ID,
+                  appName: APP_NAME,
+                  appPath: APP_PATH,
+                  settings: {
+                    roundsTotal: Number.parseInt(els.roundCount.value, 10) || 5,
+                    topicPack: els.topicPack.value || 'work'
+                  }
+                })
+              });
+              return { code, moderatorId: modId };
+            } catch (error) {
+              if (!String(error.message).toLowerCase().includes('already exists')) throw error;
+            }
+          }
+          throw new Error('Could not create a unique room code');
+        }
+
+        function sortedPlayers() {
+          return Object.values(session?.players || {})
+            .filter((player) => player && !player.kicked)
+            .sort((a, b) => (a.joinedAt || '').localeCompare(b.joinedAt || ''));
+        }
+
+        function activeIds() {
+          return sortedPlayers().map((player) => player.id);
+        }
+
+        function playerName(id) {
+          return session?.players?.[id]?.name || 'Player';
+        }
+
+        function normalize(value) {
+          return String(value || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9 ]/g, '')
+            .replace(/\s+/g, ' ');
+        }
+
+        function stageLabel(stage) {
+          return {
+            lobby: 'Lobby',
+            answer: 'Question round',
+            vote: 'Voting',
+            topicGuess: 'Impostor guess',
+            results: 'Reveal',
+            ended: 'Final scores'
+          }[stage || 'lobby'];
+        }
+
+        function toScreen(id) {
+          for (const screen of [els.loadingScreen, els.configErrorScreen, els.lobbyScreen, els.gameScreen, els.finalScreen]) {
+            screen.classList.toggle('active', screen.id === id);
+          }
+        }
+
+        function rankScores(scores) {
+          const rows = sortedPlayers()
+            .map((player) => ({ id: player.id, name: player.name, score: Number(scores?.[player.id] || 0) }))
+            .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+          let lastScore = null;
+          let lastRank = 0;
+          return rows.map((row, index) => {
+            const rank = row.score === lastScore ? lastRank : index + 1;
+            lastScore = row.score;
+            lastRank = rank;
+            return { ...row, rank };
+          });
+        }
+
+        function renderPlayers(target, revealRoles = false) {
+          const game = session?.game || {};
+          const scores = game.scores || {};
+          const players = sortedPlayers();
+          if (!players.length) {
+            target.innerHTML = '<div class="empty">No players yet.</div>';
+            return;
+          }
+          target.innerHTML = players
+            .map((player) => {
+              const isImpostor = revealRoles && player.id === game.impostorId;
+              const status = player.id === game.currentTurnId ? 'answering' : game.responses?.[player.id] ? 'submitted' : 'waiting';
+              return `<div class="player ${player.id === playerId ? 'me' : ''} ${isImpostor ? 'impostor' : ''}">
+                <div class="name">${escapeHtml(player.name || 'Player')}</div>
+                <div class="small">${Number(scores[player.id] || 0)} pts</div>
+                <div class="small">${isImpostor ? 'impostor' : status}</div>
+              </div>`;
+            })
+            .join('');
+        }
+
+        function escapeHtml(value) {
+          return String(value || '').replace(/[&<>"']/g, (char) => {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char];
+          });
+        }
+
+        function renderLobby() {
+          toScreen('lobbyScreen');
+          els.roomBadge.textContent = sessionCode ? `Room ${sessionCode}` : 'Lobby';
+          els.joinUrl.textContent = `${window.location.origin}/join/${sessionCode}`;
+          els.moderatorSetup.classList.toggle('hide', role !== 'moderator');
+          els.playerWaiting.classList.toggle('hide', role !== 'player');
+          const players = sortedPlayers();
+          els.playerCount.textContent = `${players.length} player${players.length === 1 ? '' : 's'}`;
+          els.roundPill.textContent = 'Lobby';
+          els.startBtn.disabled = role !== 'moderator' || players.length < 3;
+          els.lobbyHint.textContent =
+            players.length < 3 ? 'Need at least 3 active players to start.' : 'Ready for a suspiciously normal question.';
+          renderPlayers(els.playerGrid);
+        }
+
+        function renderTurnList() {
+          const game = session?.game || {};
+          els.turnList.innerHTML = sortedPlayers()
+            .map((player, index) => {
+              const answered = game.answers?.[player.id] || game.responses?.[player.id];
+              return `<div class="turn-item ${player.id === game.currentTurnId ? 'current' : ''}">
+                <strong>${index + 1}. ${escapeHtml(player.name)}</strong>
+                <span class="small">${answered ? 'answered' : 'waiting'}</span>
+              </div>`;
+            })
+            .join('');
+        }
+
+        function renderAnswers() {
+          const game = session?.game || {};
+          const answers = game.answers || (game.stage === 'answer' ? game.responses || {} : {});
+          const rows = Object.entries(answers).filter(([id]) => session?.players?.[id] && !session.players[id].kicked);
+          els.answerList.innerHTML = rows.length
+            ? rows
+                .map(([id, answer]) => `<div class="answer"><strong>${escapeHtml(playerName(id))}:</strong> ${escapeHtml(answer)}</div>`)
+                .join('')
+            : '<div class="empty">Answers will appear here as players submit.</div>';
+        }
+
+        function renderGame() {
+          const game = session?.game || {};
+          const players = sortedPlayers();
+          const myRole = game.roles?.[playerId];
+          const mySubmitted = Boolean(game.responses?.[playerId]);
+          const isMyTurn = game.currentTurnId === playerId;
+          const isImpostor = myRole === 'impostor';
+          const isModerator = role === 'moderator';
+          const stage = game.stage || 'lobby';
+
+          if (stage === 'ended') {
+            renderFinal();
+            return;
+          }
+          if (stage === 'lobby') {
+            renderLobby();
+            return;
+          }
+
+          toScreen('gameScreen');
+          els.roomBadge.textContent = `Room ${sessionCode}`;
+          els.stagePill.textContent = stageLabel(stage);
+          els.turnPill.textContent = `Round ${Number(game.logicalRound || 0) + 1} of ${Number(session?.settings?.roundsTotal || 5)}`;
+          els.questionText.textContent = game.question || 'What is your favorite?';
+
+          els.roleCard.classList.toggle('impostor', role === 'player' && isImpostor);
+          if (role === 'moderator') {
+            els.roleTitle.textContent = 'Moderator view';
+            els.roleValue.textContent = game.topic || 'Topic';
+            els.roleHint.textContent = `Impostor: ${playerName(game.impostorId)}`;
+          } else if (isImpostor) {
+            els.roleTitle.textContent = 'Your secret role';
+            els.roleValue.textContent = 'You are the impostor';
+            els.roleHint.textContent = 'Answer vaguely, listen closely, then guess the topic if you survive.';
+          } else {
+            els.roleTitle.textContent = 'Your shared topic';
+            els.roleValue.textContent = game.topic || 'Topic';
+            els.roleHint.textContent = 'Give a real answer that proves you know the topic without making it too easy.';
+          }
+
+          const canAnswer = role === 'player' && stage === 'answer' && isMyTurn && !mySubmitted;
+          els.answerForm.classList.toggle('hide', stage !== 'answer' || role !== 'player');
+          els.answerBtn.disabled = !canAnswer;
+          els.answerInput.disabled = !canAnswer;
+          els.answerInput.placeholder = isMyTurn ? 'Your short, slightly strategic answer...' : 'Wait for your turn...';
+          els.phaseHint.textContent =
+            stage === 'answer'
+              ? `${playerName(game.currentTurnId)} is answering.`
+              : stage === 'vote'
+                ? 'Vote privately. You cannot vote for yourself.'
+                : stage === 'topicGuess'
+                  ? 'The impostor gets one topic guess.'
+                  : 'Review the reveal and scores.';
+
+          els.voteBox.classList.toggle('hide', stage !== 'vote' || role !== 'player');
+          renderVoteChoices();
+
+          els.guessForm.classList.toggle('hide', stage !== 'topicGuess' || role !== 'player' || !isImpostor);
+          els.topicGuessBtn.disabled = role !== 'player' || !isImpostor || Boolean(game.responses?.[playerId]);
+
+          els.resultsBox.classList.toggle('hide', stage !== 'results');
+          if (stage === 'results') {
+            renderResults();
+          }
+
+          els.moderatorControls.classList.toggle('hide', !isModerator);
+          els.nextTurnBtn.classList.toggle('hide', stage !== 'answer');
+          els.openVoteBtn.classList.toggle('hide', stage !== 'answer');
+          els.revealVotesBtn.classList.toggle('hide', stage !== 'vote');
+          els.finishGuessBtn.classList.toggle('hide', stage !== 'topicGuess');
+          els.nextTurnBtn.disabled = !game.responses?.[game.currentTurnId];
+          els.openVoteBtn.disabled = players.some((player) => !game.responses?.[player.id]);
+          els.revealVotesBtn.disabled = players.some((player) => player.id !== game.impostorId && !game.responses?.[player.id]);
+          els.finishGuessBtn.disabled = !game.responses?.[game.impostorId];
+
+          renderPlayers(els.gamePlayerGrid, stage === 'results' || stage === 'ended');
+          renderTurnList();
+          renderAnswers();
+        }
+
+        function renderVoteChoices() {
+          const game = session?.game || {};
+          const locked = game.responses?.[playerId];
+          els.voteChoices.innerHTML = sortedPlayers()
+            .map((player) => {
+              const disabled = player.id === playerId || Boolean(locked);
+              const suffix = player.id === playerId ? ' (you)' : '';
+              return `<button class="btn vote-option ${locked === player.id ? 'gold' : ''}" type="button"
+                data-vote="${escapeHtml(player.id)}" ${disabled ? 'disabled' : ''}>
+                ${escapeHtml(player.name || 'Player')}${suffix}
+              </button>`;
+            })
+            .join('');
+        }
+
+        function renderResults() {
+          const game = session?.game || {};
+          const caught = Boolean(game.caught);
+          const guessed = Boolean(game.topicGuessed);
+          els.resultTitle.textContent = caught ? 'The table caught the impostor.' : 'The impostor slipped through.';
+          els.resultText.textContent = caught
+            ? `${playerName(game.impostorId)} was the impostor. The topic was ${game.topic}.`
+            : guessed
+              ? `${playerName(game.impostorId)} escaped the vote and guessed "${game.topic}".`
+              : `${playerName(game.impostorId)} escaped the vote but missed the topic: ${game.topic}.`;
+          els.resultActions.classList.toggle('hide', role !== 'moderator');
+        }
+
+        function renderFinal() {
+          const game = session?.game || {};
+          toScreen('finalScreen');
+          els.roomBadge.textContent = `Room ${sessionCode}`;
+          renderPlayers(els.finalPlayerGrid, true);
+          const ranked = rankScores(game.scores || {});
+          els.finalScores.innerHTML = ranked
+            .map(
+              (row) => `<div class="score-row">
+                <strong>#${row.rank} ${escapeHtml(row.name)}</strong>
+                <span>${row.score} pts</span>
+              </div>`
+            )
+            .join('');
+          els.playAgainBtn.classList.toggle('hide', role !== 'moderator');
+        }
+
+        function render() {
+          if (!session) return;
+          const stage = session.game?.stage || 'lobby';
+          if (session.status === 'ended' || stage === 'ended') renderFinal();
+          else if (stage === 'lobby') renderLobby();
+          else renderGame();
+        }
+
+        function pickTopic(pack, usedTopics = []) {
+          const pool = TOPICS[pack] || TOPICS.work;
+          const fresh = pool.filter((item) => !usedTopics.includes(item.topic));
+          const options = fresh.length ? fresh : pool;
+          return options[Math.floor(Math.random() * options.length)];
+        }
+
+        async function startGame() {
+          const players = sortedPlayers();
+          if (players.length < 3) return;
+          const pack = els.topicPack.value || 'work';
+          const topic = pickTopic(pack);
+          const impostor = players[Math.floor(Math.random() * players.length)];
+          const roles = {};
+          const scores = {};
+          players.forEach((player) => {
+            roles[player.id] = player.id === impostor.id ? 'impostor' : 'insider';
+            scores[player.id] = 0;
+          });
+          await patchSession(
+            {
+              'settings/roundsTotal': Number.parseInt(els.roundCount.value, 10) || 5,
+              'settings/topicPack': pack,
+              'game/mode': 'quiz-vote',
+              'game/phase': 'question',
+              'game/stage': 'answer',
+              'game/logicalRound': 0,
+              'game/roundIndex': 0,
+              'game/usedTopics': [topic.topic],
+              'game/topic': topic.topic,
+              'game/question': topic.question,
+              'game/impostorId': impostor.id,
+              'game/roles': roles,
+              'game/turnOrder': players.map((player) => player.id),
+              'game/currentTurnIndex': 0,
+              'game/currentTurnId': players[0].id,
+              'game/responses': {},
+              'game/answers': {},
+              'game/votes': {},
+              'game/scores': scores,
+              'game/roundGains': {},
+              'game/caught': false,
+              'game/topicGuessed': false
+            },
+            'playing'
+          );
+        }
+
+        async function nextTurn() {
+          const game = session?.game || {};
+          const order = game.turnOrder || activeIds();
+          const nextIndex = Math.min(Number(game.currentTurnIndex || 0) + 1, order.length - 1);
+          await patchSession({
+            'game/currentTurnIndex': nextIndex,
+            'game/currentTurnId': order[nextIndex]
+          });
+        }
+
+        async function openVoting() {
+          const game = session?.game || {};
+          await patchSession({
+            'game/stage': 'vote',
+            'game/phase': 'question',
+            'game/roundIndex': Number(game.logicalRound || 0) * 3 + 1,
+            'game/answers': game.responses || {},
+            'game/responses': {},
+            'game/votes': {}
+          });
+        }
+
+        function computeVoteReveal() {
+          const game = session?.game || {};
+          const votes = game.responses || {};
+          const totals = {};
+          Object.values(votes).forEach((target) => {
+            totals[target] = (totals[target] || 0) + 1;
+          });
+          const maxVotes = Math.max(0, ...Object.values(totals));
+          const accused = Object.entries(totals)
+            .filter(([, count]) => count === maxVotes)
+            .map(([id]) => id);
+          return { votes, totals, accused, caught: accused.includes(game.impostorId) && maxVotes > 0 };
+        }
+
+        async function revealVotes() {
+          const game = session?.game || {};
+          const reveal = computeVoteReveal();
+          if (!reveal.caught) {
+            await patchSession({
+              'game/stage': 'topicGuess',
+              'game/phase': 'question',
+              'game/roundIndex': Number(game.logicalRound || 0) * 3 + 2,
+              'game/votes': reveal.votes,
+              'game/voteTotals': reveal.totals,
+              'game/accused': reveal.accused,
+              'game/caught': false,
+              'game/responses': {}
+            });
+            return;
+          }
+          const scores = { ...(game.scores || {}) };
+          activeIds().forEach((id) => {
+            if (id !== game.impostorId) scores[id] = Number(scores[id] || 0) + 2;
+          });
+          await patchSession({
+            'game/stage': 'results',
+            'game/phase': 'results',
+            'game/votes': reveal.votes,
+            'game/voteTotals': reveal.totals,
+            'game/accused': reveal.accused,
+            'game/caught': true,
+            'game/topicGuessed': false,
+            'game/scores': scores,
+            'game/responses': {}
+          });
+        }
+
+        async function finishTopicGuess() {
+          const game = session?.game || {};
+          const guess = game.responses?.[game.impostorId] || '';
+          const guessed = normalize(guess) === normalize(game.topic);
+          const scores = { ...(game.scores || {}) };
+          if (guessed) {
+            scores[game.impostorId] = Number(scores[game.impostorId] || 0) + 4;
+          } else {
+            scores[game.impostorId] = Number(scores[game.impostorId] || 0) + 1;
+          }
+          await patchSession({
+            'game/stage': 'results',
+            'game/phase': 'results',
+            'game/topicGuess': guess,
+            'game/topicGuessed': guessed,
+            'game/scores': scores
+          });
+        }
+
+        async function nextRound() {
+          const game = session?.game || {};
+          const next = Number(game.logicalRound || 0) + 1;
+          const total = Number(session?.settings?.roundsTotal || 5);
+          if (next >= total) {
+            await endGame();
+            return;
+          }
+          const players = sortedPlayers();
+          const pack = session?.settings?.topicPack || 'work';
+          const topic = pickTopic(pack, game.usedTopics || []);
+          const impostor = players[Math.floor(Math.random() * players.length)];
+          const roles = {};
+          players.forEach((player) => {
+            roles[player.id] = player.id === impostor.id ? 'impostor' : 'insider';
+          });
+          await patchSession({
+            'game/stage': 'answer',
+            'game/phase': 'question',
+            'game/logicalRound': next,
+            'game/roundIndex': next * 3,
+            'game/usedTopics': [...(game.usedTopics || []), topic.topic],
+            'game/topic': topic.topic,
+            'game/question': topic.question,
+            'game/impostorId': impostor.id,
+            'game/roles': roles,
+            'game/turnOrder': players.map((player) => player.id),
+            'game/currentTurnIndex': 0,
+            'game/currentTurnId': players[0]?.id || null,
+            'game/responses': {},
+            'game/answers': {},
+            'game/votes': {},
+            'game/voteTotals': {},
+            'game/accused': [],
+            'game/caught': false,
+            'game/topicGuessed': false,
+            'game/topicGuess': ''
+          });
+        }
+
+        async function endGame() {
+          await patchSession({ 'game/stage': 'ended', 'game/phase': 'ended' }, 'ended');
+        }
+
+        async function resetLobby() {
+          await patchSession(
+            {
+              'game/stage': 'lobby',
+              'game/phase': 'lobby',
+              'game/responses': {},
+              'game/answers': {},
+              'game/votes': {},
+              'game/scores': {},
+              'game/roles': {},
+              'game/topic': '',
+              'game/question': '',
+              'game/impostorId': null
+            },
+            'lobby'
+          );
+        }
+
+        async function refreshSession() {
+          if (!sessionCode) return;
+          try {
+            session = await loadSession(sessionCode);
+            render();
+          } catch (error) {
+            console.error('Failed to refresh session', error);
+          }
+        }
+
+        function bindEvents() {
+          els.copyLinkBtn.addEventListener('click', async () => {
+            const url = `${window.location.origin}/join/${sessionCode}`;
+            try {
+              await navigator.clipboard.writeText(url);
+              els.lobbyHint.textContent = 'Join link copied.';
+            } catch {
+              els.lobbyHint.textContent = url;
+            }
+          });
+
+          els.startBtn.addEventListener('click', () => startGame().catch(console.error));
+          els.roundCount.addEventListener('change', () => {
+            if (role === 'moderator') {
+              patchSession({ 'settings/roundsTotal': Number.parseInt(els.roundCount.value, 10) || 5 }).catch(() => {});
+            }
+          });
+          els.topicPack.addEventListener('change', () => {
+            if (role === 'moderator') {
+              patchSession({ 'settings/topicPack': els.topicPack.value || 'work' }).catch(() => {});
+            }
+          });
+
+          els.answerForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const value = els.answerInput.value.trim();
+            if (!value) return;
+            submitValue(value)
+              .then(() => {
+                els.answerInput.value = '';
+                return refreshSession();
+              })
+              .catch(console.error);
+          });
+
+          els.voteChoices.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-vote]');
+            if (!button) return;
+            submitValue(button.getAttribute('data-vote')).then(refreshSession).catch(console.error);
+          });
+
+          els.guessForm.addEventListener('submit', (event) => {
+            event.preventDefault();
+            const value = els.topicGuessInput.value.trim();
+            if (!value) return;
+            submitValue(value)
+              .then(() => {
+                els.topicGuessInput.value = '';
+                return refreshSession();
+              })
+              .catch(console.error);
+          });
+
+          els.nextTurnBtn.addEventListener('click', () => nextTurn().catch(console.error));
+          els.openVoteBtn.addEventListener('click', () => openVoting().catch(console.error));
+          els.revealVotesBtn.addEventListener('click', () => revealVotes().catch(console.error));
+          els.finishGuessBtn.addEventListener('click', () => finishTopicGuess().catch(console.error));
+          els.nextRoundBtn.addEventListener('click', () => nextRound().catch(console.error));
+          els.endGameBtn.addEventListener('click', () => endGame().catch(console.error));
+          els.playAgainBtn.addEventListener('click', () => resetLobby().catch(console.error));
+        }
+
+        async function bootstrap() {
+          bindEvents();
+          const configured = await checkStatus();
+          if (!configured) {
+            toScreen('configErrorScreen');
+            return;
+          }
+
+          const hash = parseHash();
+          if (hash.role === 'player' && hash.code && hash.pid) {
+            role = 'player';
+            sessionCode = hash.code;
+            playerId = hash.pid;
+          } else {
+            role = 'moderator';
+            const stored = hash.code ? loadModeratorRecord(hash.code) : null;
+            if (hash.code && stored?.moderatorId) {
+              sessionCode = hash.code;
+              moderatorId = stored.moderatorId;
+            } else {
+              const created = await createSession();
+              sessionCode = created.code;
+              moderatorId = created.moderatorId;
+              saveModeratorRecord(sessionCode, moderatorId);
+              window.location.hash = `code=${sessionCode}&role=moderator`;
+            }
+          }
+
+          await refreshSession();
+          pollHandle = setInterval(refreshSession, 1000);
+        }
+
+        window.addEventListener('beforeunload', () => {
+          if (pollHandle) clearInterval(pollHandle);
+        });
+
+        bootstrap().catch((error) => {
+          console.error('Bootstrap failed', error);
+          toScreen('configErrorScreen');
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/meta.json
+++ b/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/meta.json
@@ -44,16 +44,6 @@
       "implementedAt": "2026-04-24T20:27:27Z",
       "agentName": "Codex",
       "llmModel": "GPT-5"
-    },
-    {
-      "issueNumber": 411,
-      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/411",
-      "runId": "run-20260425T214321Z-cf67d4",
-      "description": "Fixed voting race condition: concurrent vote submissions caused last-writer-wins data loss. Added record_session_vote SQL RPC with SELECT FOR UPDATE row locking and JSONB || merge so all votes are recorded atomically.",
-      "requestor": "jeffholst",
-      "implementedAt": "2026-04-25T22:18:05Z",
-      "agentName": "Claude Code",
-      "llmModel": "claude-sonnet-4-6"
     }
   ]
 }

--- a/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/thumbnail.svg
+++ b/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/thumbnail.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-labelledby="title desc">
+  <title id="title">The Impostor Question thumbnail</title>
+  <desc id="desc">A Zoom-style hidden-role game room with a moderator board, secret topic card, player grid, and voting controls.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#111827" />
+      <stop offset="0.48" stop-color="#172033" />
+      <stop offset="1" stop-color="#0b1120" />
+    </linearGradient>
+    <linearGradient id="teal" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2dd4bf" />
+      <stop offset="1" stop-color="#99f6e4" />
+    </linearGradient>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbbf24" />
+      <stop offset="1" stop-color="#fde68a" />
+    </linearGradient>
+    <radialGradient id="dangerGlow" cx="50%" cy="50%" r="60%">
+      <stop offset="0" stop-color="#fb7185" stop-opacity="0.75" />
+      <stop offset="1" stop-color="#fb7185" stop-opacity="0" />
+    </radialGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="8" result="blur" />
+      <feOffset dx="0" dy="10" result="offset" />
+      <feMerge>
+        <feMergeNode in="offset" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <filter id="titleGlow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="3" result="glow" />
+      <feMerge>
+        <feMergeNode in="glow" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="0" y="0" width="800" height="450" fill="url(#bg)" />
+  <circle cx="116" cy="56" r="160" fill="#2dd4bf" opacity="0.13" />
+  <circle cx="700" cy="38" r="150" fill="#fbbf24" opacity="0.12" />
+  <path d="M0 358 C160 312 256 410 420 354 C566 304 662 328 800 286 L800 450 L0 450 Z" fill="#0b1120" opacity="0.45" />
+
+  <text x="42" y="62" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="34" font-weight="900" filter="url(#titleGlow)">The Impostor Question</text>
+  <text x="44" y="91" fill="#aab8d3" font-family="Inter, Segoe UI, sans-serif" font-size="15" font-weight="700">One shared topic. One player bluffing. Everyone votes.</text>
+  <rect x="622" y="34" width="132" height="36" rx="18" fill="url(#teal)" />
+  <text x="648" y="58" fill="#08111f" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="900">ROOM G7K2Q</text>
+
+  <g filter="url(#softShadow)">
+    <rect x="42" y="122" width="446" height="286" rx="18" fill="#172033" stroke="#40506f" />
+    <rect x="66" y="146" width="183" height="86" rx="14" fill="#22304a" stroke="#2dd4bf" />
+    <text x="86" y="174" fill="#aab8d3" font-family="Inter, Segoe UI, sans-serif" font-size="13" font-weight="900">YOUR SHARED TOPIC</text>
+    <text x="86" y="207" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="31" font-weight="900">Coffee</text>
+
+    <rect x="268" y="146" width="196" height="86" rx="14" fill="#22304a" stroke="#fbbf24" />
+    <text x="290" y="174" fill="#aab8d3" font-family="Inter, Segoe UI, sans-serif" font-size="13" font-weight="900">QUESTION</text>
+    <text x="290" y="202" fill="#fbbf24" font-family="Inter, Segoe UI, sans-serif" font-size="21" font-weight="900">Favorite start?</text>
+
+    <rect x="66" y="252" width="398" height="48" rx="12" fill="#1f2937" stroke="#40506f" />
+    <text x="86" y="283" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="18" font-weight="800">Jordan: “Something warm and urgent.”</text>
+    <rect x="66" y="316" width="126" height="48" rx="12" fill="url(#teal)" />
+    <rect x="206" y="316" width="126" height="48" rx="12" fill="#22304a" stroke="#40506f" />
+    <rect x="346" y="316" width="118" height="48" rx="12" fill="url(#gold)" />
+    <text x="100" y="346" fill="#08111f" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="900">Submit</text>
+    <text x="239" y="346" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="900">Vote</text>
+    <text x="374" y="346" fill="#201400" font-family="Inter, Segoe UI, sans-serif" font-size="16" font-weight="900">Reveal</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect x="518" y="122" width="236" height="286" rx="18" fill="#172033" stroke="#40506f" />
+    <text x="542" y="156" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="22" font-weight="900">Moderator board</text>
+    <text x="542" y="181" fill="#aab8d3" font-family="Inter, Segoe UI, sans-serif" font-size="14" font-weight="700">Round 3 of 5</text>
+    <g>
+      <rect x="542" y="204" width="84" height="64" rx="12" fill="#22304a" stroke="#2dd4bf" />
+      <rect x="646" y="204" width="84" height="64" rx="12" fill="#22304a" stroke="#40506f" />
+      <rect x="542" y="284" width="84" height="64" rx="12" fill="#22304a" stroke="#40506f" />
+      <rect x="646" y="284" width="84" height="64" rx="12" fill="#22304a" stroke="#fb7185" />
+      <circle cx="584" cy="226" r="13" fill="#2dd4bf" />
+      <circle cx="688" cy="226" r="13" fill="#fbbf24" />
+      <circle cx="584" cy="306" r="13" fill="#99f6e4" />
+      <circle cx="688" cy="306" r="28" fill="url(#dangerGlow)" />
+      <circle cx="688" cy="306" r="13" fill="#fb7185" />
+      <text x="560" y="254" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="13" font-weight="800">Maya</text>
+      <text x="665" y="254" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="13" font-weight="800">Lee</text>
+      <text x="562" y="334" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="13" font-weight="800">Ari</text>
+      <text x="661" y="334" fill="#f8fafc" font-family="Inter, Segoe UI, sans-serif" font-size="13" font-weight="800">Sam?</text>
+    </g>
+    <rect x="542" y="366" width="188" height="24" rx="12" fill="#1f2937" stroke="#40506f" />
+    <rect x="542" y="366" width="92" height="24" rx="12" fill="url(#gold)" />
+    <text x="558" y="383" fill="#201400" font-family="Inter, Segoe UI, sans-serif" font-size="12" font-weight="900">Votes locked</text>
+  </g>
+</svg>

--- a/data/apps.json
+++ b/data/apps.json
@@ -48,6 +48,16 @@
         "implementedAt": "2026-04-24T20:27:27Z",
         "agentName": "Codex",
         "llmModel": "GPT-5"
+      },
+      {
+        "issueNumber": 411,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/411",
+        "runId": "run-20260425T214321Z-cf67d4",
+        "description": "Fixed voting race condition: concurrent vote submissions caused last-writer-wins data loss. Added record_session_vote SQL RPC with SELECT FOR UPDATE row locking and JSONB || merge so all votes are recorded atomically.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-04-25T22:18:05Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ],
     "allowImprovements": true,
@@ -58,6 +68,11 @@
         "runId": "run-20260424T202727Z-65ce0a",
         "path": "backups/run-20260424T202727Z-65ce0a/index.html",
         "url": "/apps/2026/04/24/impostor-question/backups/run-20260424T202727Z-65ce0a/index.html"
+      },
+      {
+        "runId": "run-20260425T214321Z-cf67d4",
+        "path": "backups/run-20260425T214321Z-cf67d4/index.html",
+        "url": "/apps/2026/04/24/impostor-question/backups/run-20260425T214321Z-cf67d4/index.html"
       }
     ]
   },

--- a/supabase/migrations/20260425220000_record_session_vote.sql
+++ b/supabase/migrations/20260425220000_record_session_vote.sql
@@ -1,0 +1,65 @@
+-- Atomic vote-recording helper for the impostor-question game's voting phase.
+-- Merges a single player's vote into game.responses using JSONB || merge,
+-- preventing the lost-update race that occurs when multiple players submit
+-- votes simultaneously in the non-atomic read-modify-write path.
+-- The function is SECURITY DEFINER and restricted to the service role,
+-- following the same pattern as add_multiplayer_player.
+create or replace function public.record_session_vote(
+  p_code      text,
+  p_player_id text,
+  p_voted_for text,
+  p_round     int
+) returns table (accepted boolean, already_submitted boolean)
+language plpgsql
+security definer
+as $$
+declare
+  v_player jsonb;
+begin
+  -- Lock the row so concurrent vote submissions are serialized.
+  select players -> p_player_id
+    into v_player
+    from public.multiplayer_sessions
+   where code = p_code
+     for update;
+
+  if not found or v_player is null then
+    return query select false::boolean, false::boolean;
+    return;
+  end if;
+
+  -- Idempotency guard: player already voted in this round.
+  if coalesce((v_player->>'voteRound')::int, 0) = p_round
+     and (v_player->>'lastAnswer') is not null then
+    return query select true::boolean, true::boolean;
+    return;
+  end if;
+
+  -- Atomically merge vote into game.responses and update the player record.
+  -- Using || (JSONB merge) on game.responses means concurrent votes for
+  -- different players are never clobbered by the last writer.
+  update public.multiplayer_sessions
+     set game    = jsonb_set(
+                     game,
+                     '{responses}',
+                     coalesce(game->'responses', '{}') || jsonb_build_object(p_player_id, p_voted_for)
+                   ),
+         players = jsonb_set(
+                     players,
+                     array[p_player_id],
+                     (players -> p_player_id) || jsonb_build_object(
+                       'lastAnswer', p_voted_for,
+                       'voteRound',  p_round,
+                       'updatedAt',  to_char(now() at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+                     )
+                   )
+   where code = p_code;
+
+  return query select true::boolean, false::boolean;
+end;
+$$;
+
+-- Restrict to service-role only (same pattern as add_multiplayer_player).
+revoke execute on function public.record_session_vote(text, text, text, int) from public;
+revoke execute on function public.record_session_vote(text, text, text, int) from anon;
+revoke execute on function public.record_session_vote(text, text, text, int) from authenticated;


### PR DESCRIPTION
## Summary

- Voting phase had a concurrent write race condition: when multiple players submitted votes simultaneously, the answers endpoint used a non-atomic read-modify-write on `game.responses`, causing last-writer-wins data loss
- Added `record_session_vote` SQL RPC (`supabase/migrations/20260425220000_record_session_vote.sql`) that uses `SELECT … FOR UPDATE` row locking and a single `UPDATE` with JSONB `||` merge, so concurrent votes are never clobbered
- Updated the `quiz-vote` branch of the answers endpoint to call the new RPC instead of the old pattern — same approach already used by `add_multiplayer_player` for concurrent player joins

Closes #411

## Test plan

- [ ] Start a game session with 3+ players
- [ ] Advance to the voting stage
- [ ] Have all players submit votes simultaneously (or in quick succession)
- [ ] Verify all votes appear in `game.responses` — no votes dropped
- [ ] Verify the moderator's "Reveal Votes" button becomes enabled once all non-impostor players have voted
- [ ] Verify the vote reveal and scoring flow completes normally
- [ ] Verify single-player voting still works (vote is recorded, button locks, gold highlight shows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)