### PR TITLE
improve(rubric-showdown): remove chart.js dependency and radar chart (#445)

### DIFF
--- a/apps/2026/05/23/rubric-showdown/index.html
+++ b/apps/2026/05/23/rubric-showdown/index.html
@@ -24,7 +24,6 @@
     <meta name="voa-social-instagram-url" content="__SOCIAL_INSTAGRAM_URL__" />
     <meta name="application-name" content="Rubric Showdown" />
     <meta name="voa-app-id" content="2026/05/23/rubric-showdown" />
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js" defer></script>
     <script src="/apps/shared/app-shell.js" defer></script>
 
     <style>
@@ -274,7 +273,7 @@
 
       .criterion-grid {
         display: grid;
-        grid-template-columns: 32px 1fr 72px 92px 40px;
+        grid-template-columns: 32px 1fr 72px 40px;
         gap: 8px;
         align-items: center;
       }
@@ -305,13 +304,6 @@
         color: #11140c;
         background: var(--accent-2);
         font-weight: 900;
-      }
-
-      .scoreboard {
-        display: grid;
-        grid-template-columns: minmax(0, 1.05fr) minmax(300px, 0.95fr);
-        gap: 14px;
-        margin-bottom: 14px;
       }
 
       .leaderboard {
@@ -357,15 +349,6 @@
       .mini {
         color: var(--muted);
         font-size: 0.84rem;
-      }
-
-      .chart-wrap {
-        min-height: 320px;
-      }
-
-      #radarChart {
-        width: 100%;
-        max-height: 370px;
       }
 
       .matrix {
@@ -580,8 +563,7 @@
       }
 
       @media (max-width: 1040px) {
-        .layout,
-        .scoreboard {
+        .layout {
           grid-template-columns: 1fr;
         }
 
@@ -604,7 +586,7 @@
         }
 
         .criterion-grid {
-          grid-template-columns: 32px 1fr 62px 76px 40px;
+          grid-template-columns: 32px 1fr 62px 40px;
           gap: 6px;
         }
 
@@ -657,25 +639,15 @@
         </aside>
 
         <section aria-label="Scoring workspace">
-          <div class="scoreboard">
-            <article class="panel">
-              <div class="panel-head">
-                <h2>Live Leaderboard</h2>
-                <span class="pill" id="leaderLabel">0 scored</span>
-              </div>
-              <div class="panel-body leaderboard" id="leaderboard"></div>
-            </article>
+          <article class="panel" style="margin-bottom: 14px">
+            <div class="panel-head">
+              <h2>Live Leaderboard</h2>
+              <span class="pill" id="leaderLabel">0 scored</span>
+            </div>
+            <div class="panel-body leaderboard" id="leaderboard"></div>
+          </article>
 
-            <article class="panel chart-wrap">
-              <div class="panel-head">
-                <h2>Category Radar</h2>
-                <span class="pill" id="categoryLabel">0 categories</span>
-              </div>
-              <div class="panel-body">
-                <canvas id="radarChart" aria-label="Radar chart comparing competitors"></canvas>
-              </div>
-            </article>
-          </div>
+          <p class="verdict" id="verdict" style="margin-bottom: 14px" aria-live="polite"></p>
 
           <article class="panel">
             <div class="panel-head">
@@ -692,8 +664,6 @@
             </div>
             <div class="panel-body competitor-list" id="competitorList"></div>
           </article>
-
-          <p class="verdict" id="verdict" style="margin-top: 14px" aria-live="polite"></p>
         </section>
       </section>
     </main>
@@ -715,15 +685,14 @@
       <div class="help-card">
         <h2 id="helpTitle">Rubric Showdown Help</h2>
         <p>
-          Build a scoring rubric, compare named competitors, and use the leaderboard, radar
-          chart, notes, and reveal tools to make a decision.
+          Build a scoring rubric, compare named competitors, and use the leaderboard, notes, and reveal tools to make a decision.
         </p>
         <h3>Rubric Builder</h3>
         <ul>
           <li>Use Add Criterion to create a new scoring row.</li>
           <li>Edit the full-width criterion name field for longer descriptions.</li>
           <li>Drag the handle to reorder criteria.</li>
-          <li>Set each criterion to 1x, 2x, or 3x, choose a category, and toggle plus or minus.</li>
+          <li>Set each criterion to 1x, 2x, or 3x and toggle plus or minus.</li>
           <li>Delete Criterion removes that criterion from every competitor score.</li>
         </ul>
         <h3>Scoring Competitors</h3>
@@ -736,8 +705,7 @@
         <h3>Results</h3>
         <ul>
           <li>The leaderboard updates as scores, weights, signs, and confidence change.</li>
-          <li>The category radar compares positive category strengths across competitors.</li>
-          <li>Reveal Winner opens a spotlight result with a verdict based on the leading category.</li>
+          <li>Reveal Winner opens a spotlight result with a verdict based on the leading score.</li>
           <li>Copy Summary copies ranked results, and Export PNG downloads a scorecard.</li>
           <li>Undo and Redo step through recent rubric, competitor, and scoring changes.</li>
         </ul>
@@ -772,7 +740,6 @@
       let state = loadState();
       let undoStack = [];
       let redoStack = [];
-      let radarChart;
       let draggedCriterionId = null;
       let lastWinner = null;
 
@@ -833,10 +800,6 @@
         }, 900);
       }
 
