### PR TITLE
improve: virus-vials — brighter pollution-blob colors for easier matching

### DIFF
--- a/apps/2026/06/13/virus-vials/index.html
+++ b/apps/2026/06/13/virus-vials/index.html
@@ -496,31 +496,33 @@
       const NUM_COLORS = 3;
 
       // Reef palette. Coral fragments use base / light / dark / glow; pollution
-      // blobs reuse the same hues in desaturated, oily blob stops (blobLight/blobDark).
+      // blobs reuse the SAME hues (blobLight/blobDark) so they read as clearly the
+      // same color as the pieces — kept a touch deeper/oilier than the glossy coral,
+      // with the dark shimmer streak + angry eyes carrying the "pollution" look.
       const COLORS = [
         {
           base: '#ff6b6b',
           light: '#ffb3b3',
           dark: '#c24545',
           glow: 'rgba(255,107,107,0.6)',
-          blobLight: '#b07a7a',
-          blobDark: '#3a2424',
+          blobLight: '#ff8f8f',
+          blobDark: '#7a2b2b',
         }, // coral red
         {
           base: '#ffe66d',
           light: '#fff4b0',
           dark: '#c2a82e',
           glow: 'rgba(255,230,109,0.6)',
-          blobLight: '#b0a76d',
-          blobDark: '#3a3520',
+          blobLight: '#ffe27a',
+          blobDark: '#7a6a18',
         }, // sun yellow
         {
           base: '#4ecdc4',
           light: '#a6ebe6',
           dark: '#2e8c85',
           glow: 'rgba(78,205,196,0.6)',
-          blobLight: '#6b9c98',
-          blobDark: '#1e3a38',
+          blobLight: '#6fd6cd',
+          blobDark: '#1d5d57',
         }, // seafoam teal
       ];
 


### PR DESCRIPTION
## What changed
Brightened the pollution-blob (enemy) colors so they clearly read as the same hues as the coral pieces — red / yellow / teal — making matches much easier to spot.

Before, the blobs used heavily desaturated, near-brown/dark stops (`#b07a7a`/`#3a2424`, etc.) that were hard to distinguish against the navy water and from each other. Now `blobLight`/`blobDark` are clear, mid-deep versions of each piece hue. The dark oily shimmer streak and angry eyes still carry the "pollution" character, so blobs remain visually distinct from the glossy coral pieces — just unmistakably the same color.

## Why
Player feedback: enemy colors were too hard to see / match.

## Verification
- Rendered the board headlessly (difficulty 6, full of blobs) and confirmed all three blob colors now clearly match their coral-piece counterparts; no page errors.
- validate:apps, lint (0 warnings), test (570 passing), validate:responsive (passes), build — all green.
- One-line-per-hue change to the `COLORS` table only; no mechanics or other visuals touched.
