### PR TITLE
feat: opt-in 3D galaxy background + moon polish on the gallery

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import DonateModal from '@/components/DonateModal';
 import WelcomeModal from '@/components/WelcomeModal';
@@ -16,6 +17,9 @@ import appsData from '@/data/apps.json';
 import appVoteStats from '@/data/app-vote-stats.json';
 import postsData from '@/data/posts.json';
 import BlogPostCard from '@/components/BlogPostCard';
+
+// Lazy-loaded so the `three` bundle is only fetched when the 3D Galaxy toggle is on.
+const ThreeBackground = dynamic(() => import('@/components/ThreeBackground'), { ssr: false });
 
 const OPTIONS_STORAGE_KEY = 'voa-page-options';
 const FILTERS_STORAGE_KEY = 'voa-gallery-filters';
@@ -40,6 +44,7 @@ const DEFAULT_OPTIONS = {
   clouds: false,
   lightning: false,
   earthquake: false,
+  galaxy3d: false,
 };
 
 const staticVoteCounts = appVoteStats.apps ?? {};
@@ -310,6 +315,8 @@ export default function HomePage() {
   return (
     <>
       <div className="valley-cinematic-bg" aria-hidden="true">
+        {/* Rendered inside the cinematic bg so it sits in the sky, behind the mountains */}
+        {mounted && options.galaxy3d && <ThreeBackground />}
         <div className="valley-mountain-row-back" />
         <div className="valley-mountain-row-mid" />
         {options.shootingStars >= 1 && <div className="valley-shooting-stars" />}

--- a/components/OptionsDrawer.jsx
+++ b/components/OptionsDrawer.jsx
@@ -30,6 +30,7 @@ const TOGGLES = [
   { key: 'clouds', label: 'Clouds', icon: '☁️' },
   { key: 'lightning', label: 'Lightning', icon: '⚡' },
   { key: 'earthquake', label: 'Earthquake', icon: '🌍' },
+  { key: 'galaxy3d', label: '3D Galaxy', icon: '🌌' },
 ];
 
 /** Range/slider definitions — order here = order in drawer UI (rendered after toggles) */

--- a/components/ThreeBackground.jsx
+++ b/components/ThreeBackground.jsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+/**
+ * ThreeBackground — opt-in WebGL parallax starfield + nebula rendered behind the
+ * gallery content. Lazy-loaded via next/dynamic (ssr:false) so the `three` bundle
+ * is only fetched when the user enables the "3D Galaxy" toggle in OptionsDrawer.
+ *
+ * Rendered inside `valley-cinematic-bg` below the mountain rows (z-index) so the
+ * mountains occlude it and the stars read as living only in the sky. Pure visual
+ * flourish with a gentle, ambient
+ * time-based drift (no pointer interaction) — pointer-events: none,
+ * aria-hidden. Respects prefers-reduced-motion (renders a single static frame)
+ * and pauses its rAF loop when the tab is hidden. Fully disposes GPU resources
+ * on unmount so toggling off leaks nothing.
+ */
+
+const STAR_COUNT = 2200;
+const FIELD = 600; // half-extent of the cube the stars are scattered through
+
+export default function ThreeBackground() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    const reduceMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(70, width / height, 1, 2000);
+    camera.position.z = 500;
+
+    let renderer;
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true });
+    } catch {
+      // WebGL unavailable — bail out gracefully, CSS background still shows.
+      return undefined;
+    }
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(width, height);
+    renderer.setClearColor(0x000000, 0);
+    container.appendChild(renderer.domElement);
+
+    // --- Starfield (THREE.Points across several implicit depth layers) ---
+    const starGeometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(STAR_COUNT * 3);
+    const colors = new Float32Array(STAR_COUNT * 3);
+    const palette = [
+      new THREE.Color(0xc4b5fd), // light purple
+      new THREE.Color(0x818cf8), // indigo
+      new THREE.Color(0x60a5fa), // blue
+      new THREE.Color(0xf9fafb), // near-white
+    ];
+    for (let i = 0; i < STAR_COUNT; i += 1) {
+      positions[i * 3] = (Math.random() - 0.5) * FIELD * 2;
+      positions[i * 3 + 1] = (Math.random() - 0.5) * FIELD * 2;
+      positions[i * 3 + 2] = (Math.random() - 0.5) * FIELD * 2;
+      const c = palette[Math.floor(Math.random() * palette.length)];
+      colors[i * 3] = c.r;
+      colors[i * 3 + 1] = c.g;
+      colors[i * 3 + 2] = c.b;
+    }
+    starGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    starGeometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    const starMaterial = new THREE.PointsMaterial({
+      size: 2.4,
+      sizeAttenuation: true,
+      vertexColors: true,
+      transparent: true,
+      opacity: 0.9,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    const stars = new THREE.Points(starGeometry, starMaterial);
+    scene.add(stars);
+
+    // --- Soft nebula: a few large additive sprites for volumetric glow ---
+    const nebulaTexture = makeNebulaTexture();
+    const nebula = new THREE.Group();
+    const nebulaColors = [0x6d28d9, 0x1e3a8a, 0x4c1d95];
+    for (let i = 0; i < 3; i += 1) {
+      const mat = new THREE.SpriteMaterial({
+        map: nebulaTexture,
+        color: nebulaColors[i],
+        transparent: true,
+        opacity: 0.22,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+      });
+      const sprite = new THREE.Sprite(mat);
+      sprite.position.set((Math.random() - 0.5) * 500, (Math.random() - 0.5) * 320 - 60, -200);
+      const scale = 520 + Math.random() * 280;
+      sprite.scale.set(scale, scale, 1);
+      nebula.add(sprite);
+    }
+    scene.add(nebula);
+
+    const onResize = () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    };
+    window.addEventListener('resize', onResize);
+
+    let frameId = null;
+    let running = true;
+    const clock = new THREE.Clock();
+
+    const renderFrame = () => {
+      const t = clock.getElapsedTime();
+      // Gentle time-based drift only — no pointer interaction.
+      stars.rotation.y = t * 0.02;
+      stars.rotation.x = Math.sin(t * 0.05) * 0.05;
+      renderer.render(scene, camera);
+    };
+
+    const animate = () => {
+      if (!running) {
+        return;
+      }
+      renderFrame();
+      frameId = requestAnimationFrame(animate);
+    };
+
+    if (reduceMotion) {
+      renderFrame(); // single static frame, no loop
+    } else {
+      animate();
+    }
+
+    const onVisibility = () => {
+      if (reduceMotion) {
+        return;
+      }
+      if (document.hidden) {
+        running = false;
+        if (frameId !== null) {
+          cancelAnimationFrame(frameId);
+          frameId = null;
+        }
+      } else if (!running) {
+        running = true;
+        clock.getDelta(); // discard the paused interval
+        animate();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      running = false;
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener('resize', onResize);
+      document.removeEventListener('visibilitychange', onVisibility);
+      starGeometry.dispose();
+      starMaterial.dispose();
+      nebulaTexture.dispose();
+      nebula.children.forEach((sprite) => sprite.material.dispose());
+      renderer.dispose();
+      if (renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return <div ref={containerRef} className="three-bg" aria-hidden="true" />;
+}
+
+/** Radial-gradient canvas texture used for the soft additive nebula sprites. */
+function makeNebulaTexture() {
+  const size = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  gradient.addColorStop(0, 'rgba(255,255,255,0.9)');
+  gradient.addColorStop(0.35, 'rgba(255,255,255,0.35)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  return texture;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-turnstile": "^1.1.5",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1",
-        "stripe": "22.2.0"
+        "stripe": "22.2.0",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2084,9 +2085,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,9 +2100,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2122,9 +2117,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,9 +2132,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11058,6 +11047,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "react-turnstile": "^1.1.5",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
-    "stripe": "22.2.0"
+    "stripe": "22.2.0",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -243,10 +243,10 @@
   @keyframes valley-moon-glow {
     0%,
     100% {
-      filter: drop-shadow(0 0 5px rgba(246, 240, 223, 0.16));
+      filter: drop-shadow(0 0 6px rgba(246, 240, 223, 0.18));
     }
     50% {
-      filter: drop-shadow(0 0 7px rgba(246, 240, 223, 0.22));
+      filter: drop-shadow(0 0 10px rgba(246, 240, 223, 0.26));
     }
   }
 
@@ -356,6 +356,18 @@
     overflow: hidden;
   }
 
+  /* Opt-in WebGL galaxy (ThreeBackground). Rendered inside .valley-cinematic-bg,
+     which establishes a stacking context (isolation: isolate). z-index sits above
+     the opaque night-sky gradient so its additive stars show, but below the
+     mountain rows (z-index 1-3) so they occlude it — making the stars appear to
+     live only in the sky. Transparent canvas; pointer-events: none. */
+  .three-bg {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
   .valley-mountain-row-back {
     position: absolute;
     left: -8%;
@@ -436,43 +448,61 @@
     -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 72%, transparent 94%);
     mask-image: linear-gradient(180deg, #000 0%, #000 72%, transparent 94%);
     background:
+      /* lit-edge specular bloom (light source upper-right) */
       radial-gradient(
-        circle at 78% 18%,
-        rgba(244, 240, 228, 0.15) 0 76px,
-        rgba(244, 240, 228, 0) 77px
+        circle at 79.5% 15.9%,
+        rgba(255, 253, 246, 0.42) 0 5px,
+        rgba(255, 253, 246, 0) 14px
+      ),
+      /* craters — layered above the disc so they read as surface texture */
+        radial-gradient(
+          circle at 76.6% 16.7%,
+          rgba(150, 142, 126, 0.34) 0 6.8px,
+          rgba(150, 142, 126, 0) 7.6px
+        ),
+      radial-gradient(
+        circle at 80.4% 20.4%,
+        rgba(132, 125, 112, 0.3) 0 5.4px,
+        rgba(132, 125, 112, 0) 6.2px
       ),
       radial-gradient(
-        circle at 78% 18%,
-        rgba(241, 236, 220, 0.98) 0 34px,
-        rgba(227, 221, 203, 0.97) 35px 39px,
-        rgba(210, 202, 184, 0.94) 40px 42px,
-        rgba(181, 171, 152, 0) 43px
+        circle at 78.7% 17.4%,
+        rgba(158, 150, 135, 0.24) 0 9px,
+        rgba(158, 150, 135, 0) 9.8px
       ),
       radial-gradient(
-        circle at 76.9% 16.9%,
-        rgba(142, 136, 124, 0.22) 0 6.6px,
-        rgba(142, 136, 124, 0) 6.8px
+        circle at 76.9% 19.6%,
+        rgba(118, 112, 101, 0.26) 0 3.9px,
+        rgba(118, 112, 101, 0) 4.6px
       ),
       radial-gradient(
-        circle at 80.4% 20.2%,
-        rgba(128, 122, 111, 0.18) 0 5.4px,
-        rgba(128, 122, 111, 0) 5.6px
+        circle at 79.9% 15.6%,
+        rgba(110, 104, 95, 0.22) 0 2.9px,
+        rgba(110, 104, 95, 0) 3.5px
       ),
-      radial-gradient(
-        circle at 78.5% 17.5%,
-        rgba(154, 148, 136, 0.16) 0 8.8px,
-        rgba(154, 148, 136, 0) 9px
-      ),
-      radial-gradient(
-        circle at 77.1% 19.4%,
-        rgba(114, 109, 100, 0.14) 0 3.8px,
-        rgba(114, 109, 100, 0) 4px
-      ),
-      radial-gradient(
-        circle at 79.9% 15.7%,
-        rgba(106, 101, 93, 0.13) 0 2.9px,
-        rgba(106, 101, 93, 0) 3.1px
-      ),
+      /* terminator shading — darkens the lower-left limb for a spherical look */
+        radial-gradient(
+          circle at 81% 14.8%,
+          rgba(18, 16, 32, 0) 0 25px,
+          rgba(18, 16, 32, 0.32) 41px,
+          rgba(18, 16, 32, 0) 47px
+        ),
+      /* moon disc body */
+        radial-gradient(
+          circle at 78% 18%,
+          rgba(245, 240, 226, 0.99) 0 30px,
+          rgba(231, 225, 208, 0.98) 34px,
+          rgba(213, 205, 187, 0.95) 38px 40px,
+          rgba(188, 178, 158, 0.9) 41px 42px,
+          rgba(181, 171, 152, 0) 43px
+        ),
+      /* layered glow halo */
+        radial-gradient(
+          circle at 78% 18%,
+          rgba(246, 240, 223, 0.2) 0 44px,
+          rgba(246, 240, 223, 0.09) 62px,
+          rgba(246, 240, 223, 0) 96px
+        ),
       radial-gradient(circle at 12% 15%, rgba(255, 255, 255, 0.98) 0 1.2px, transparent 1.3px),
       radial-gradient(circle at 18% 27%, rgba(255, 255, 255, 0.9) 0 1.1px, transparent 1.2px),
       radial-gradient(circle at 24% 8%, rgba(209, 228, 255, 0.95) 0 1.4px, transparent 1.5px),


### PR DESCRIPTION
## Summary

Adds an **opt-in, lazy-loaded** Three.js starfield/nebula background to the home gallery, plus visual improvements to the existing CSS moon.

### 3D Galaxy background
- New `components/ThreeBackground.jsx` — vanilla three.js starfield (~2.2k points) + soft additive nebula, with a gentle ambient time-based drift (no pointer interaction).
- Lazy-loaded via `next/dynamic({ ssr: false })`, so the `three` bundle (~512K, its own chunk) is **only fetched when the new "🌌 3D Galaxy" toggle is enabled**. Default is **off** — the baseline page keeps zero WebGL/bundle cost.
- Toggle registered in `OptionsDrawer` and `DEFAULT_OPTIONS`; state persists via the existing options localStorage effect.
- Rendered **inside** `.valley-cinematic-bg` at `z-index: 0` (above the opaque sky gradient, below the mountain rows at z-index 1–3) so the mountains occlude it — the stars read as living **only in the sky**.
- Perf/a11y: caps `devicePixelRatio`, pauses the rAF loop on tab-hide, renders a single static frame under `prefers-reduced-motion`, and fully disposes GPU resources on unmount.

### Moon polish
- Fixed a latent bug: craters were stacked *behind* the opaque disc and thus invisible — moved above it so surface texture shows.
- Added terminator shading for a spherical 3D look, a contained specular highlight, and a richer layered glow halo.

## Verification
- `npm run lint` → 0 warnings · `npm test` → 570/570 pass · `npm run build` → compiles; `three` confirmed code-split into its own chunk (not in the homepage bundle).
- Visually verified via Playwright: galaxy stars render in the sky and are occluded by the mountains; moon renders as a clean 3D sphere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)