-      function criteriaByCategory() {
-        return [...new Set(state.criteria.map((item) => item.category.trim() || 'General'))];
-      }
-
       function rawCriterionScore(competitor, criterion) {
         const value = Number(state.scores[`${competitor.id}:${criterion.id}`] || 3);
         return value * Number(criterion.weight) * Number(criterion.sign);
@@ -857,28 +820,14 @@
 
       function sortedCompetitors() {
         return state.competitors
-          .map((competitor) => ({
-            ...competitor,
-            total: competitorTotal(competitor),
-            topCategory: topCategoryFor(competitor),
-          }))
+          .map((competitor) => ({ ...competitor, total: competitorTotal(competitor) }))
           .sort((a, b) => b.total - a.total);
-      }
-
-      function topCategoryFor(competitor) {
-        return criteriaByCategory()
-          .map((category) => {
-            const criteria = state.criteria.filter((criterion) => (criterion.category.trim() || 'General') === category);
-            const total = criteria.reduce((sum, criterion) => sum + rawCriterionScore(competitor, criterion), 0);
-            return { category, total };
-          })
-          .sort((a, b) => b.total - a.total)[0]?.category || 'balanced strength';
       }
 
       function verdictFor(winner) {
         const runnerUp = sortedCompetitors()[1];
         const margin = runnerUp ? (winner.total - runnerUp.total).toFixed(1) : winner.total.toFixed(1);
-        return `${winner.name} wins by owning ${winner.topCategory}, with a ${winner.confidence}% confidence signal and a ${margin}-point edge over the nearest challenger.`;
+        return `${winner.name} leads with ${winner.total} points, a ${winner.confidence}% confidence signal, and a ${margin}-point edge over the nearest challenger.`;
       }
 
       function renderCriteria() {
@@ -898,14 +847,12 @@
                 <option value="2">2x</option>
                 <option value="3">3x</option>
               </select>
-              <input aria-label="Category" value="${escapeHtml(criterion.category)}" />
               <button class="icon-btn sign-toggle ${criterion.sign < 0 ? '' : 'active'}" type="button" aria-label="Toggle plus or minus">${criterion.sign < 0 ? '-' : '+'}</button>
             </div>
             <button class="btn" type="button" style="margin-top:8px;width:100%">Delete Criterion</button>
           `;
           const nameInput = row.querySelector('.criterion-name');
           const weightSelect = row.querySelector('select');
-          const categoryInput = row.querySelector('input');
           weightSelect.value = criterion.weight;
           nameInput.addEventListener('change', () =>
             commit(() => {
@@ -915,11 +862,6 @@
           weightSelect.addEventListener('change', () =>
             commit(() => {
               criterion.weight = Number(weightSelect.value);
-            }),
-          );
-          categoryInput.addEventListener('change', () =>
-            commit(() => {
-              criterion.category = categoryInput.value.trim() || 'General';
             }),
           );
           row.querySelector('.sign-toggle').addEventListener('click', () =>
@@ -965,7 +907,7 @@
             <div class="rank">${index + 1}</div>
             <div>
               <h3>${escapeHtml(competitor.name)}</h3>
-              <p class="mini">${escapeHtml(competitor.topCategory)} lead · ${competitor.confidence}% confidence</p>
+              <p class="mini">${competitor.confidence}% confidence</p>
             </div>
             <div class="score">${competitor.total}</div>
           `;
@@ -997,7 +939,7 @@
               <tr>
                 <td>
                   <strong>${escapeHtml(criterion.name)}</strong>
-                  <div class="mini">${escapeHtml(criterion.category)} · ${criterion.sign > 0 ? '+' : '-'}${criterion.weight}x</div>
+                  <div class="mini">${criterion.sign > 0 ? '+' : '-'}${criterion.weight}x</div>
                 </td>
                 ${cells}
               </tr>
@@ -1022,7 +964,6 @@
             input.nextElementSibling.textContent = input.value;
             localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
             renderLeaderboard();
-            updateChart();
           });
           input.addEventListener('change', () => {
             if (input.dataset.before) undoStack.push(JSON.parse(input.dataset.before));
@@ -1076,7 +1017,6 @@
             updateConfidence(competitor, confidenceInput.value, confidenceLabel, confidenceNumber);
             localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
             renderLeaderboard();
-            updateChart();
           });
           confidenceInput.addEventListener('change', () => {
             if (confidenceInput.dataset.before) undoStack.push(JSON.parse(confidenceInput.dataset.before));
@@ -1102,68 +1042,6 @@
         });
       }
 
