### PR TITLE
improve(duck-flight): canvas UI overhaul — menu, HUD, game-over screen (#469)

### DIFF
--- a/apps/2026/05/24/duck-flight/index.html
+++ b/apps/2026/05/24/duck-flight/index.html
@@ -65,69 +65,11 @@
         image-rendering: crisp-edges;
       }
 
-      #overlay {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background: rgba(0, 0, 0, 0.72);
-        gap: 16px;
-        padding: 24px;
-      }
-
-      #overlay.hidden { display: none; }
-
-      #overlay h1 {
-        font-size: clamp(28px, 7vw, 48px);
-        font-weight: 900;
-        letter-spacing: -1px;
-        color: #fbbf24;
-        text-shadow: 0 0 20px rgba(251, 191, 36, 0.6);
-      }
-
-      #overlay p {
-        font-size: clamp(13px, 3.5vw, 17px);
-        color: #cbd5e1;
-        text-align: center;
-        max-width: 340px;
-        line-height: 1.55;
-      }
-
-      #overlay .score-display {
-        font-size: clamp(22px, 6vw, 38px);
-        font-weight: 800;
-        color: #fbbf24;
-      }
-
-      #start-btn {
-        margin-top: 8px;
-        padding: 14px 36px;
-        font-size: 18px;
-        font-weight: 700;
-        border: none;
-        border-radius: 10px;
-        background: #f59e0b;
-        color: #000;
-        cursor: pointer;
-        transition: background 0.15s;
-      }
-      #start-btn:hover { background: #fbbf24; }
     </style>
   </head>
   <body>
     <div id="game-wrap">
       <canvas id="canvas"></canvas>
-      <div id="overlay">
-        <h1>🦆 Duck Flight</h1>
-        <p>Fly through rings as a duck in first-person view.<br>
-           Steer left/right to pass through rings.<br>
-           Miss too many and you lose momentum — crash!</p>
-        <p><strong>Desktop:</strong> Arrow keys or A/D<br>
-           <strong>Mobile:</strong> Tap left/right side of screen</p>
-        <button id="start-btn">Start Flying</button>
-      </div>
     </div>
 
     <script>
@@ -191,6 +133,7 @@
     let shakeAmt = 0;        // current screen-shake amplitude in logical pixels
     let fogDepthMod = 1.0;   // fog density multiplier (1=normal, ramps up during stall)
     let popups = [];         // score popup text objects {x, y, vy, life}
+    let bestScore = parseInt(localStorage.getItem('duckFlight_best') || '0', 10);
 
     // Input state
     const input = {
@@ -400,6 +343,9 @@
         const tag = document.activeElement?.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
         if (document.querySelector('.voa-lb-backdrop.open, .voa-share-backdrop.open')) return;
+        if ((e.key === ' ' || e.key === 'Enter') && (state === STATE.MENU || state === STATE.GAMEOVER)) {
+          startGame(); return;
+        }
         if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') input.left = true;
         if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') input.right = true;
       });
