### PR TITLE
improve: reef-rescue — refresh thumbnail to match coral pieces

### DIFF
--- a/apps/2026/06/13/reef-rescue/thumbnail.svg
+++ b/apps/2026/06/13/reef-rescue/thumbnail.svg
@@ -33,16 +33,16 @@
       <stop offset="1" stop-color="#c2a82e" />
     </radialGradient>
     <radialGradient id="blobRed" cx="0.4" cy="0.35" r="0.7">
-      <stop offset="0" stop-color="#b07a7a" />
-      <stop offset="1" stop-color="#3a2424" />
+      <stop offset="0" stop-color="#ff6b6b" />
+      <stop offset="1" stop-color="#c24545" />
     </radialGradient>
     <radialGradient id="blobTeal" cx="0.4" cy="0.35" r="0.7">
-      <stop offset="0" stop-color="#6b9c98" />
-      <stop offset="1" stop-color="#1e3a38" />
+      <stop offset="0" stop-color="#4ecdc4" />
+      <stop offset="1" stop-color="#2e8c85" />
     </radialGradient>
     <radialGradient id="blobYellow" cx="0.4" cy="0.35" r="0.7">
-      <stop offset="0" stop-color="#b0a76d" />
-      <stop offset="1" stop-color="#3a3520" />
+      <stop offset="0" stop-color="#ffe66d" />
+      <stop offset="1" stop-color="#c2a82e" />
     </radialGradient>
     <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="5" result="b" />
@@ -102,16 +102,53 @@
   <rect x="285" y="120" width="230" height="300" rx="16" fill="url(#glass)"
     stroke="#4ecdc4" stroke-opacity="0.55" stroke-width="2.5" filter="url(#glow)" />
 
-  <!-- Falling coral capsule (two-tone fragment) -->
-  <g filter="url(#glow)">
-    <rect x="372" y="150" width="30" height="30" rx="11" fill="url(#coralRed)" />
-    <rect x="402" y="150" width="30" height="30" rx="11" fill="url(#coralTeal)" />
+  <!-- Falling coral capsule (two-tone fragment, halves joined flat in the center) -->
+  <g>
+    <!-- Left half: coral red, flat on its right edge -->
+    <g filter="url(#glow)" fill="url(#coralRed)">
+      <path d="M378 149 H401 V181 H378 Q369 181 369 172 V158 Q369 149 378 149 Z" />
+      <circle cx="380" cy="149" r="5" /><circle cx="392" cy="150" r="5" />
+      <circle cx="380" cy="181" r="5" /><circle cx="392" cy="180" r="5" />
+      <circle cx="369" cy="160" r="5" /><circle cx="369" cy="172" r="5" />
+    </g>
+    <circle cx="389" cy="161" r="3.6" fill="#ffb3b3" opacity="0.6" />
+    <circle cx="389" cy="161" r="1.4" fill="#c24545" opacity="0.55" />
+    <circle cx="380" cy="172" r="2.6" fill="#ffb3b3" opacity="0.6" />
+    <!-- Right half: seafoam teal, flat on its left edge -->
+    <g filter="url(#glow)" fill="url(#coralTeal)">
+      <path d="M401 149 H424 Q433 149 433 158 V172 Q433 181 424 181 H401 V149 Z" />
+      <circle cx="412" cy="149" r="5" /><circle cx="424" cy="150" r="5" />
+      <circle cx="412" cy="181" r="5" /><circle cx="424" cy="180" r="5" />
+      <circle cx="433" cy="160" r="5" /><circle cx="433" cy="172" r="5" />
+    </g>
+    <circle cx="414" cy="161" r="3.6" fill="#a6ebe6" opacity="0.6" />
+    <circle cx="414" cy="161" r="1.4" fill="#2e8c85" opacity="0.55" />
+    <circle cx="423" cy="172" r="2.6" fill="#a6ebe6" opacity="0.6" />
   </g>
 
-  <!-- Settled coral pieces -->
-  <g filter="url(#glow)">
-    <rect x="312" y="356" width="28" height="28" rx="10" fill="url(#coralYellow)" />
-    <rect x="460" y="356" width="28" height="28" rx="10" fill="url(#coralTeal)" />
+  <!-- Settled coral pieces (solo chunks, lumpy on every edge) -->
+  <g>
+    <g filter="url(#glow)" fill="url(#coralYellow)">
+      <rect x="311" y="355" width="30" height="30" rx="8" />
+      <circle cx="320" cy="355" r="5" /><circle cx="332" cy="356" r="5" />
+      <circle cx="320" cy="385" r="5" /><circle cx="332" cy="384" r="5" />
+      <circle cx="311" cy="364" r="5" /><circle cx="311" cy="376" r="5" />
+      <circle cx="341" cy="364" r="5" /><circle cx="341" cy="376" r="5" />
+    </g>
+    <circle cx="330" cy="366" r="3.4" fill="#fff4b0" opacity="0.6" />
+    <circle cx="330" cy="366" r="1.3" fill="#c2a82e" opacity="0.55" />
+    <circle cx="322" cy="376" r="2.6" fill="#fff4b0" opacity="0.55" />
+
+    <g filter="url(#glow)" fill="url(#coralTeal)">
+      <rect x="459" y="355" width="30" height="30" rx="8" />
+      <circle cx="468" cy="355" r="5" /><circle cx="480" cy="356" r="5" />
+      <circle cx="468" cy="385" r="5" /><circle cx="480" cy="384" r="5" />
+      <circle cx="459" cy="364" r="5" /><circle cx="459" cy="376" r="5" />
+      <circle cx="489" cy="364" r="5" /><circle cx="489" cy="376" r="5" />
+    </g>
+    <circle cx="478" cy="366" r="3.4" fill="#a6ebe6" opacity="0.6" />
+    <circle cx="478" cy="366" r="1.3" fill="#2e8c85" opacity="0.55" />
+    <circle cx="470" cy="376" r="2.6" fill="#a6ebe6" opacity="0.55" />
   </g>
 
   <!-- Pollution blobs with tiny angry eyes -->


### PR DESCRIPTION
## What changed
Refreshes the gallery thumbnail to match the app's current look.

- **Coral pieces** are now lumpy coral chunks (scalloped edges + polyp dots) instead of rounded-rect pills, matching the in-game `drawHalf`. The falling capsule's two halves join flat in the center with bumpy outer edges.
- **Pollution-blob gradients** updated to the vivid hue-matched colors (red/yellow/teal), so the thumbnail blobs are clearly the same hues as the pieces — same as in-game.

## Verification
- `xmllint --noout` valid; `viewBox="0 0 800 450"`; multiple gradients + glow filter; mid-use state with title/HUD.
- Rendered headlessly and reviewed: coral chunks + hue-matched blobs read correctly.
- `validate:apps` and `build` pass.
- Thumbnail-only change.
