### PR TITLE
Improve mobile gallery filter accessibility and shortcut button labels

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -358,6 +358,8 @@ export default function HomePage() {
           onInputModeChange={handleFilterChange(setInputModeFilter)}
           activeFilterCount={activeFilterCount}
           onReset={resetFilters}
+          sortBy={sortBy}
+          onSortChange={handleFilterChange(setSortBy)}
         />
 
         <GalleryPagination

--- a/components/GalleryFilters.jsx
+++ b/components/GalleryFilters.jsx
@@ -17,6 +17,7 @@ const SORT_OPTIONS = [
   { value: 'highest', label: 'Highest rated' },
   { value: 'trending', label: 'Trending' },
 ];
+const MOBILE_BREAKPOINT_QUERY = '(max-width: 639px)';
 
 function MobileFiltersSheet({ activeFilterCount, onClose, children }) {
   const panelRef = useRef(null);
@@ -111,7 +112,7 @@ export default function GalleryFilters({
       return;
     }
 
-    const media = window.matchMedia('(max-width: 639px)');
+    const media = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
     const handleChange = () => setIsMobileView(media.matches);
     handleChange();
 

--- a/components/GalleryFilters.jsx
+++ b/components/GalleryFilters.jsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import appsData from '@/data/apps.json';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 
 const categories = [...new Set(appsData.map((app) => app.category).filter(Boolean))].sort();
 const agents = [
@@ -16,6 +17,75 @@ const SORT_OPTIONS = [
   { value: 'highest', label: 'Highest rated' },
   { value: 'trending', label: 'Trending' },
 ];
+
+function MobileFiltersSheet({ activeFilterCount, onClose, children }) {
+  const panelRef = useRef(null);
+  useFocusTrap(panelRef);
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/40 z-40 sm:hidden"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={panelRef}
+        className="fixed inset-x-0 bottom-0 z-50 sm:hidden rounded-t-2xl
+          bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700
+          shadow-2xl transition-transform duration-300 ease-out translate-y-0"
+        style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom))' }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gallery-filters-mobile-title"
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pt-3 pb-1">
+          <div className="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded-full" />
+        </div>
+        {/* Sheet header */}
+        <div className="flex items-center justify-between px-5 py-3">
+          <span
+            id="gallery-filters-mobile-title"
+            className="font-semibold text-gray-900 dark:text-white"
+          >
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-medium bg-primary-600 text-white rounded-full">
+                {activeFilterCount}
+              </span>
+            )}
+          </span>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-1"
+            aria-label="Close filters"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="px-5 pb-2">{children}</div>
+      </div>
+    </>
+  );
+}
 
 export default function GalleryFilters({
   searchQuery,
@@ -34,6 +104,25 @@ export default function GalleryFilters({
   onSortChange = null,
 }) {
   const [showFilters, setShowFilters] = useState(false);
+  const [isMobileView, setIsMobileView] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const media = window.matchMedia('(max-width: 639px)');
+    const handleChange = () => setIsMobileView(media.matches);
+    handleChange();
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handleChange);
+      return () => media.removeEventListener('change', handleChange);
+    }
+
+    media.addListener(handleChange);
+    return () => media.removeListener(handleChange);
+  }, []);
 
   // Shared filter grid used in both mobile sheet and desktop card
   const filterGrid = (
@@ -209,55 +298,20 @@ export default function GalleryFilters({
         </button>
       </div>
 
-      {/* Mobile: backdrop + bottom sheet */}
-      {showFilters && (
-        <div
-          className="fixed inset-0 bg-black/40 z-40 sm:hidden"
-          onClick={() => setShowFilters(false)}
-          aria-hidden="true"
-        />
+      {/* Mobile: modal bottom sheet */}
+      {showFilters && isMobileView && (
+        <MobileFiltersSheet
+          activeFilterCount={activeFilterCount}
+          onClose={() => setShowFilters(false)}
+        >
+          {filterGrid}
+        </MobileFiltersSheet>
       )}
-      <div
-        className={`fixed inset-x-0 bottom-0 z-50 sm:hidden rounded-t-2xl
-          bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700
-          shadow-2xl transition-transform duration-300 ease-out
-          ${showFilters ? 'translate-y-0' : 'translate-y-full pointer-events-none'}`}
-        style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom))' }}
-      >
-        {/* Drag handle */}
-        <div className="flex justify-center pt-3 pb-1">
-          <div className="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded-full" />
-        </div>
-        {/* Sheet header */}
-        <div className="flex items-center justify-between px-5 py-3">
-          <span className="font-semibold text-gray-900 dark:text-white">
-            Filters
-            {activeFilterCount > 0 && (
-              <span className="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-medium bg-primary-600 text-white rounded-full">
-                {activeFilterCount}
-              </span>
-            )}
-          </span>
-          <button
-            onClick={() => setShowFilters(false)}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-1"
-            aria-label="Close filters"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-        <div className="px-5 pb-2">{filterGrid}</div>
-      </div>
 
       {/* Desktop: inline card (unchanged) */}
-      {showFilters && <div className="hidden sm:block card p-4 mb-4">{filterGrid}</div>}
+      {showFilters && !isMobileView && (
+        <div className="hidden sm:block card p-4 mb-4">{filterGrid}</div>
+      )}
     </div>
   );
 }

--- a/components/GalleryFilters.jsx
+++ b/components/GalleryFilters.jsx
@@ -35,6 +35,117 @@ export default function GalleryFilters({
 }) {
   const [showFilters, setShowFilters] = useState(false);
 
+  // Shared filter grid used in both mobile sheet and desktop card
+  const filterGrid = (
+    <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+      <div>
+        <label htmlFor="categoryFilter" className="label">
+          Category
+        </label>
+        <select
+          id="categoryFilter"
+          value={categoryFilter}
+          onChange={(e) => onCategoryChange(e.target.value)}
+          className="input"
+        >
+          <option value="">All Categories</option>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="agentFilter" className="label">
+          Agent
+        </label>
+        <select
+          id="agentFilter"
+          value={agentFilter}
+          onChange={(e) => onAgentChange(e.target.value)}
+          className="input"
+        >
+          <option value="">All Agents</option>
+          {agents.map((agent) => (
+            <option key={agent} value={agent}>
+              {agent}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="modelFilter" className="label">
+          Model
+        </label>
+        <select
+          id="modelFilter"
+          value={modelFilter}
+          onChange={(e) => onModelChange(e.target.value)}
+          className="input"
+        >
+          <option value="">All Models</option>
+          {models.map((model) => (
+            <option key={model} value={model}>
+              {model}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="inputModeFilter" className="label">
+          Input Mode
+        </label>
+        <select
+          id="inputModeFilter"
+          value={inputModeFilter}
+          onChange={(e) => onInputModeChange(e.target.value)}
+          className="input"
+        >
+          <option value="">All Input Modes</option>
+          {INPUT_MODE_OPTIONS.map((mode) => (
+            <option key={mode} value={mode}>
+              {mode}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {sortBy !== null && onSortChange && (
+        <div className="sm:hidden">
+          <label htmlFor="mobileSortFilter" className="label">
+            Sort by
+          </label>
+          <select
+            id="mobileSortFilter"
+            value={sortBy}
+            onChange={(e) => onSortChange(e.target.value)}
+            className="input"
+          >
+            {SORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="col-span-2 sm:col-span-1 flex items-end">
+        <button
+          onClick={onReset}
+          disabled={activeFilterCount === 0 && !searchQuery}
+          className="btn-secondary w-full disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Clear All
+        </button>
+      </div>
+    </div>
+  );
+
   return (
     <div className="mb-8">
       {/* Search Bar */}
@@ -98,118 +209,55 @@ export default function GalleryFilters({
         </button>
       </div>
 
-      {/* Filter Panel */}
+      {/* Mobile: backdrop + bottom sheet */}
       {showFilters && (
-        <div className="card p-4 mb-4">
-          <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-            <div>
-              <label htmlFor="categoryFilter" className="label">
-                Category
-              </label>
-              <select
-                id="categoryFilter"
-                value={categoryFilter}
-                onChange={(e) => onCategoryChange(e.target.value)}
-                className="input"
-              >
-                <option value="">All Categories</option>
-                {categories.map((cat) => (
-                  <option key={cat} value={cat}>
-                    {cat}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="agentFilter" className="label">
-                Agent
-              </label>
-              <select
-                id="agentFilter"
-                value={agentFilter}
-                onChange={(e) => onAgentChange(e.target.value)}
-                className="input"
-              >
-                <option value="">All Agents</option>
-                {agents.map((agent) => (
-                  <option key={agent} value={agent}>
-                    {agent}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="modelFilter" className="label">
-                Model
-              </label>
-              <select
-                id="modelFilter"
-                value={modelFilter}
-                onChange={(e) => onModelChange(e.target.value)}
-                className="input"
-              >
-                <option value="">All Models</option>
-                {models.map((model) => (
-                  <option key={model} value={model}>
-                    {model}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="inputModeFilter" className="label">
-                Input Mode
-              </label>
-              <select
-                id="inputModeFilter"
-                value={inputModeFilter}
-                onChange={(e) => onInputModeChange(e.target.value)}
-                className="input"
-              >
-                <option value="">All Input Modes</option>
-                {INPUT_MODE_OPTIONS.map((mode) => (
-                  <option key={mode} value={mode}>
-                    {mode}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {sortBy !== null && onSortChange && (
-              <div className="sm:hidden">
-                <label htmlFor="mobileSortFilter" className="label">
-                  Sort by
-                </label>
-                <select
-                  id="mobileSortFilter"
-                  value={sortBy}
-                  onChange={(e) => onSortChange(e.target.value)}
-                  className="input"
-                >
-                  {SORT_OPTIONS.map((o) => (
-                    <option key={o.value} value={o.value}>
-                      {o.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-
-            <div className="col-span-2 sm:col-span-1 flex items-end">
-              <button
-                onClick={onReset}
-                disabled={activeFilterCount === 0 && !searchQuery}
-                className="btn-secondary w-full disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                Clear All
-              </button>
-            </div>
-          </div>
-        </div>
+        <div
+          className="fixed inset-0 bg-black/40 z-40 sm:hidden"
+          onClick={() => setShowFilters(false)}
+          aria-hidden="true"
+        />
       )}
+      <div
+        className={`fixed inset-x-0 bottom-0 z-50 sm:hidden rounded-t-2xl
+          bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700
+          shadow-2xl transition-transform duration-300 ease-out
+          ${showFilters ? 'translate-y-0' : 'translate-y-full pointer-events-none'}`}
+        style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom))' }}
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pt-3 pb-1">
+          <div className="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded-full" />
+        </div>
+        {/* Sheet header */}
+        <div className="flex items-center justify-between px-5 py-3">
+          <span className="font-semibold text-gray-900 dark:text-white">
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-medium bg-primary-600 text-white rounded-full">
+                {activeFilterCount}
+              </span>
+            )}
+          </span>
+          <button
+            onClick={() => setShowFilters(false)}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors p-1"
+            aria-label="Close filters"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="px-5 pb-2">{filterGrid}</div>
+      </div>
+
+      {/* Desktop: inline card (unchanged) */}
+      {showFilters && <div className="hidden sm:block card p-4 mb-4">{filterGrid}</div>}
     </div>
   );
 }

--- a/components/GalleryFilters.jsx
+++ b/components/GalleryFilters.jsx
@@ -10,6 +10,13 @@ const agents = [
 const models = [...new Set(appsData.map((app) => app.generation?.llmModel).filter(Boolean))].sort();
 const INPUT_MODE_OPTIONS = ['Desktop', 'Mobile', 'Responsive'];
 
+const SORT_OPTIONS = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'highest', label: 'Highest rated' },
+  { value: 'trending', label: 'Trending' },
+];
+
 export default function GalleryFilters({
   searchQuery,
   onSearchChange,
@@ -23,6 +30,8 @@ export default function GalleryFilters({
   onInputModeChange,
   activeFilterCount,
   onReset,
+  sortBy = null,
+  onSortChange = null,
 }) {
   const [showFilters, setShowFilters] = useState(false);
 
@@ -92,7 +101,7 @@ export default function GalleryFilters({
       {/* Filter Panel */}
       {showFilters && (
         <div className="card p-4 mb-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-5 gap-4">
             <div>
               <label htmlFor="categoryFilter" className="label">
                 Category
@@ -169,7 +178,27 @@ export default function GalleryFilters({
               </select>
             </div>
 
-            <div className="flex items-end">
+            {sortBy !== null && onSortChange && (
+              <div className="sm:hidden">
+                <label htmlFor="mobileSortFilter" className="label">
+                  Sort by
+                </label>
+                <select
+                  id="mobileSortFilter"
+                  value={sortBy}
+                  onChange={(e) => onSortChange(e.target.value)}
+                  className="input"
+                >
+                  {SORT_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <div className="col-span-2 sm:col-span-1 flex items-end">
               <button
                 onClick={onReset}
                 disabled={activeFilterCount === 0 && !searchQuery}

--- a/components/GalleryPagination.jsx
+++ b/components/GalleryPagination.jsx
@@ -49,6 +49,7 @@ export default function GalleryPagination({
                 onClick={handleFeelingLucky}
                 className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-slate-900 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
                 title="Feeling Lucky"
+                aria-label="Feeling Lucky"
               >
                 🎲<span className="hidden sm:inline"> Feeling Lucky</span>
               </button>
@@ -58,6 +59,7 @@ export default function GalleryPagination({
                 onClick={onTrendingShortcut}
                 className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-emerald-950 bg-gradient-to-r from-emerald-300 to-cyan-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
                 title="Trending"
+                aria-label="Trending"
               >
                 🔥<span className="hidden sm:inline"> Trending</span>
               </button>
@@ -67,6 +69,7 @@ export default function GalleryPagination({
                 onClick={onNewestShortcut}
                 className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-sky-950 bg-gradient-to-r from-sky-300 to-indigo-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
                 title="Newest"
+                aria-label="Newest"
               >
                 ✨<span className="hidden sm:inline"> Newest</span>
               </button>

--- a/components/GalleryPagination.jsx
+++ b/components/GalleryPagination.jsx
@@ -48,24 +48,27 @@ export default function GalleryPagination({
               <button
                 onClick={handleFeelingLucky}
                 className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-slate-900 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                title="Feeling Lucky"
               >
-                🎲 Feeling Lucky
+                🎲<span className="hidden sm:inline"> Feeling Lucky</span>
               </button>
             )}
             {onTrendingShortcut && (
               <button
                 onClick={onTrendingShortcut}
-                className="hidden sm:inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-emerald-950 bg-gradient-to-r from-emerald-300 to-cyan-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-emerald-950 bg-gradient-to-r from-emerald-300 to-cyan-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                title="Trending"
               >
-                🔥 Trending
+                🔥<span className="hidden sm:inline"> Trending</span>
               </button>
             )}
             {onNewestShortcut && (
               <button
                 onClick={onNewestShortcut}
-                className="hidden sm:inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-sky-950 bg-gradient-to-r from-sky-300 to-indigo-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-sky-950 bg-gradient-to-r from-sky-300 to-indigo-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                title="Newest"
               >
-                ✨ Newest
+                ✨<span className="hidden sm:inline"> Newest</span>
               </button>
             )}
           </div>

--- a/components/GalleryPagination.jsx
+++ b/components/GalleryPagination.jsx
@@ -55,7 +55,7 @@ export default function GalleryPagination({
             {onTrendingShortcut && (
               <button
                 onClick={onTrendingShortcut}
-                className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-emerald-950 bg-gradient-to-r from-emerald-300 to-cyan-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                className="hidden sm:inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-emerald-950 bg-gradient-to-r from-emerald-300 to-cyan-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
               >
                 🔥 Trending
               </button>
@@ -63,14 +63,14 @@ export default function GalleryPagination({
             {onNewestShortcut && (
               <button
                 onClick={onNewestShortcut}
-                className="inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-sky-950 bg-gradient-to-r from-sky-300 to-indigo-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
+                className="hidden sm:inline-flex items-center gap-0.5 text-[0.72rem] font-semibold tracking-wide text-sky-950 bg-gradient-to-r from-sky-300 to-indigo-300 rounded-full px-2.5 py-0.5 whitespace-nowrap transition-transform hover:scale-105"
               >
                 ✨ Newest
               </button>
             )}
           </div>
 
-          <div className="flex flex-wrap items-center gap-4">
+          <div className="hidden sm:flex flex-wrap items-center gap-4">
             <div className="flex items-center gap-2">
               <label htmlFor="perPage" className="text-sm text-gray-600 dark:text-gray-400">
                 Show:


### PR DESCRIPTION
## Description
Addresses PR review feedback by fixing accessibility issues in the homepage mobile filter experience and shortcut pills, while keeping the original mobile filtering behavior intact.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue without changing feature behavior)
- [ ] ✨ New feature (adds functionality)
- [x] 🔄 Refactoring (improves code without changing behavior)
- [ ] 📚 Documentation (updates docs, README, guides)
- [ ] ⚡ Performance improvement
- [ ] 🎨 Style/formatting (code style, theme updates)

## Changes Made
- Updated `GalleryFilters` mobile bottom sheet to behave as a proper modal dialog (`role="dialog"`, `aria-modal`, labeled title, Escape-to-close, focus trap).
- Prevented hidden/focusable controls and duplicate filter IDs by conditionally rendering only the active mobile or desktop filter panel.
- Added explicit `aria-label`s for mobile shortcut pill buttons in `GalleryPagination` (`Feeling Lucky`, `Trending`, `Newest`).

## How to Test
Steps to verify the changes work as expected:
1. Go to the homepage on a mobile viewport.
2. Open Filters and verify focus is trapped in the sheet and Escape closes it.
3. Verify screen readers announce the filter sheet as a dialog and shortcut pills by action name (not emoji only).
4. Run `npm run lint`.
5. Run `npm test -- --passWithNoTests`.

## Screenshots / Videos (if applicable)
Show before and after, or demonstrate the new feature in action.

## Checklist
- [ ] Code follows [STYLE_GUIDE.md](../docs/STYLE_GUIDE.md)
- [x] ESLint passes: `npm run lint`
- [ ] Code is formatted: `npm run format`
- [ ] Build succeeds: `npm run build`
- [x] No new console warnings or errors
- [ ] Responsive design tested (mobile & desktop)
- [ ] Dark mode tested (if UI changes)
- [x] Accessibility checked (`alt` text, ARIA labels, keyboard nav)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Documentation updated (if user-facing change)
- [x] Related tests pass (if applicable)

## Deployment Notes
No special deployment changes required.  
Note: local sandbox build can fail due blocked Google Fonts fetch in this environment.

## Reviewers
Assign reviewers who should review this PR.

## Additional Context
This update is scoped to the review thread feedback and does not introduce unrelated feature changes.