@@ -412,6 +358,7 @@
       });
 
       canvas.addEventListener('pointerdown', e => {
+        if (state === STATE.MENU || state === STATE.GAMEOVER) { startGame(); return; }
         const rect = canvas.getBoundingClientRect();
         const cx = (e.clientX - rect.left) / scale;
         if (cx < LOGICAL_W / 2) {
@@ -925,41 +872,193 @@
     }
 
     function drawHUD() {
-      // Score
+      if (!duck) return;
+      const H = LOGICAL_H;
       ctx.save();
+
+      // Score — large numerals, top-left with outline
+      const scoreSize = Math.round(H * 0.052);
+      ctx.font = `bold ${scoreSize}px system-ui, sans-serif`;
+      ctx.textAlign = 'left';
+      ctx.strokeStyle = 'rgba(0,0,0,0.65)';
+      ctx.lineWidth = 4;
+      ctx.lineJoin = 'round';
+      ctx.strokeText(String(duck.score), 14, scoreSize + 6);
       ctx.fillStyle = '#fbbf24';
-      ctx.font = 'bold 22px system-ui, sans-serif';
-      ctx.textAlign = 'left';
-      ctx.fillText('Score: ' + duck.score, 14, 32);
+      ctx.fillText(String(duck.score), 14, scoreSize + 6);
 
-      // Momentum bar
-      const barW = 120;
-      const barH = 10;
-      const bx = LOGICAL_W - barW - 14;
-      const by = 18;
-
-      ctx.fillStyle = 'rgba(0,0,0,0.5)';
-      ctx.beginPath();
-      ctx.roundRect(bx, by, barW, barH, 4);
-      ctx.fill();
-
-      const pct = duck.momentum / MOMENTUM_MAX;
+      // Momentum bar — centered at top, thin (6px)
+      const barW = Math.round(LOGICAL_W * 0.44);
+      const barH = 6;
+      const bx = (LOGICAL_W - barW) / 2;
+      const by = 10;
+      const pct = Math.max(0, duck.momentum / MOMENTUM_MAX);
       const barColor = pct > 0.6 ? '#34d399' : pct > 0.3 ? '#fbbf24' : '#ef4444';
-      ctx.fillStyle = barColor;
+
+      ctx.fillStyle = 'rgba(0,0,0,0.52)';
       ctx.beginPath();
-      ctx.roundRect(bx, by, barW * pct, barH, 4);
+      ctx.roundRect(bx, by, barW, barH, 3);
       ctx.fill();
 
-      ctx.fillStyle = '#f9fafb';
-      ctx.font = '11px system-ui, sans-serif';
-      ctx.textAlign = 'right';
-      ctx.fillText('Momentum', bx - 6, by + 9);
+      if (pct > 0) {
+        const pulse = pct < 0.3 ? 0.6 + 0.4 * Math.sin(performance.now() / 220) : 1;
+        ctx.globalAlpha = pulse;
+        ctx.fillStyle = barColor;
+        ctx.beginPath();
+        ctx.roundRect(bx, by, Math.max(barH, barW * pct), barH, 3);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+      }
 
-      // Misses
-      ctx.textAlign = 'left';
-      ctx.font = '13px system-ui, sans-serif';
-      ctx.fillStyle = '#fca5a5';
-      ctx.fillText('Misses: ' + duck.misses, 14, 52);
+      ctx.restore();
+    }
+
+    function drawMenuDuck(cx, cy) {
+      const t = performance.now() / 1000;
+      const flap = Math.sin(t * 3.2) * 20;
+      ctx.save();
+
+      // Left wing
+      const lg = ctx.createLinearGradient(cx - 70, cy + flap, cx, cy - 10);
+      lg.addColorStop(0, '#3d1505');
+      lg.addColorStop(1, '#a35215');
+      ctx.fillStyle = lg;
+      ctx.globalAlpha = 0.88;
+      ctx.beginPath();
+      ctx.moveTo(cx - 10, cy - 6);
+      ctx.bezierCurveTo(cx - 28, cy - 18 - flap, cx - 56, cy - 8 - flap, cx - 70, cy + flap + 8);
+      ctx.bezierCurveTo(cx - 48, cy + 16, cx - 20, cy + 10, cx - 8, cy + 4);
+      ctx.closePath();
+      ctx.fill();
+
+      // Right wing
+      const rg = ctx.createLinearGradient(cx + 70, cy + flap, cx, cy - 10);
+      rg.addColorStop(0, '#3d1505');
+      rg.addColorStop(1, '#a35215');
+      ctx.fillStyle = rg;
+      ctx.beginPath();
+      ctx.moveTo(cx + 10, cy - 6);
+      ctx.bezierCurveTo(cx + 28, cy - 18 - flap, cx + 56, cy - 8 - flap, cx + 70, cy + flap + 8);
+      ctx.bezierCurveTo(cx + 48, cy + 16, cx + 20, cy + 10, cx + 8, cy + 4);
+      ctx.closePath();
+      ctx.fill();
+
+      // Body
+      ctx.globalAlpha = 0.96;
+      ctx.fillStyle = '#78350f';
+      ctx.beginPath();
+      ctx.ellipse(cx, cy, 12, 16, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Head
+      ctx.beginPath();
+      ctx.ellipse(cx, cy - 20, 8, 9, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Beak
+      ctx.fillStyle = '#e8c84a';
+      ctx.globalAlpha = 0.92;
+      ctx.beginPath();
+      ctx.moveTo(cx - 5, cy - 27);
+      ctx.lineTo(cx, cy - 34);
+      ctx.lineTo(cx + 5, cy - 27);
+      ctx.closePath();
+      ctx.fill();
+
+      ctx.restore();
+    }
+
+    function drawMenu() {
+      const W = LOGICAL_W;
+      const H = LOGICAL_H;
+
+      // Dark overlay on world background
+      ctx.fillStyle = 'rgba(0,10,30,0.54)';
+      ctx.fillRect(0, 0, W, H);
+
+      ctx.save();
+      ctx.textAlign = 'center';
+
+      // Duck silhouette (hovering, animated)
+      const bob = Math.sin(performance.now() / 580) * 5;
+      drawMenuDuck(W / 2, H * 0.34 + bob);
+
+      // Title
+      const titleSize = Math.round(H * 0.078);
+      ctx.font = `900 ${titleSize}px system-ui, sans-serif`;
+      ctx.lineJoin = 'round';
+      ctx.strokeStyle = 'rgba(0,0,0,0.72)';
+      ctx.lineWidth = 6;
+      ctx.strokeText('DUCK FLIGHT', W / 2, H * 0.56);
+      ctx.shadowColor = 'rgba(251,191,36,0.55)';
+      ctx.shadowBlur = 22;
+      ctx.fillStyle = '#fbbf24';
+      ctx.fillText('DUCK FLIGHT', W / 2, H * 0.56);
+      ctx.shadowBlur = 0;
+
+      // Subtitle
+      const subSize = Math.round(H * 0.026);
+      ctx.font = `${subSize}px system-ui, sans-serif`;
+      ctx.fillStyle = '#cbd5e1';
+      ctx.fillText('Tap to begin', W / 2, H * 0.67);
+      ctx.fillText('Hold left or right to steer', W / 2, H * 0.67 + subSize * 1.6);
+
+      // Best score if non-zero
+      if (bestScore > 0) {
+        ctx.font = `${Math.round(H * 0.022)}px system-ui, sans-serif`;
+        ctx.fillStyle = 'rgba(251,191,36,0.55)';
+        ctx.fillText(`Best: ${bestScore}`, W / 2, H * 0.79);
+      }
+
+      ctx.restore();
+    }
+
+    function drawGameOver() {
+      const W = LOGICAL_W;
+      const H = LOGICAL_H;
+
+      // Dark overlay
+      ctx.fillStyle = 'rgba(0,0,0,0.68)';
+      ctx.fillRect(0, 0, W, H);
+
+      ctx.save();
+      ctx.textAlign = 'center';
+
+      // "GAME OVER"
+      const goSize = Math.round(H * 0.072);
+      ctx.font = `900 ${goSize}px system-ui, sans-serif`;
+      ctx.lineJoin = 'round';
+      ctx.strokeStyle = 'rgba(0,0,0,0.82)';
+      ctx.lineWidth = 6;
+      ctx.strokeText('GAME OVER', W / 2, H * 0.30);
+      ctx.shadowColor = 'rgba(239,68,68,0.55)';
+      ctx.shadowBlur = 18;
+      ctx.fillStyle = '#ef4444';
+      ctx.fillText('GAME OVER', W / 2, H * 0.30);
+      ctx.shadowBlur = 0;
+
+      // Final score — large
+      const scoreSize = Math.round(H * 0.10);
+      ctx.font = `bold ${scoreSize}px system-ui, sans-serif`;
+      ctx.strokeStyle = 'rgba(0,0,0,0.65)';
+      ctx.lineWidth = 4;
+      ctx.strokeText(String(duck ? duck.score : 0), W / 2, H * 0.48);
+      ctx.fillStyle = '#fbbf24';
+      ctx.fillText(String(duck ? duck.score : 0), W / 2, H * 0.48);
+
+      // Best score
+      const labelSize = Math.round(H * 0.025);
+      ctx.font = `${labelSize}px system-ui, sans-serif`;
+      ctx.fillStyle = '#94a3b8';
+      ctx.fillText(`Best: ${bestScore}`, W / 2, H * 0.57);
+
+      // Pulsing "Tap to retry"
+      const pulse = 0.5 + 0.5 * Math.sin(performance.now() / 580);
+      ctx.globalAlpha = pulse;
+      ctx.font = `${Math.round(H * 0.030)}px system-ui, sans-serif`;
+      ctx.fillStyle = '#f9fafb';
+      ctx.fillText('Tap to retry', W / 2, H * 0.70);
+      ctx.globalAlpha = 1;
 
       ctx.restore();
     }
@@ -1055,6 +1154,11 @@
       const rawDt = Math.min((ts - lastTime) / 1000, 0.1);
       lastTime = ts;
 
+      if (state === STATE.MENU) {
+        Anim.update(rawDt);
+        return;
+      }
+
       if (state === STATE.STALLING) {
         stallTimer -= rawDt;
         // Slow-mo: effective dt shrinks from full speed to near-zero as stall progresses
@@ -1098,6 +1202,14 @@
     function draw() {
       ctx.clearRect(0, 0, LOGICAL_W, LOGICAL_H);
 
+      drawSky();
+      drawGround();
+
+      if (state === STATE.MENU) {
+        drawMenu();
+        return;
+      }
+
       // Screen shake: translate canvas during stall onset
       const shaking = shakeAmt > 0.5;
       if (shaking) {
@@ -1108,8 +1220,6 @@
         );
       }
 
-      drawSky();
-      drawGround();
       drawSpeedLines();
       drawShapes();
       drawParticles();
@@ -1132,6 +1242,7 @@
       drawInputHints();
       if (state === STATE.PLAYING || state === STATE.STALLING) drawHUD();
       drawPopups();
+      if (state === STATE.GAMEOVER) drawGameOver();
     }
 
     function loop(ts) {
@@ -1162,7 +1273,6 @@
       fogDepthMod = 1.0;
       popups = [];
       state = STATE.PLAYING;
-      document.getElementById('overlay').classList.add('hidden');
       lastTime = performance.now();
       if (animId) cancelAnimationFrame(animId);
       animId = requestAnimationFrame(loop);
@@ -1170,7 +1280,11 @@
 
     function endGame() {
       state = STATE.GAMEOVER;
-      showGameOver();
+
+      if (duck.score > bestScore) {
+        bestScore = duck.score;
+        localStorage.setItem('duckFlight_best', String(bestScore));
+      }
 
       if (!scoreSubmitted && duck.score > 0) {
         scoreSubmitted = true;
@@ -1180,33 +1294,10 @@
       }
     }
 
-    function showGameOver() {
-      const overlay = document.getElementById('overlay');
-      overlay.innerHTML = `
-        <h1>Game Over</h1>
-        <p class="score-display">Score: ${duck.score}</p>
-        <p>Misses: ${duck.misses}<br>You ran out of momentum!</p>
-        <button id="start-btn">Fly Again</button>
-      `;
-      overlay.classList.remove('hidden');
-      document.getElementById('start-btn').addEventListener('click', startGame);
-    }
-
     // ─── Boot ─────────────────────────────────────────────────────────────────────
     setupInput();
-    document.getElementById('start-btn').addEventListener('click', startGame);
-
-    // Idle render loop while on menu/gameover (so background animates)
-    function idleDraw() {
-      if (state !== STATE.PLAYING) {
-        ctx.clearRect(0, 0, LOGICAL_W, LOGICAL_H);
-        drawSky();   // reuse the shared sky (includes animated clouds)
-        drawGround();
-      }
-      if (state !== STATE.PLAYING) requestAnimationFrame(idleDraw);
-    }
-
-    requestAnimationFrame(idleDraw);
+    lastTime = performance.now();
+    animId = requestAnimationFrame(loop);
     </script>
   </body>
 </html>

--- a/apps/2026/05/24/duck-flight/meta.json
+++ b/apps/2026/05/24/duck-flight/meta.json
@@ -87,6 +87,16 @@
       "implementedAt": "2026-05-25T04:42:00Z",
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
+    },
+    {
+      "issueNumber": 469,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/469",
+      "runId": "run-20260525T045401Z-b7c2d8",
+      "description": "Canvas-only UI overhaul: removed DOM #overlay; MENU state shows animated world background with hovering duck silhouette (flapping wings, body, beak), 'DUCK FLIGHT' title with gold glow, subtitle, and persisted best score; HUD redesigned to large outlined score numerals (top-left) + thin centered momentum bar (green-amber-red, pulses below 30%); GAMEOVER state renders dimmed world, red 'GAME OVER', large final score, best score, and pulsing 'Tap to retry'; best score persisted to localStorage; tap/Space/Enter start/retry from canvas; main loop runs continuously from boot.",
+      "requestor": "jeffholst",
+      "implementedAt": "2026-05-25T05:10:00Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
     }
   ]
 }

--- a/apps/2026/05/24/duck-flight/thumbnail.svg
+++ b/apps/2026/05/24/duck-flight/thumbnail.svg
@@ -217,15 +217,16 @@
   <!-- Vignette overlay -->
   <rect x="0" y="0" width="800" height="450" fill="url(#vignette)"/>
 
-  <!-- HUD panel -->
-  <rect x="10" y="10" width="155" height="58" rx="8" fill="url(#hudpanel)"/>
-  <text x="20" y="33" font-family="system-ui,sans-serif" font-weight="700" font-size="18" fill="#fbbf24">Score: 140</text>
-  <text x="20" y="54" font-family="system-ui,sans-serif" font-size="12" fill="#fca5a5">Misses: 1</text>
+  <!-- Score: large numerals, top-left, outlined -->
+  <text x="14" y="54" font-family="system-ui,sans-serif" font-weight="900" font-size="44"
+        fill="none" stroke="rgba(0,0,0,0.65)" stroke-width="4" stroke-linejoin="round"
+        paint-order="stroke">140</text>
+  <text x="14" y="54" font-family="system-ui,sans-serif" font-weight="900" font-size="44"
+        fill="#fbbf24">140</text>
 
-  <!-- Momentum bar -->
-  <text x="638" y="24" font-family="system-ui,sans-serif" font-size="11" fill="#cbd5e1" text-anchor="end">Momentum</text>
-  <rect x="642" y="14" width="146" height="10" rx="5" fill="rgba(0,0,0,0.5)"/>
-  <rect x="642" y="14" width="112" height="10" rx="5" fill="#34d399"/>
+  <!-- Momentum bar: centered at top, thin (8px) -->
+  <rect x="224" y="14" width="352" height="8" rx="4" fill="rgba(0,0,0,0.52)"/>
+  <rect x="224" y="14" width="270" height="8" rx="4" fill="#34d399"/>
 
   <!-- Title hint -->
   <text x="400" y="444" font-family="system-ui,sans-serif" font-size="13" fill="rgba(255,255,255,0.25)" text-anchor="middle">Duck Flight</text>

--- a/data/apps.json
+++ b/data/apps.json
@@ -90,6 +90,16 @@
         "implementedAt": "2026-05-25T04:42:00Z",
         "agentName": "Claude Code",
         "llmModel": "claude-sonnet-4-6"
+      },
+      {
+        "issueNumber": 469,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/469",
+        "runId": "run-20260525T045401Z-b7c2d8",
+        "description": "Canvas-only UI overhaul: removed DOM #overlay; MENU state shows animated world background with hovering duck silhouette (flapping wings, body, beak), 'DUCK FLIGHT' title with gold glow, subtitle, and persisted best score; HUD redesigned to large outlined score numerals (top-left) + thin centered momentum bar (green-amber-red, pulses below 30%); GAMEOVER state renders dimmed world, red 'GAME OVER', large final score, best score, and pulsing 'Tap to retry'; best score persisted to localStorage; tap/Space/Enter start/retry from canvas; main loop runs continuously from boot.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-05-25T05:10:00Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ],
     "allowImprovements": true,
@@ -125,6 +135,11 @@
         "runId": "run-20260525T044200Z-e8d3a2",
         "path": "backups/run-20260525T044200Z-e8d3a2/index.html",
         "url": "/apps/2026/05/24/duck-flight/backups/run-20260525T044200Z-e8d3a2/index.html"
+      },
+      {
+        "runId": "run-20260525T045401Z-b7c2d8",
+        "path": "backups/run-20260525T045401Z-b7c2d8/index.html",
+        "url": "/apps/2026/05/24/duck-flight/backups/run-20260525T045401Z-b7c2d8/index.html"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- **MENU**: Animated world background with hovering duck silhouette (flapping wings), gold glowing "DUCK FLIGHT" title, "Tap to begin / Hold left or right to steer" subtitle, and persisted best score shown if non-zero
- **HUD**: Redesigned to large outlined score numerals (top-left, scales with canvas height) + centered thin 6px momentum bar that color-shifts green→amber→red and pulses when in stall range (< 30%)
- **GAMEOVER**: Dimmed world, red "GAME OVER" with glow, large final score, best score, pulsing "Tap to retry"
- **Architecture**: DOM `#overlay` removed entirely; all UI rendered on canvas; `loop()` runs continuously from boot (replaces `idleDraw()`); best score persisted to `localStorage`; tap/Space/Enter start/retry from any canvas state

## Test plan

- [ ] Load game — animated world background with duck silhouette and DUCK FLIGHT title renders
- [ ] Tap/click or press Space/Enter — game starts immediately from menu
- [ ] During play — score shows large gold numerals top-left; centered bar turns amber at low momentum and red+pulsing near stall
- [ ] Run out of momentum — GAME OVER screen appears with score and "Tap to retry"
- [ ] Retry — game resets cleanly; best score persists across page reloads
- [ ] Mobile — touch tap starts game and steers correctly

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)