### PR TITLE
fix: reef-rescue — coral halves join flat in the center (horizontal)

### DIFF
--- a/apps/2026/06/13/reef-rescue/index.html
+++ b/apps/2026/06/13/reef-rescue/index.html
@@ -1274,10 +1274,13 @@
         const col = COLORS[color];
 
         // Edges not joined to a partner are "free" and get scalloped bumps.
+        // link points toward the partner, so that edge is the flush join: the
+        // left half of a horizontal pair has link 'R' (its right edge joins);
+        // the right half has link 'L' (its left edge joins).
         const freeTop = link !== 'D';
         const freeBottom = link !== 'U';
-        const freeLeft = link !== 'R';
-        const freeRight = link !== 'L';
+        const freeLeft = link !== 'L';
+        const freeRight = link !== 'R';
 
         const grad = ctx.createLinearGradient(left, top, left, top + h);
         grad.addColorStop(0, col.light);
@@ -1516,8 +1519,8 @@
           s = size - pad * 2;
         const rO = s * 0.26,
           rI = s * 0.06;
-        const freeLeft = link !== 'R';
-        const freeRight = link !== 'L';
+        const freeLeft = link !== 'L';
+        const freeRight = link !== 'R';
         const tl = freeLeft ? rO : rI;
         const bl = freeLeft ? rO : rI;
         const tr = freeRight ? rO : rI;


### PR DESCRIPTION
## What changed
Fixes a regression from the coral-shape change: in a **horizontal** capsule the two halves had their flat join edge on the **outside** and the rounded/scalloped edge in the center, so the pair didn't read as joined.

Root cause: `drawHalf`/`drawHalfOn` computed `freeLeft`/`freeRight` from the wrong link letters. `link` points toward the partner, so `'L'` means the left edge joins and `'R'` means the right edge joins. Corrected both functions.

## Verification
- Rendered the spawned horizontal capsule headlessly: the flat sides now meet in the center and the lumpy coral edges are on the outside; halves merge flush. (Vertical pairs were already correct and still are.)
- validate:apps, lint (0 warnings), test (570 passing), validate:responsive, build — all pass.
- 3-line logic fix; no other changes.