-      function updateChart() {
-        const categories = criteriaByCategory();
-        const datasets = state.competitors.map((competitor, index) => ({
-          label: competitor.name,
-          data: categories.map((category) => {
-            const criteria = state.criteria.filter((criterion) => (criterion.category.trim() || 'General') === category);
-            return criteria.reduce((sum, criterion) => sum + Math.max(0, rawCriterionScore(competitor, criterion)), 0);
-          }),
-          fill: true,
-          borderColor: palette[index % palette.length],
-          backgroundColor: `${palette[index % palette.length]}33`,
-          pointBackgroundColor: palette[index % palette.length],
-          borderWidth: 2,
-        }));
-        document.getElementById('categoryLabel').textContent = `${categories.length} categories`;
-        if (!window.Chart) return;
-        const textColor = getComputedStyle(document.documentElement).getPropertyValue('--text').trim();
-        const gridColor = getComputedStyle(document.documentElement).getPropertyValue('--border').trim();
-        const chartSignature = JSON.stringify({
-          categories,
-          competitors: state.competitors.map((competitor) => competitor.id),
-        });
-        if (radarChart && radarChart.$signature !== chartSignature) {
-          radarChart.destroy();
-          radarChart = null;
-        }
-        if (!radarChart) {
-          radarChart = new Chart(document.getElementById('radarChart'), {
-            type: 'radar',
-            data: { labels: categories, datasets },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: {
-                legend: { labels: { color: textColor, boxWidth: 12 } },
-              },
-              scales: {
-                r: {
-                  beginAtZero: true,
-                  grid: { color: gridColor },
-                  angleLines: { color: gridColor },
-                  pointLabels: { color: textColor },
-                  ticks: { color: textColor, backdropColor: 'transparent' },
-                },
-              },
-              animation: { duration: 350 },
-            },
-          });
-          radarChart.$signature = chartSignature;
-          return;
-        }
-        radarChart.data.labels = categories;
-        radarChart.data.datasets = datasets;
-        radarChart.options.plugins.legend.labels.color = textColor;
-        radarChart.options.scales.r.grid.color = gridColor;
-        radarChart.options.scales.r.angleLines.color = gridColor;
-        radarChart.options.scales.r.pointLabels.color = textColor;
-        radarChart.options.scales.r.ticks.color = textColor;
-        radarChart.$signature = chartSignature;
-        radarChart.update();
-      }
-
       function updateConfidence(competitor, value, label, pairedInput) {
         competitor.confidence = Math.max(0, Math.min(100, Number(value) || 0));
         label.textContent = `${competitor.confidence}%`;
@@ -1176,7 +1054,6 @@
         renderLeaderboard();
         renderMatrix();
         renderCompetitors();
-        updateChart();
         document.getElementById('undoBtn').disabled = undoStack.length === 0;
         document.getElementById('redoBtn').disabled = redoStack.length === 0;
       }

