### PR TITLE
fix: replace canvas emoji fillText in simmotion, cyber-hop, dungeon-puzzle-run

### DIFF
--- a/apps/2026/03/18/cyber-hop/index.html
+++ b/apps/2026/03/18/cyber-hop/index.html
@@ -1010,10 +1010,15 @@
             ctx.shadowBlur = 0;
 
             if (reached) {
-              ctx.font = `${CELL * 0.48}px serif`;
+              ctx.fillStyle = '#00ff88';
+              ctx.beginPath();
+              ctx.arc(cx2, cy2, CELL * 0.28, 0, Math.PI * 2);
+              ctx.fill();
+              ctx.fillStyle = '#003322';
+              ctx.font = `bold ${CELL * 0.28}px system-ui`;
               ctx.textAlign = 'center';
               ctx.textBaseline = 'middle';
-              ctx.fillText('🐸', cx2, cy2);
+              ctx.fillText('✓', cx2, cy2 + 1);
             } else {
               // Crosshair target icon
               const cr = CELL * 0.18;

--- a/apps/2026/03/23/dungeon-puzzle-run/index.html
+++ b/apps/2026/03/23/dungeon-puzzle-run/index.html
@@ -1032,10 +1032,6 @@ function drawPath(canvas, d, CELL) {
       ctx.font = `bold ${CELL*.4}px system-ui`;
       ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
       ctx.fillText(isStart ? 'S' : 'E', c*CELL+CELL/2, r*CELL+CELL/2);
-    } else if (isWall) {
-      ctx.fillStyle = '#5a3a70'; ctx.font = `${CELL*.45}px system-ui`;
-      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-      ctx.fillText('🪨', c*CELL+CELL/2, r*CELL+CELL/2+2);
     }
     if (G.relics.includes('torch') && isWall) {
       // Show hint: walls near valid path glow slightly

--- a/apps/2026/05/23/simmotion/index.html
+++ b/apps/2026/05/23/simmotion/index.html
@@ -809,7 +809,7 @@
 
         // Lives
         ctx.fillStyle = isDark ? '#ef4444' : '#dc2626';
-        ctx.fillText('❤️ ' + lives, 10, 14);
+        ctx.fillText('♥ ' + lives, 10, 14);
 
         // Time
         const mins = Math.floor(survivalTime / 60)
@@ -820,7 +820,7 @@
           .padStart(2, '0');
         ctx.fillStyle = isDark ? '#f9fafb' : '#1f2937';
         ctx.textAlign = 'center';
-        ctx.fillText('⏱ ' + mins + ':' + secs, W / 2, 14);
+        ctx.fillText(mins + ':' + secs, W / 2, 14);
 
         // Caught / Missed
         ctx.textAlign = 'right';


### PR DESCRIPTION
## Summary

Same Safari canvas emoji bug fixed in PR #544 (tapper-rush) found in 3 more apps. Safari/WebKit renders color emoji via `ctx.fillText(...)` as blank; Chrome works fine; automated checks (headless Chromium) don't catch it.

**simmotion** — HUD lives and timer
- `❤️` → `♥` (U+2665 BLACK HEART SUIT — plain text glyph, works in canvas `fillText` on all browsers)
- `⏱` prefix dropped from timer — no plain-text stopwatch equivalent exists; centered `MM:SS` is self-explanatory

**cyber-hop** — goal pad reached indicator
- `fillText('🐸')` → canvas-drawn filled green circle (`#00ff88`) with a plain-text `✓` inside, matching the pad's existing glow color

**dungeon-puzzle-run** — wall tile decoration
- `fillText('🪨')` removed entirely — wall cells are already visually distinct from path/empty cells via their `#3a2a50` fill color

## Verification
- `validate:apps`, `lint` (0 warnings), `npm test` (570 passed), `validate:responsive:sample`, `build` — all pass
- Approach matches the fix documented in `shared.md`, `CLAUDE.md`, and `AGENTS.md` from #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
