### PR TITLE
fix: only show leaderboard submit dialog when score qualifies for top 10

### DIFF
--- a/apps/shared/app-shell.js
+++ b/apps/shared/app-shell.js
@@ -1415,13 +1415,53 @@
       appendLbCloseBtn();
     }
 
-    function openLeaderboardSubmit(score, opts) {
+    async function openLeaderboardSubmit(score, opts) {
       const appId = resolveAppId();
       if (!appId) {
         return;
       }
       const appName = getAppName();
       const label = opts && typeof opts.label === 'string' ? opts.label : 'points';
+
+      // Open immediately with a loading state so the player gets instant feedback
+      lbTitle.textContent = '\uD83C\uDFC6 Checking scores\u2026';
+      lbContentArea.innerHTML = '<p class="voa-lb-empty">Loading\u2026</p>';
+      openLbModal();
+
+      // Fetch the current top 10 to decide whether this score qualifies
+      let topScores = [];
+      let fetchFailed = false;
+      try {
+        topScores = await fetchTopScores(appId);
+      } catch {
+        fetchFailed = true;
+      }
+
+      // Player may have dismissed the loading modal during the fetch \u2014 don't re-open
+      if (!_leaderboardModalOpen) {
+        return;
+      }
+
+      // Qualifies if: fetch failed (give benefit of the doubt), fewer than 10 scores exist,
+      // or this score strictly beats the current lowest top-10 score
+      const qualifies =
+        fetchFailed || topScores.length < 10 || score > topScores[topScores.length - 1].score;
+
+      if (!qualifies) {
+        // Player didn't reach the top 10 \u2014 show the leaderboard with their score for context
+        lbTitle.textContent = `\uD83C\uDFC6 Top 10 \u2014 ${appName}`;
+        lbContentArea.innerHTML = '';
+        const yourScoreEl = document.createElement('p');
+        yourScoreEl.style.cssText =
+          'text-align:center;font:600 0.92rem/1.4 system-ui;color:var(--muted,#94a3b8);margin:0 0 12px;';
+        yourScoreEl.textContent = `Your score: ${score} ${label}`;
+        lbContentArea.appendChild(yourScoreEl);
+        lbContentArea.appendChild(renderScoreTable(topScores, null));
+        appendLbCloseBtn();
+        return;
+      }
+
+      // Score qualifies \u2014 build the name submission form
       const prefix = resolveStoragePrefix();
       const savedName = (() => {
         try {
@@ -1471,7 +1511,7 @@
       errorMsg.setAttribute('role', 'alert');
       lbContentArea.appendChild(errorMsg);
 
-      openLbModal();
+      // Modal is already open from the loading state above \u2014 no need to call openLbModal() again
 
       let turnstileToken = null;
       if (siteKey && !isLocal) {
@@ -1592,7 +1632,7 @@
 
     window.voaLeaderboard = {
       submit: function (score, opts) {
-        openLeaderboardSubmit(score, opts || {});
+        void openLeaderboardSubmit(score, opts || {});
       },
       show: function () {
         const appId = resolveAppId();


### PR DESCRIPTION
## Bug

`window.voaLeaderboard.submit(score)` unconditionally opened the "🏆 New High Score!" dialog on every game-over, regardless of whether the player's score actually ranked in the top 10 stored in Supabase.

## Fix

`openLeaderboardSubmit` now fetches the current top 10 before showing any UI, then branches on whether the score qualifies:

| Condition | Behavior |
|---|---|
| Fewer than 10 scores on the board | Show "New High Score!" submit form (existing behavior) |
| Score strictly beats 10th-place entry | Show "New High Score!" submit form (existing behavior) |
| Score does not qualify | Show read-only leaderboard with "Your score: N pts" at the top |
| Fetch fails | Fall back to submit form (benefit of the doubt) |
| Player dismisses the loading modal before fetch returns | Bail out silently — do not re-open |

A brief "Checking scores…" loading state is shown while the fetch is in-flight, giving the player immediate feedback.

## Files changed

- `apps/shared/app-shell.js` — `openLeaderboardSubmit` made `async`; pre-fetch + qualification check added; `window.voaLeaderboard.submit` updated to `void` the async call. `public/apps/shared/app-shell.js` is gitignored (generated at build time from the source).

## Testing

No new unit tests — the changed code is a browser-side IIFE with no existing test infrastructure. The API layer (`GET /api/scores`, `POST /api/scores`) is unchanged and already fully covered in `__tests__/api/scores.test.js`. All 570 existing tests pass.