--- a/apps/2026/05/23/rubric-showdown/meta.json
+++ b/apps/2026/05/23/rubric-showdown/meta.json
@@ -1,12 +1,12 @@
 {
   "id": "rubric-showdown",
   "name": "Rubric Showdown",
-  "shortDescription": "Build weighted rubrics, score multiple competitors side-by-side, compare category strengths on a radar chart, and export a winner scorecard.",
+  "shortDescription": "Build weighted rubrics, score multiple competitors side-by-side, watch a live leaderboard with instant verdict, and export a winner scorecard.",
   "thumbnail": "thumbnail.svg",
   "createdAt": "2026-05-23T15:05:07Z",
   "category": "Utilities",
   "status": "active",
-  "tags": ["rubric", "scoring", "ranking", "charts", "comparison", "export"],
+  "tags": ["rubric", "scoring", "ranking", "comparison", "export", "leaderboard"],
   "homepagePath": "index.html",
   "inputMode": "responsive",
   "suggestion": {
@@ -46,6 +46,16 @@
       "implementedAt": "2026-05-23T16:47:15Z",
       "agentName": "Codex",
       "llmModel": "GPT-5"
+    },
+    {
+      "issueNumber": 445,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/445",
+      "runId": "run-20260523T173416Z-4823fc",
+      "description": "Moved verdict above score matrix. Removed criterion category option, chart.js CDN dependency, radar chart, updateChart() and criteriaByCategory() functions. Simplified leaderboard and matrix to remove category references.",
+      "requestor": "jeffholst",
+      "implementedAt": "2026-05-23T17:42:15Z",
+      "agentName": "Claude",
+      "llmModel": "claude-sonnet-4-6"
     }
   ]
 }

--- a/apps/2026/05/23/rubric-showdown/thumbnail.svg
+++ b/apps/2026/05/23/rubric-showdown/thumbnail.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-labelledby="title desc">
   <title id="title">Rubric Showdown thumbnail</title>
-  <desc id="desc">A rubric scoring dashboard with leaderboard, sliders, and radar chart.</desc>
+  <desc id="desc">A rubric scoring dashboard with leaderboard, sliders, and score matrix.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="800" y2="450" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#101319" />
@@ -14,6 +14,10 @@
     <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#f2b705" />
       <stop offset="1" stop-color="#ffe28b" />
+    </linearGradient>
+    <linearGradient id="verdictGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2dd4bf" stop-opacity="0.22" />
+      <stop offset="1" stop-color="#f2b705" stop-opacity="0.14" />
     </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceAlpha" stdDeviation="8" result="blur" />
@@ -36,81 +40,91 @@
   <path d="M34 398H766" stroke="#2dd4bf" stroke-opacity="0.18" stroke-width="2" />
   <path d="M34 52H766" stroke="#f2b705" stroke-opacity="0.16" stroke-width="2" />
 
-  <text
-    x="46"
-    y="74"
-    fill="#f7f3e8"
-    font-family="Inter, Arial, sans-serif"
-    font-size="42"
-    font-weight="900"
-    filter="url(#titleGlow)"
-  >
-    Rubric Showdown
-  </text>
-    <text x="50" y="105" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="18">
-    full-width criteria · guided scoring
-  </text>
+  <text x="46" y="74" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="900" filter="url(#titleGlow)">Rubric Showdown</text>
+  <text x="50" y="105" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="18">weighted criteria · live leaderboard · verdict</text>
 
+  <!-- Criteria panel -->
   <g filter="url(#shadow)">
