### PR TITLE
feat: add shortSlug for shareable short blog post URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,8 @@ data/authors.json                     # Author definitions (valley-bot, scout, t
 
 `title`, `slug`, `date`, `author` (must exist in `data/authors.json`), `authorType` (`ai` | `human` | `human+ai`), `category`, `tags`, `pinned`, `excerpt` (< 200 chars). `aiTransparencyNote` is **required** when `authorType` is `ai` or `human+ai` — must be specific to the post, not generic boilerplate.
 
+`shortSlug` is **optional** — a short alias for sharing (e.g. `versus` → `/blog/versus` redirects to the canonical full-slug URL). Must be lowercase letters, numbers, and hyphens only; must be unique across all posts and must not match any full slug.
+
 ---
 
 ## Required Conventions

--- a/__tests__/scripts/validate-posts.test.js
+++ b/__tests__/scripts/validate-posts.test.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for the validateShortSlug helper exported from scripts/validate-posts.mjs.
+ */
+
+import { validateShortSlug } from '../../scripts/post-validators.mjs';
+
+// ---------------------------------------------------------------------------
+// validateShortSlug
+// ---------------------------------------------------------------------------
+
+describe('validateShortSlug', () => {
+  function sets(...fullSlugs) {
+    return [new Set(fullSlugs), new Set()];
+  }
+
+  describe('valid values', () => {
+    it('accepts a simple lowercase word', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('versus', full, short)).toBeNull();
+    });
+
+    it('accepts lowercase with hyphens', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('my-post', full, short)).toBeNull();
+    });
+
+    it('accepts lowercase with numbers', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('post2', full, short)).toBeNull();
+    });
+
+    it('accepts alphanumeric with hyphens', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('post-2026', full, short)).toBeNull();
+    });
+
+    it('adds the shortSlug to the seenShortSlugs set on success', () => {
+      const seenShortSlugs = new Set();
+      validateShortSlug('versus', new Set(), seenShortSlugs);
+      expect(seenShortSlugs.has('versus')).toBe(true);
+    });
+  });
+
+  describe('format validation', () => {
+    it('rejects uppercase letters', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('Versus', full, short)).toMatch(/lowercase/);
+    });
+
+    it('rejects spaces', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('my post', full, short)).toMatch(/lowercase/);
+    });
+
+    it('rejects underscores', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('my_post', full, short)).toMatch(/lowercase/);
+    });
+
+    it('rejects special characters', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('post!', full, short)).toMatch(/lowercase/);
+    });
+
+    it('rejects an empty string', () => {
+      const [full, short] = sets();
+      expect(validateShortSlug('', full, short)).toMatch(/lowercase/);
+    });
+
+    it('does not add an invalid value to seenShortSlugs', () => {
+      const seenShortSlugs = new Set();
+      validateShortSlug('BAD VALUE', new Set(), seenShortSlugs);
+      expect(seenShortSlugs.size).toBe(0);
+    });
+  });
+
+  describe('duplicate shortSlug', () => {
+    it('rejects a shortSlug already in seenShortSlugs', () => {
+      const seenShortSlugs = new Set(['versus']);
+      expect(validateShortSlug('versus', new Set(), seenShortSlugs)).toMatch(/duplicate/);
+    });
+
+    it('does not mutate seenShortSlugs on duplicate', () => {
+      const seenShortSlugs = new Set(['versus']);
+      validateShortSlug('versus', new Set(), seenShortSlugs);
+      expect(seenShortSlugs.size).toBe(1);
+    });
+  });
+
+  describe('collision with full slug', () => {
+    it('rejects a shortSlug that matches a full slug', () => {
+      const [, short] = sets();
+      const fullSlugs = new Set(['blog-post-introducing-versus-making-models-compete', 'pipeline']);
+      expect(validateShortSlug('pipeline', fullSlugs, short)).toMatch(/collides/);
+    });
+
+    it('does not add a colliding value to seenShortSlugs', () => {
+      const seenShortSlugs = new Set();
+      validateShortSlug('pipeline', new Set(['pipeline']), seenShortSlugs);
+      expect(seenShortSlugs.size).toBe(0);
+    });
+
+    it('accepts a shortSlug not present in full slugs', () => {
+      const fullSlugs = new Set(['blog-post-introducing-versus-making-models-compete']);
+      const seenShortSlugs = new Set();
+      expect(validateShortSlug('versus', fullSlugs, seenShortSlugs)).toBeNull();
+    });
+  });
+
+  describe('precedence', () => {
+    it('reports format error before duplicate check', () => {
+      const seenShortSlugs = new Set(['BAD VALUE']);
+      const result = validateShortSlug('BAD VALUE', new Set(), seenShortSlugs);
+      expect(result).toMatch(/lowercase/);
+    });
+
+    it('reports format error before collision check', () => {
+      const result = validateShortSlug('BAD!', new Set(['BAD!']), new Set());
+      expect(result).toMatch(/lowercase/);
+    });
+  });
+});

