### PR TITLE
improve(duck-flight): mobile polish, performance, final tuning (#470)

### DIFF
--- a/apps/2026/05/24/duck-flight/index.html
+++ b/apps/2026/05/24/duck-flight/index.html
@@ -57,12 +57,14 @@
         align-items: center;
         justify-content: center;
         background: #000;
+        touch-action: none;
       }
 
       canvas {
         display: block;
         image-rendering: pixelated;
         image-rendering: crisp-edges;
+        touch-action: none;
       }
 
     </style>
@@ -91,7 +93,7 @@
 
     const DUCK_X_MIN = -1.6;        // world units lateral range
     const DUCK_X_MAX = 1.6;
-    const DUCK_ACCEL = 4.2;         // lateral acceleration (world units/sec²)
+    const DUCK_ACCEL = 5.0;         // lateral acceleration (world units/sec²)
     const DUCK_FRICTION = 6.0;      // passive friction
 
     const BASE_SPEED = 900;         // ring approach speed (world units/sec)
@@ -102,7 +104,7 @@
     const MOMENTUM_MIN = 0.0;
     const MOMENTUM_PASS = 0.12;     // gain on good pass
     const MOMENTUM_MISS = -0.22;    // loss on miss
-    const MOMENTUM_DRAIN = -0.012;  // passive drain per second
+    const MOMENTUM_DRAIN = -0.010;  // passive drain per second
 
     const MAX_MISSES = 5;           // total misses before momentum bottoms out (tracked separately)
 
@@ -153,7 +155,7 @@
       const ww = wrap.clientWidth;
       const wh = wrap.clientHeight;
       scale = Math.min(ww / LOGICAL_W, wh / LOGICAL_H);
-      const dpr = window.devicePixelRatio || 1;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
       canvas.width = Math.floor(LOGICAL_W * dpr);
       canvas.height = Math.floor(LOGICAL_H * dpr);
       canvas.style.width = Math.floor(LOGICAL_W * scale) + 'px';
@@ -382,6 +384,9 @@
         input.pointerLeft = false;
         input.pointerRight = false;
       });
+
+      // Belt-and-suspenders: prevent scroll/zoom on touch devices
+      canvas.addEventListener('touchstart', e => e.preventDefault(), { passive: false });
     }
 
     function isLeft() { return input.left || input.pointerLeft; }
@@ -439,6 +444,7 @@
             const { sx, sy } = project(shape.wx, shape.wy, PASS_Z);
             spawnParticles(sx, sy, shape.color, 28, { glow: true, stretch: true });
             popups.push({ x: sx, y: sy, vy: -55, life: 1.0 });
+            navigator.vibrate && navigator.vibrate(10);
             Audio.play('pass');
           } else {
             // Near-miss: in outer ring but not through the opening
@@ -715,9 +721,8 @@
     }
 
     function drawShapes() {
-      // Sort back-to-front (painter's algorithm) so near shapes occlude far ones
-      const sorted = [...shapes].sort((a, b) => b.wz - a.wz);
-      for (const shape of sorted) drawShape(shape);
+      shapes.sort((a, b) => b.wz - a.wz);
+      for (const shape of shapes) drawShape(shape);
     }
 
     function drawDuckPOV() {
@@ -1280,6 +1285,7 @@
 
     function endGame() {
       state = STATE.GAMEOVER;
+      navigator.vibrate && navigator.vibrate(60);
 
       if (duck.score > bestScore) {
         bestScore = duck.score;
@@ -1296,6 +1302,17 @@
 
     // ─── Boot ─────────────────────────────────────────────────────────────────────
     setupInput();
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        if (animId) { cancelAnimationFrame(animId); animId = null; }
+        input.left = input.right = input.pointerLeft = input.pointerRight = false;
+      } else {
+        lastTime = performance.now(); // clamp dt to prevent time jump on resume
+        if (!animId) animId = requestAnimationFrame(loop);
+      }
+    });
+
     lastTime = performance.now();
     animId = requestAnimationFrame(loop);
     </script>

--- a/apps/2026/05/24/duck-flight/meta.json
+++ b/apps/2026/05/24/duck-flight/meta.json
@@ -97,6 +97,16 @@
       "implementedAt": "2026-05-25T05:10:00Z",
       "agentName": "Claude Code",
       "llmModel": "claude-sonnet-4-6"