-    <rect x="44" y="132" width="244" height="248" rx="8" fill="#191f29" stroke="#334050" />
-    <text x="66" y="164" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="800">
-      Criteria
-    </text>
-    <g font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">
-      <rect x="65" y="188" width="198" height="62" rx="8" fill="#121821" stroke="#334050" />
-      <text x="82" y="211" fill="#f7f3e8">Originality and</text>
-      <text x="82" y="230" fill="#f7f3e8">audience fit</text>
-      <text x="217" y="230" fill="#f2b705">+3x</text>
-      <rect x="65" y="264" width="198" height="44" rx="8" fill="#121821" stroke="#334050" />
-      <text x="82" y="292" fill="#f7f3e8">Execution quality</text>
-      <text x="217" y="292" fill="#f2b705">+3x</text>
-      <rect x="65" y="320" width="198" height="30" rx="8" fill="#2dd4bf" fill-opacity="0.16" stroke="#2dd4bf" />
-      <text x="82" y="341" fill="#2dd4bf">Help open</text>
+    <rect x="44" y="132" width="224" height="248" rx="8" fill="#191f29" stroke="#334050" />
+    <text x="66" y="164" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">Criteria</text>
+    <g font-family="Inter, Arial, sans-serif" font-size="14" font-weight="700">
+      <rect x="65" y="176" width="182" height="52" rx="8" fill="#121821" stroke="#334050" />
+      <text x="80" y="198" fill="#f7f3e8">Originality and</text>
+      <text x="80" y="218" fill="#f7f3e8">audience fit</text>
+      <text x="210" y="218" fill="#f2b705">+3x</text>
+      <rect x="65" y="240" width="182" height="36" rx="8" fill="#121821" stroke="#334050" />
+      <text x="80" y="264" fill="#f7f3e8">Execution quality</text>
+      <text x="210" y="264" fill="#f2b705">+3x</text>
+      <rect x="65" y="288" width="182" height="36" rx="8" fill="#121821" stroke="#334050" />
+      <text x="80" y="312" fill="#f7f3e8">Clarity</text>
+      <text x="210" y="312" fill="#aab3bd">+2x</text>
+      <rect x="65" y="336" width="182" height="30" rx="8" fill="#2dd4bf" fill-opacity="0.14" stroke="#2dd4bf" stroke-opacity="0.5" />
+      <text x="80" y="357" fill="#2dd4bf">Risk</text>
+      <text x="210" y="357" fill="#ff6b6b">-2x</text>
     </g>
   </g>
 
+  <!-- Leaderboard + verdict panel -->
   <g filter="url(#shadow)">
-    <rect x="314" y="132" width="204" height="248" rx="8" fill="#191f29" stroke="#334050" />
-    <text x="336" y="164" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="800">
-      Radar
-    </text>
-    <g transform="translate(416 264)">
-      <polygon points="0,-74 64,-23 40,60 -40,60 -64,-23" fill="none" stroke="#334050" stroke-width="2" />
-      <polygon points="0,-48 42,-15 26,39 -26,39 -42,-15" fill="none" stroke="#334050" stroke-width="2" />
-      <line x1="0" y1="0" x2="0" y2="-74" stroke="#334050" />
-      <line x1="0" y1="0" x2="64" y2="-23" stroke="#334050" />
-      <line x1="0" y1="0" x2="40" y2="60" stroke="#334050" />
-      <line x1="0" y1="0" x2="-40" y2="60" stroke="#334050" />
-      <line x1="0" y1="0" x2="-64" y2="-23" stroke="#334050" />
-      <polygon points="0,-64 52,-18 24,50 -30,44 -50,-18" fill="#2dd4bf" fill-opacity="0.28" stroke="#2dd4bf" stroke-width="4" />
-      <polygon points="0,-38 58,-12 34,35 -18,55 -42,-9" fill="#f2b705" fill-opacity="0.22" stroke="#f2b705" stroke-width="4" />
-    </g>
+    <rect x="288" y="132" width="220" height="248" rx="8" fill="#191f29" stroke="#334050" />
+    <text x="310" y="164" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">Leaderboard</text>
+    <rect x="310" y="174" width="174" height="46" rx="8" fill="url(#gold)" />
+    <text x="330" y="203" fill="#101319" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="900">1  Aster Labs  42.8</text>
+    <rect x="310" y="232" width="154" height="30" rx="8" fill="#2dd4bf" fill-opacity="0.8" />
+    <text x="326" y="252" fill="#071313" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="900">2  Northstar  35.6</text>
+    <rect x="310" y="274" width="134" height="30" rx="8" fill="#74a7ff" fill-opacity="0.75" />
+    <text x="326" y="294" fill="#071313" font-family="Inter, Arial, sans-serif" font-size="14" font-weight="900">3  Bright Forge  31.4</text>
+    <!-- verdict bar -->
+    <rect x="310" y="322" width="174" height="42" rx="8" fill="url(#verdictGrad)" stroke="#2dd4bf" stroke-opacity="0.5" />
+    <text x="323" y="339" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="11">Aster Labs leads with</text>
+    <text x="323" y="355" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="11">42.8 pts · 7.2-pt edge</text>
   </g>
 