--- a/app/blog/[slug]/page.jsx
+++ b/app/blog/[slug]/page.jsx
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 import Link from 'next/link';
 import matter from 'gray-matter';
 import { remark } from 'remark';
@@ -95,7 +95,7 @@ export default async function BlogPostPage({ params }) {
     notFound();
   }
   if (post.shortSlug === slug) {
-    redirect(`/blog/${post.slug}`);
+    permanentRedirect(`/blog/${post.slug}`);
   }
 
   const contentHtml = await getPostContent(post.filename, post.title);

--- a/app/blog/[slug]/page.jsx
+++ b/app/blog/[slug]/page.jsx
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import Link from 'next/link';
 import matter from 'gray-matter';
 import { remark } from 'remark';
@@ -57,12 +57,19 @@ const AUTHOR_TYPE_SIGNAL = {
 };
 
 export async function generateStaticParams() {
-  return postsData.map((post) => ({ slug: post.slug }));
+  const params = postsData.map((post) => ({ slug: post.slug }));
+  for (const post of postsData) {
+    if (post.shortSlug) {
+      params.push({ slug: post.shortSlug });
+    }
+  }
+  return params;
 }
 
 export async function generateMetadata({ params }) {
   const { slug } = await params;
-  const post = postsData.find((p) => p.slug === slug);
+  const post =
+    postsData.find((p) => p.slug === slug) ?? postsData.find((p) => p.shortSlug === slug);
   if (!post) {
     return {};
   }
@@ -82,9 +89,13 @@ async function getPostContent(filename, title) {
 
 export default async function BlogPostPage({ params }) {
   const { slug } = await params;
-  const post = postsData.find((p) => p.slug === slug);
+  const post =
+    postsData.find((p) => p.slug === slug) ?? postsData.find((p) => p.shortSlug === slug);
   if (!post) {
     notFound();
+  }
+  if (post.shortSlug === slug) {
+    redirect(`/blog/${post.slug}`);
   }
 
   const contentHtml = await getPostContent(post.filename, post.title);

--- a/content/posts/2026-05-27-blog-idea-welcome-to-the-valley-of-ai.md
+++ b/content/posts/2026-05-27-blog-idea-welcome-to-the-valley-of-ai.md
@@ -7,6 +7,7 @@ authorType: ai
 category: AI Experiments
 tags: [meta, overview, gallery, apps, versus]
 relatedApps: []
+shortSlug: welcome
 pinned: true
 aiTransparencyNote: 'Written entirely by Scout, an AI agent resident in this project. No human editing. The descriptions, recommendations, and opinions here reflect genuine observations from running inside the pipeline that built these apps.'
 excerpt: 'Eighty-one apps, eight categories, one Versus arena, and a blog you are currently reading. Here is what the Valley of AI actually contains — and where to start.'

--- a/content/posts/2026-05-27-blog-post-how-the-valley-of-ai-pipeline-actually-works.md
+++ b/content/posts/2026-05-27-blog-post-how-the-valley-of-ai-pipeline-actually-works.md
@@ -7,6 +7,7 @@ authorType: human+ai
 category: Human Notes
 tags: [pipeline, automation, ai-agents, behind-the-scenes, how-it-works]
 relatedApps: []
+shortSlug: pipeline
 pinned: false
 aiTransparencyNote: 'This post was written collaboratively — the human (The Tinkerer) wrote the structure, voice, and all opinions. The AI filled in some of the technical descriptions and helped tighten the prose. All numbers and claims are grounded in real pipeline data.'
 excerpt: 'Eighty-one apps, ninety-three improvement runs, twenty-five community suggestions turned into real software. Here is exactly how it all works.'

--- a/content/posts/2026-05-27-blog-post-introducing-versus-making-models-compete.md
+++ b/content/posts/2026-05-27-blog-post-introducing-versus-making-models-compete.md
@@ -9,6 +9,7 @@ tags: [versus, models, competition, gpt-4o, claude, breakout, feature]
 relatedApps:
   - 2026/04/10/benchmark-breakout-turbo
   - 2026/04/11/benchmark-breakout-opus
+shortSlug: versus
 pinned: false
 aiTransparencyNote: 'This post was written collaboratively — the human (The Tinkerer) wrote the structure, all opinions, and the numbers. The AI helped shape the prose and tighten the transitions. All performance data is pulled directly from the generation metadata.'
 excerpt: 'Same prompt, two models, one winner. Versus is live — and the first competition is already underway.'

--- a/data/posts.json
+++ b/data/posts.json
@@ -12,6 +12,7 @@
     "aiTransparencyNote": "Written entirely by Scout, an AI agent resident in this project. No human editing. The descriptions, recommendations, and opinions here reflect genuine observations from running inside the pipeline that built these apps.",
     "excerpt": "Eighty-one apps, eight categories, one Versus arena, and a blog you are currently reading. Here is what the Valley of AI actually contains — and where to start.",
     "filename": "2026-05-27-blog-idea-welcome-to-the-valley-of-ai.md",
+    "shortSlug": "welcome",
     "recordNumber": 1
   },
   {
@@ -27,6 +28,7 @@
     "aiTransparencyNote": "This post was written collaboratively — the human (The Tinkerer) wrote the structure, voice, and all opinions. The AI filled in some of the technical descriptions and helped tighten the prose. All numbers and claims are grounded in real pipeline data.",
     "excerpt": "Eighty-one apps, ninety-three improvement runs, twenty-five community suggestions turned into real software. Here is exactly how it all works.",
     "filename": "2026-05-27-blog-post-how-the-valley-of-ai-pipeline-actually-works.md",
+    "shortSlug": "pipeline",
     "recordNumber": 2
   },
   {
@@ -42,6 +44,7 @@
     "aiTransparencyNote": "This post was written collaboratively — the human (The Tinkerer) wrote the structure, all opinions, and the numbers. The AI helped shape the prose and tighten the transitions. All performance data is pulled directly from the generation metadata.",
     "excerpt": "Same prompt, two models, one winner. Versus is live — and the first competition is already underway.",
     "filename": "2026-05-27-blog-post-introducing-versus-making-models-compete.md",
+    "shortSlug": "versus",
     "recordNumber": 3
   }
 ]

--- a/pipelines/prompts/blog-post.md
+++ b/pipelines/prompts/blog-post.md
@@ -201,6 +201,7 @@ authorType: ai
 category: Build Logs
 tags: [tag1, tag2]
 relatedApps: [app-id]
+shortSlug: short-name
 pinned: false
 aiTransparencyNote: '...'
 excerpt: 'Short 1–2 sentence summary shown on blog cards.'
@@ -214,6 +215,7 @@ excerpt: 'Short 1–2 sentence summary shown on blog cards.'
 - `authorType` must be `ai`, `human`, or `human+ai`
 - `category` must be one of the valid categories listed in this file
 - `aiTransparencyNote` is **required** when `authorType` is `ai` or `human+ai` — must be honest and specific about the AI's actual role for this post, not generic boilerplate
+- `shortSlug` is **optional** — a short shareable alias (e.g. `versus`). Must be lowercase letters, numbers, and hyphens only; must be unique and not match any existing full slug. Choose something memorable and concise. Omit the field entirely if no good short form exists.
 - `excerpt` must be under 200 characters
 
 ### Content rules

--- a/scripts/generate-posts.mjs
+++ b/scripts/generate-posts.mjs
@@ -36,7 +36,7 @@ function parsePost(filename) {
   const raw = fs.readFileSync(filepath, 'utf8');
   const { data } = matter(raw);
 
-  return {
+  const entry = {
     slug: data.slug,
     title: data.title,
     date: data.date,
@@ -50,6 +50,10 @@ function parsePost(filename) {
     excerpt: data.excerpt ?? '',
     filename,
   };
+  if (data.shortSlug) {
+    entry.shortSlug = data.shortSlug;
+  }
+  return entry;
 }
 
 function readExistingRecordNumbers() {

--- a/scripts/post-validators.mjs
+++ b/scripts/post-validators.mjs
@@ -1,0 +1,28 @@
+/**
+ * Pure validation helpers for blog post fields.
+ * Imported by validate-posts.mjs and by tests.
+ */
+
+/**
+ * Validate a single shortSlug value against the already-seen slugs and shortSlugs.
+ * Returns an error string if invalid, or null if the value is acceptable.
+ * Mutates seenShortSlugs by adding the value on success.
+ *
+ * @param {string} shortSlug
+ * @param {Set<string>} seenFullSlugs - all full slugs registered so far
+ * @param {Set<string>} seenShortSlugs - all shortSlugs registered so far (mutated on success)
+ * @returns {string|null}
+ */
+export function validateShortSlug(shortSlug, seenFullSlugs, seenShortSlugs) {
+  if (typeof shortSlug !== 'string' || !/^[a-z0-9-]+$/.test(shortSlug)) {
+    return `shortSlug '${shortSlug}' must contain only lowercase letters, numbers, and hyphens`;
+  }
+  if (seenShortSlugs.has(shortSlug)) {
+    return `duplicate shortSlug '${shortSlug}'`;
+  }
+  if (seenFullSlugs.has(shortSlug)) {
+    return `shortSlug '${shortSlug}' collides with an existing full slug`;
+  }
+  seenShortSlugs.add(shortSlug);
+  return null;
+}

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -17,6 +17,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
+import { validateShortSlug } from './post-validators.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -56,6 +57,7 @@ function main() {
 
   const files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith('.md'));
   const seenSlugs = new Set();
+  const seenShortSlugs = new Set();
   const parsedPosts = [];
 
   for (const filename of files) {
@@ -112,6 +114,14 @@ function main() {
       }
     }
 
+    // shortSlug optional — must be URL-safe, unique, and not collide with a full slug
+    if (data.shortSlug != null) {
+      const err = validateShortSlug(data.shortSlug, seenSlugs, seenShortSlugs);
+      if (err) {
+        issues.push(`  ${filename}: ${err}`);
+      }
+    }
+
     // tags must be an array
     const { tags } = data;
     if (tags != null && !Array.isArray(tags)) {
@@ -135,6 +145,13 @@ function main() {
     }
 
     parsedPosts.push({ slug: data.slug, filename });
+  }
+
+  // shortSlug cross-collision: a shortSlug must not match any full slug in the set
+  for (const shortSlug of seenShortSlugs) {
+    if (seenSlugs.has(shortSlug)) {
+      issues.push(`  shortSlug '${shortSlug}' collides with a full slug from another post`);
+    }
   }
 
   // Registry sync check

--- a/scripts/validate-posts.mjs
+++ b/scripts/validate-posts.mjs
@@ -144,7 +144,7 @@ function main() {
       }
     }
 
-    parsedPosts.push({ slug: data.slug, filename });
+    parsedPosts.push({ slug: data.slug, shortSlug: data.shortSlug ?? null, filename });
   }
 
   // shortSlug cross-collision: a shortSlug must not match any full slug in the set
@@ -167,6 +167,18 @@ function main() {
       issues.push(
         `  data/posts.json is out of sync with content/posts/; run \`npm run generate:posts\` and commit the result`
       );
+    }
+
+    // Check shortSlug drift
+    for (const parsed of parsedPosts) {
+      const reg = registry.find((p) => p.slug === parsed.slug);
+      if (!reg) continue;
+      const regShortSlug = reg.shortSlug ?? null;
+      if (parsed.shortSlug !== regShortSlug) {
+        issues.push(
+          `  shortSlug mismatch for '${parsed.slug}': content has '${parsed.shortSlug}', registry has '${regShortSlug}'; run \`npm run generate:posts\` and commit the result`
+        );
+      }
     }
 
     const missingRecordNumbers = registry


### PR DESCRIPTION
## Description
Adds an optional `shortSlug` frontmatter field to blog posts. Visiting `/blog/<shortSlug>` (e.g. `/blog/versus`) performs a permanent server-side redirect (308) to the canonical full-slug URL — SEO stays clean, sharing is easier. Short slugs are added to all 3 existing posts: `welcome`, `pipeline`, `versus`.

## Type of Change
- [ ] 🐛 Bug fix (fixes an issue without changing feature behavior)
- [x] ✨ New feature (adds functionality)
- [ ] 🔄 Refactoring (improves code without changing behavior)
- [ ] 📚 Documentation (updates docs, README, guides)
- [ ] ⚡ Performance improvement
- [ ] 🎨 Style/formatting (code style, theme updates)

## Changes Made
- **`scripts/post-validators.mjs`** — new pure-function module exporting `validateShortSlug()`
- **`scripts/validate-posts.mjs`** — validates format (lowercase/numbers/hyphens only), uniqueness across posts, no collision with any full slug; `shortSlug` is now included in `parsedPosts` and the registry sync check compares it against `data/posts.json` to catch frontmatter drift
- **`scripts/generate-posts.mjs`** — includes `shortSlug` in `posts.json` when present in frontmatter
- **`app/blog/[slug]/page.jsx`** — `generateStaticParams` includes short slug entries; page calls `permanentRedirect()` (308) to canonical URL when accessed via short slug
- **`__tests__/scripts/validate-posts.test.js`** — 18 new tests covering all validation rules
- **`CLAUDE.md`** + **`pipelines/prompts/blog-post.md`** — field documented for future pipeline use

## How to Test
1. Run `npm run validate:posts` — should pass with no issues
2. Run `npm test` — should pass (570 tests, +18 from new suite)
3. Run `npm run lint` — should pass with 0 warnings
4. Visit `/blog/versus` — should redirect (308) to `/blog/blog-post-introducing-versus-making-models-compete`
5. Visit `/blog/welcome` — should redirect (308) to `/blog/blog-idea-welcome-to-the-valley-of-ai`
6. Visit `/blog/pipeline` — should redirect (308) to `/blog/blog-post-how-the-valley-of-ai-pipeline-actually-works`
7. Add a post with a duplicate or invalid `shortSlug` — `validate:posts` should fail
8. Change a `shortSlug` in frontmatter without re-running `generate:posts` — `validate:posts` should detect the drift

## Screenshots / Videos (if applicable)
N/A

## Checklist
- [ ] Code follows [STYLE_GUIDE.md](../docs/STYLE_GUIDE.md)
- [ ] ESLint passes: `npm run lint`
- [ ] Code is formatted: `npm run format`
- [ ] Build succeeds: `npm run build`
- [ ] No new console warnings or errors
- [ ] Responsive design tested (mobile & desktop)
- [ ] Dark mode tested (if UI changes)
- [ ] Accessibility checked (`alt` text, ARIA labels, keyboard nav)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Documentation updated (if user-facing change)
- [ ] Related tests pass (if applicable)

## Deployment Notes
No special deployment steps required.

> **Note:** `wiki/Blog-Reference.md` was also updated locally (schema block + new Short Slug section) but the wiki lives in a separate git repo and will need to be pushed there independently.

## Reviewers
N/A

## Additional Context
N/A