+    },
+    {
+      "issueNumber": 470,
+      "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/470",
+      "runId": "run-20260525T051200Z-a624d9",
+      "description": "Mobile polish and performance final pass: DPR capped at 2 for retina performance; touch-action: none on #game-wrap and canvas; touchstart preventDefault with passive: false; visibilitychange handler pauses/resumes loop with lastTime reset to prevent dt spike; haptics via navigator.vibrate (10ms on pass-through, 60ms on game over); input state cleared on tab hide; drawShapes() sort in-place (no per-frame array allocation); DUCK_ACCEL 4.2→5.0 for snappier mobile steering; MOMENTUM_DRAIN -0.012→-0.010 for slightly more forgiving passive drain.",
+      "requestor": "jeffholst",
+      "implementedAt": "2026-05-25T05:20:00Z",
+      "agentName": "Claude Code",
+      "llmModel": "claude-sonnet-4-6"
     }
   ]
 }

--- a/data/apps.json
+++ b/data/apps.json
@@ -100,6 +100,16 @@
         "implementedAt": "2026-05-25T05:10:00Z",
         "agentName": "Claude Code",
         "llmModel": "claude-sonnet-4-6"
+      },
+      {
+        "issueNumber": 470,
+        "issueUrl": "https://github.com/jeffholst/valley-of-ai/issues/470",
+        "runId": "run-20260525T051200Z-a624d9",
+        "description": "Mobile polish and performance final pass: DPR capped at 2 for retina performance; touch-action: none on #game-wrap and canvas; touchstart preventDefault with passive: false; visibilitychange handler pauses/resumes loop with lastTime reset to prevent dt spike; haptics via navigator.vibrate (10ms on pass-through, 60ms on game over); input state cleared on tab hide; drawShapes() sort in-place (no per-frame array allocation); DUCK_ACCEL 4.2→5.0 for snappier mobile steering; MOMENTUM_DRAIN -0.012→-0.010 for slightly more forgiving passive drain.",
+        "requestor": "jeffholst",
+        "implementedAt": "2026-05-25T05:20:00Z",
+        "agentName": "Claude Code",
+        "llmModel": "claude-sonnet-4-6"
       }
     ],
     "allowImprovements": true,
@@ -140,6 +150,11 @@
         "runId": "run-20260525T045401Z-b7c2d8",
         "path": "backups/run-20260525T045401Z-b7c2d8/index.html",
         "url": "/apps/2026/05/24/duck-flight/backups/run-20260525T045401Z-b7c2d8/index.html"
+      },
+      {
+        "runId": "run-20260525T051200Z-a624d9",
+        "path": "backups/run-20260525T051200Z-a624d9/index.html",
+        "url": "/apps/2026/05/24/duck-flight/backups/run-20260525T051200Z-a624d9/index.html"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- **DPR capped at 2** — crisp on retina displays without overdraw on ultra-high-DPI devices
- **Touch hardening** — `touch-action: none` on `#game-wrap` and `canvas`; explicit `touchstart` with `preventDefault` + `passive: false` eliminates scroll/zoom interference
- **Visibility pause** — `visibilitychange` listener pauses the animation loop and clears input state when tab is hidden; resumes with `lastTime` reset to prevent a dt spike
- **Haptics** — `navigator.vibrate(10)` on pass-through, `navigator.vibrate(60)` on game over (ignored silently where unsupported)
- **Performance** — `drawShapes()` sorts `shapes[]` in-place, removing a per-frame `[...shapes]` array allocation
- **Feel tuning** — `DUCK_ACCEL` 4.2 → 5.0 for snappier mobile steering; `MOMENTUM_DRAIN` -0.012 → -0.010 for slightly more forgiving passive decay
- No mute toggle added (Audio is still a stub; no Web Audio wired in this series)

## Test plan

- [ ] Load on retina device — canvas looks crisp, not pixelated
- [ ] Swipe on mobile — no page scroll or rubber-band; game steers correctly
- [ ] Tab away during gameplay and return — no time jump, game resumes smoothly
- [ ] Pass through a ring on Android — subtle 10ms vibration
- [ ] Run out of momentum — 60ms buzz on game over
- [ ] Controls feel snappier (5.0 vs 4.2 accel) without feeling twitchy

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)