+  <!-- Score matrix panel -->
   <g filter="url(#shadow)">
-    <rect x="544" y="132" width="212" height="248" rx="8" fill="#191f29" stroke="#334050" />
-    <text x="566" y="164" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="800">
-      Leaderboard
-    </text>
-    <rect x="566" y="190" width="166" height="48" rx="24" fill="url(#gold)" />
-    <text x="586" y="222" fill="#101319" font-family="Inter, Arial, sans-serif" font-size="19" font-weight="900">
-      1 Aster 42.8
-    </text>
-    <rect x="566" y="254" width="138" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.82" />
-    <text x="582" y="275" fill="#071313" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="900">
-      Northstar 35.6
-    </text>
-    <rect x="566" y="304" width="118" height="30" rx="15" fill="#74a7ff" fill-opacity="0.82" />
-    <text x="582" y="325" fill="#071313" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="900">
-      Forge 31.4
-    </text>
-    <rect x="566" y="346" width="130" height="16" rx="8" fill="#334050" />
-    <rect x="566" y="346" width="65" height="16" rx="8" fill="#2dd4bf" />
-    <text x="704" y="360" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="800">
-      50%
-    </text>
+    <rect x="530" y="132" width="226" height="248" rx="8" fill="#191f29" stroke="#334050" />
+    <text x="552" y="164" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="800">Score Matrix</text>
+    <!-- header row -->
+    <text x="552" y="194" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="11" font-weight="800">CRITERION</text>
+    <text x="672" y="194" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="11" font-weight="800">ASTER</text>
+    <text x="718" y="194" fill="#aab3bd" font-family="Inter, Arial, sans-serif" font-size="11" font-weight="800">NTH</text>
+    <!-- row 1 -->
+    <line x1="534" y1="202" x2="750" y2="202" stroke="#334050" />
+    <text x="552" y="220" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="13">Originality</text>
+    <rect x="666" y="210" width="36" height="8" rx="4" fill="#334050" />
+    <rect x="666" y="210" width="30" height="8" rx="4" fill="#2dd4bf" />
+    <rect x="712" y="210" width="28" height="8" rx="4" fill="#334050" />
+    <rect x="712" y="210" width="20" height="8" rx="4" fill="#2dd4bf" />
+    <!-- row 2 -->
+    <line x1="534" y1="228" x2="750" y2="228" stroke="#334050" />
+    <text x="552" y="248" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="13">Execution</text>
+    <rect x="666" y="238" width="36" height="8" rx="4" fill="#334050" />
+    <rect x="666" y="238" width="22" height="8" rx="4" fill="#f2b705" />
+    <rect x="712" y="238" width="28" height="8" rx="4" fill="#334050" />
+    <rect x="712" y="238" width="28" height="8" rx="4" fill="#f2b705" />
+    <!-- row 3 -->
+    <line x1="534" y1="256" x2="750" y2="256" stroke="#334050" />
+    <text x="552" y="276" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="13">Clarity</text>
+    <rect x="666" y="266" width="36" height="8" rx="4" fill="#334050" />
+    <rect x="666" y="266" width="32" height="8" rx="4" fill="#74a7ff" />
+    <rect x="712" y="266" width="28" height="8" rx="4" fill="#334050" />
+    <rect x="712" y="266" width="16" height="8" rx="4" fill="#74a7ff" />
+    <!-- row 4 -->
+    <line x1="534" y1="284" x2="750" y2="284" stroke="#334050" />
+    <text x="552" y="304" fill="#f7f3e8" font-family="Inter, Arial, sans-serif" font-size="13">Risk</text>
+    <rect x="666" y="294" width="36" height="8" rx="4" fill="#334050" />
+    <rect x="666" y="294" width="12" height="8" rx="4" fill="#ff6b6b" />
+    <rect x="712" y="294" width="28" height="8" rx="4" fill="#334050" />
+    <rect x="712" y="294" width="20" height="8" rx="4" fill="#ff6b6b" />
+    <line x1="534" y1="310" x2="750" y2="310" stroke="#334050" />
+    <!-- export button hint -->
+    <rect x="552" y="336" width="100" height="28" rx="8" fill="#2dd4bf" fill-opacity="0.18" stroke="#2dd4bf" stroke-opacity="0.5" />
+    <text x="572" y="355" fill="#2dd4bf" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="800">Export PNG</text>
+    <rect x="664" y="336" width="80" height="28" rx="8" fill="#f2b705" fill-opacity="0.22" stroke="#f2b705" stroke-opacity="0.5" />
+    <text x="678" y="355" fill="#f2b705" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="800">Reveal</text>
   </g>
 
+  <!-- trophy badge -->
   <g>
     <circle cx="705" cy="69" r="25" fill="url(#gold)" filter="url(#titleGlow)" />
     <path d="M692 68l9 9 18-22" fill="none" stroke="#101319" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" />

--- a/data/apps.json
+++ b/data/apps.json
@@ -2,7 +2,7 @@
   {
     "id": "2026/05/23/rubric-showdown",
     "name": "Rubric Showdown",
-    "shortDescription": "Build weighted rubrics, score multiple competitors side-by-side, compare category strengths on a radar chart, and export a winner scorecard.",
+    "shortDescription": "Build weighted rubrics, score multiple competitors side-by-side, watch a live leaderboard with instant verdict, and export a winner scorecard.",
     "thumbnailUrl": "/apps/2026/05/23/rubric-showdown/thumbnail.svg",
     "createdAt": "2026-05-23T15:05:07Z",
     "year": 2026,
@@ -11,7 +11,7 @@
     "category": "Utilities",
     "inputMode": "responsive",
     "status": "active",
-    "tags": ["rubric", "scoring", "ranking", "charts", "comparison", "export"],
+    "tags": ["rubric", "scoring", "ranking", "comparison", "export", "leaderboard"],
     "route": "/apps/2026/05/23/rubric-showdown",
     "appPath": "/apps/2026/05/23/rubric-showdown/index.html",
     "generation": {
@@ -50,6 +50,16 @@
         "implementedAt": "2026-05-23T16:47:15Z",
         "agentName": "Codex",
         "llmModel": "GPT-5"
+      },
+      {
+        "issueNumber": 445,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/445",
+        "runId": "run-20260523T173416Z-4823fc",
+        "description": "Moved verdict above score matrix. Removed criterion category option, chart.js CDN dependency, radar chart, updateChart() and criteriaByCategory() functions. Simplified leaderboard and matrix to remove category references.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-05-23T17:42:15Z",
+        "agentName": "Claude",
+        "llmModel": "claude-sonnet-4-6"
       }
     ],
     "allowImprovements": true,
@@ -65,6 +75,11 @@
         "runId": "run-20260523T164715Z-ef5d6b",
         "path": "backups/run-20260523T164715Z-ef5d6b/index.html",
         "url": "/apps/2026/05/23/rubric-showdown/backups/run-20260523T164715Z-ef5d6b/index.html"
+      },
+      {
+        "runId": "run-20260523T173416Z-4823fc",
+        "path": "backups/run-20260523T173416Z-4823fc/index.html",
+        "url": "/apps/2026/05/23/rubric-showdown/backups/run-20260523T173416Z-4823fc/index.html"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Removes chart.js CDN `<script src>` tag (third-party security requirement)
- Removes radar chart canvas, CSS, and all related functions (`updateChart`, `criteriaByCategory`)
- Removes criterion category option from the rubric builder UI
- Moves verdict text above the score matrix for better readability
- Simplifies leaderboard mini-text and matrix criterion rows (no category references)
- Updates thumbnail to show score matrix panel instead of radar chart
- Updates `shortDescription` and tags in `meta.json`

## Test plan

- [ ] Leaderboard renders with score and confidence % (no topCategory reference)
- [ ] Score matrix sliders update leaderboard without errors
- [ ] Confidence sliders update leaderboard without errors
- [ ] No `updateChart` or `criteriaByCategory` references remain in the HTML
- [ ] No `chart.js` or CDN script tags present
- [ ] Verdict paragraph appears above score matrix
- [ ] Help dialog text no longer references radar chart or category selection
- [ ] `npm run validate:apps` passes
- [ ] `npm run lint` passes with 0 warnings

Closes #445

🤖 Generated with [Claude Code](https://claude.ai/claude-code)